### PR TITLE
Increased minimum Ansible version to 2.2.0.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,10 @@ Released: not yet
 * Added support for specifying integer-typed properties of
   partitions also as decimal strings inthe module input.
 
+**Dependencies:**
+
+* Increased minimum Ansible release from 2.0.0.1 to 2.2.0.0.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/gen/zhmc_hba_module.rst
+++ b/docs/gen/zhmc_hba_module.rst
@@ -23,6 +23,7 @@ Requirements (on host that executes module)
 
   * Network access to HMC
   * zhmcclient >=0.14.0
+  * ansible >=2.2.0.0
 
 
 Options

--- a/docs/gen/zhmc_nic_module.rst
+++ b/docs/gen/zhmc_nic_module.rst
@@ -23,6 +23,7 @@ Requirements (on host that executes module)
 
   * Network access to HMC
   * zhmcclient >=0.14.0
+  * ansible >=2.2.0.0
 
 
 Options

--- a/docs/gen/zhmc_partition_module.rst
+++ b/docs/gen/zhmc_partition_module.rst
@@ -24,6 +24,7 @@ Requirements (on host that executes module)
 
   * Network access to HMC
   * zhmcclient >=0.14.0
+  * ansible >=2.2.0.0
 
 
 Options

--- a/docs/gen/zhmc_virtual_function_module.rst
+++ b/docs/gen/zhmc_virtual_function_module.rst
@@ -23,6 +23,7 @@ Requirements (on host that executes module)
 
   * Network access to HMC
   * zhmcclient >=0.14.0
+  * ansible >=2.2.0.0
 
 
 Options

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -19,7 +19,7 @@ wheel===0.29.0
 
 ## Direct dependencies for runtime (must be consistent with requirements.txt)
 
-ansible===2.0.0.1
+ansible===2.2.0.0
 pbr===1.10.0
 requests===2.12.4
 zhmcclient===0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-ansible>=2.0.0.1 # GPLv3 + BSD
+ansible>=2.2.0.0 # GPLv3 + BSD
 # Note: The zhmc-ansible-modules only use ansible/module_utils/basic.py
 # of the ansible package, which is BSD licensed.
 pbr>=1.10.0 # Apache-2.0

--- a/zhmc_ansible_modules/zhmc_hba.py
+++ b/zhmc_ansible_modules/zhmc_hba.py
@@ -52,6 +52,7 @@ author:
 requirements:
   - Network access to HMC
   - zhmcclient >=0.14.0
+  - ansible >=2.2.0.0
 options:
   hmc_host:
     description:

--- a/zhmc_ansible_modules/zhmc_nic.py
+++ b/zhmc_ansible_modules/zhmc_nic.py
@@ -52,6 +52,7 @@ author:
 requirements:
   - Network access to HMC
   - zhmcclient >=0.14.0
+  - ansible >=2.2.0.0
 options:
   hmc_host:
     description:

--- a/zhmc_ansible_modules/zhmc_partition.py
+++ b/zhmc_ansible_modules/zhmc_partition.py
@@ -56,6 +56,7 @@ author:
 requirements:
   - Network access to HMC
   - zhmcclient >=0.14.0
+  - ansible >=2.2.0.0
 options:
   hmc_host:
     description:

--- a/zhmc_ansible_modules/zhmc_virtual_function.py
+++ b/zhmc_ansible_modules/zhmc_virtual_function.py
@@ -53,6 +53,7 @@ author:
 requirements:
   - Network access to HMC
   - zhmcclient >=0.14.0
+  - ansible >=2.2.0.0
 options:
   hmc_host:
     description:


### PR DESCRIPTION
Reason was that PR #21 uses functionality from the `six` package, and it seemed reasonable to use the version of `six` that is bundled with the Ansible Python module support (`ansible.module_utils` package). That drives the need to increase the Ansible minimum version from 2.0.0.1 to 2.2.0.0.

Analysis of the impact of this upgrade for some Linux distros:
* For RHEL/CentOS 7, Ansible 2.3 can be installed from the EPEL repo (see https://www.liquidweb.com/kb/how-to-install-ansible-on-centos-7-via-yum/).
* For Ubuntu, Ansible 2.3 can be installed from an Ansible PPA (see https://www.digitalocean.com/community/tutorials/how-to-install-and-configure-ansible-on-ubuntu-14-04).