### PR TITLE
Fixed a mispelled CPC property acceptable_status

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -42,6 +42,11 @@ Released: not yet
   input parameter, and not for the `match` input parameter. The type conversions
   are now applied for all properties of Adapter also for the `match` parameter.
 
+* The dictionary to check input properties for the `zhmc_cpc` module had the
+  `acceptable_status` property written with a hyphen instead of underscore.
+  This had the effect that it was rejected as non-writeable when specifying
+  it as input.
+
 **Enhancements:**
 
 * Docs: Improved and fixed the documentation how to release a version

--- a/zhmc_ansible_modules/zhmc_cpc.py
+++ b/zhmc_ansible_modules/zhmc_cpc.py
@@ -200,7 +200,7 @@ ZHMC_CPC_PROPERTIES = {
 
     # update properties:
     'description': (True, None, True, True, None, to_unicode),
-    'acceptable-status': (True, None, True, True, None, None),
+    'acceptable_status': (True, None, True, True, None, None),
 
     # read-only properties (subset):
     'name': (False, None, False, None, None, None),  # provided in 'name' parm


### PR DESCRIPTION
Details:

* The dictionary to check input properties had the acceptable_status properts
  written with a hyphen instead of underscore. This had the effect that it was rejected
  as non-writeable when specifying it as input. This change fixes that.

Signed-off-by: Andreas Maier <maiera@de.ibm.com>