### PR TITLE
Allow for try_* files to be ignored in git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ env*
 /.idea
 /.vagrant
 /try
+try_*
 /tmp
 tmp_*
 *.tmp


### PR DESCRIPTION
Reason for this is that playbooks look for their vars etc files
in their own directory, so playbooks for trying something out
need to be in the playbooks directory. The already existing
git exclusion of the /try directory is not sufficient for that.