### PR TITLE
Fixes #29: Fixed that a partition in terminated status can be deleted.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,11 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed the issue that a partition in "terminated" or "paused" status
+  could not be made absent (i.e. deleted). Now, the partition is
+  stopped which should bring it into "stopped" status, and then
+  deleted. (Issue #29).
+
 **Enhancements:**
 
 **Known issues:**


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.

This should also help with not reaching stopped status from a terminated status, or at least provide a better exception message.