### PR TITLE
Fix ContextualVersionConflict problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,5 +44,5 @@ requests>=2.12.4,!=2.17.1,!=2.17.2 # Apache-2.0, from zhmcclient
 six>=1.10.0 # MIT, from zhmcclient and others
 stomp.py>=4.1.15 # Apache, from zhmcclient
 tabulate>=0.7.7 # MIT, from zhmcclient
-urllib3>=1.21.1 # MIT, from requests
+urllib3>=1.21.1,<1.22 # MIT, from requests
 wcwidth>=0.1.7 # MIT, from prompt_toolkit


### PR DESCRIPTION
When trying to upload a release to pypi,
the upload fails with  a
'ContextualVersionConflict: urllib3 1.22'.
This is fixed when we install a version
of urllib3 which is 1.21.1 or higer and
lower than 1.22.

Resolves #14

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>