### PR TITLE
Adjusting empty ssc_ipv4_gateway property to None

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,10 @@ Released: not yet
 * Docs: Improved and fixed the documentation how to release a version
   and how to start a new version.
 
+* Added support for adjusting the value of the `ssc_ipv4_gateway` input property
+  for the `zhmc_partition` module to `None` if specified as the empty string.
+  This allows defaulting the value more easily in playbooks.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/zhmc_ansible_modules/zhmc_partition.py
+++ b/zhmc_ansible_modules/zhmc_partition.py
@@ -653,6 +653,10 @@ def process_properties(cpc, partition, params):
 
         else:
             # Process a normal (= non-artificial) property
+            if prop_name == 'ssc_ipv4_gateway':
+                # Undo conversion from None to empty string in Ansible
+                if input_props[prop_name] == '':
+                    input_props[prop_name] = None
             _create_props, _update_props, _stop = process_normal_property(
                 prop_name, ZHMC_PARTITION_PROPERTIES, input_props, partition)
             create_props.update(_create_props)


### PR DESCRIPTION
For details, see the commit message.
Quickfix, therefore merging without review.