### PR TITLE
Fixed adapter crypto_number property

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,12 @@ Released: not yet
 * Updated the 'requests' package to 2.20.0 to fix the following vulnerability:
   https://nvd.nist.gov/vuln/detail/CVE-2018-18074
 
+* The `crypto_number` property of Adapter is an integer property, and thus the
+  Ansible module `zhmc_adapter` needs to change the string passed by Ansible
+  back to an integer. It did that correctly but only for the `properties`
+  input parameter, and not for the `match` input parameter. The type conversions
+  are now applied for all properties of Adapter also for the `match` parameter.
+
 **Enhancements:**
 
 * Docs: Improved and fixed the documentation how to release a version

--- a/zhmc_ansible_modules/zhmc_adapter.py
+++ b/zhmc_ansible_modules/zhmc_adapter.py
@@ -437,7 +437,15 @@ def identify_adapter(cpc, name, match_props):
         match_props_hmc = dict()
         for prop_name in match_props:
             prop_name_hmc = prop_name.replace('_', '-')
-            match_props_hmc[prop_name_hmc] = match_props[prop_name]
+            match_value = match_props[prop_name]
+
+            # Apply type cast from property definition also to match values:
+            if prop_name in ZHMC_ADAPTER_PROPERTIES:
+                type_cast = ZHMC_ADAPTER_PROPERTIES[prop_name][5]
+                if type_cast:
+                    match_value = type_cast(match_value)
+
+            match_props_hmc[prop_name_hmc] = match_value
         adapter = cpc.adapters.find(**match_props_hmc)
     return adapter
 


### PR DESCRIPTION
Details:
* The crypto_number property is an integer property, and thus the Ansible
  module needs to change the string passed by Ansible back to an integer.
  It did that only for input properties, but not for the newly introduced
  match parameter. This change applies the type conversions for all
  properties now also for the match parameter.

Signed-off-by: Andreas Maier <maiera@de.ibm.com>