### PR TITLE
Added end2end testing, using zhmc_partition as first step

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -34,7 +34,12 @@ python-coveralls>=2.9.0 # Apache-2.0
 Sphinx>=1.7.6 # BSD
 
 # Flake8 (no imports, invoked via flake8 script):
-flake8>=3.2.1 # MIT
+flake8>=3.7.0 # MIT
+# Note: Flake8 requires pyflakes>=2.1.0 and pycodestyle>=2.5.0, but for reasons
+#       not understood, the resulting installation has pycodestyle 2.2.0,
+#       causing issues. Workaround is to specify these dependencies here.
+pyflakes>=2.1.0 # MIT
+pycodestyle>=2.5.0 # MIT
 
 # Twine (no imports, invoked via twine script):
 twine>=1.8.1 # Apache-2.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,7 +30,15 @@ Released: not yet
 
 **Bug fixes:**
 
+* Increased minimum version of flake8 to 3.7.0 due to difficulties with
+  recognizing certain 'noqa' statements. This required explicitly specifying
+  its dependent pycodestyle and pyflakes packages with their minimum versions,
+  because the dependency management did not work with our minimum
+  package versions.
+
 **Enhancements:**
+
+* Added end2end test support, against real HMCs.
 
 **Known issues:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -22,8 +22,10 @@ wheel===0.29.0
 ansible===2.4.0.0
 pbr===1.10.0
 requests===2.20.0
-zhmcclient===0.20.0
-# git+https://github.com/zhmcclient/python-zhmcclient@master#egg=zhmcclient
+
+# TODO: Fall back to using the official 0.24.0 release once available.
+git+https://github.com/zhmcclient/python-zhmcclient@master#egg=zhmcclient
+# zhmcclient===0.24.0
 
 
 # Indirect dependencies for runtime (must be consistent with requirements.txt)
@@ -70,7 +72,12 @@ python-coveralls===2.9.0
 Sphinx===1.7.6
 
 # Flake8 (no imports, invoked via flake8 script):
-flake8===3.2.1
+flake8==3.7.0
+# Note: Flake8 requires pyflakes>=2.1.0 and pycodestyle>=2.5.0, but for reasons
+#       not understood, the resulting installation has pycodestyle 2.2.0,
+#       causing issues. Workaround is to specify these dependencies here.
+pyflakes==2.1.0
+pycodestyle==2.5.0
 
 # Twine (no imports, invoked via twine script):
 twine===1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,9 @@ ansible>=2.4.0.0 # GPLv3 + BSD
 pbr>=1.10.0 # Apache-2.0
 requests>=2.20.0 # Apache-2.0 (requests.packages.urllib3 and from zhmcclient)
 
-zhmcclient>=0.20.0 # Apache-2.0
-# git+https://github.com/zhmcclient/python-zhmcclient@master#egg=zhmcclient
+# TODO: Fall back to using the official 0.24.0 release once available.
+git+https://github.com/zhmcclient/python-zhmcclient@master#egg=zhmcclient
+# zhmcclient>=0.24.0 # Apache-2.0
 
 # Indirect dependencies (commented out, only listed to document their license):
 

--- a/tests/end2end/test_zhmc_partition.py
+++ b/tests/end2end/test_zhmc_partition.py
@@ -1,0 +1,132 @@
+# Copyright 2019 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for zhmc_partition module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import mock
+import requests.packages.urllib3
+import zhmcclient
+from zhmcclient.testutils.hmc_definition_fixtures import hmc_definition, hmc_session  # noqa: F401, E501
+
+from zhmc_ansible_modules import zhmc_partition
+from .utils import mock_ansible_module, get_failure_msg, get_module_output
+
+requests.packages.urllib3.disable_warnings()
+
+
+# Partition properties that are not always present, nbut only under certain
+# conditions.
+PARTITION_CONDITIONAL_PROPS = (
+    'boot-ftp-password',
+    'boot-network-nic-name',
+    'boot-storage-hba-name',
+    'ssc-master-pw',
+)
+
+
+def assert_partition_props(partition_props):
+    """
+    Assert the output object of the zhmc_partition module
+    """
+    assert isinstance(partition_props, dict)  # Dict of Partition properties
+
+    # Assert presence of normal properties in the output
+    for prop_name in zhmc_partition.ZHMC_PARTITION_PROPERTIES:
+        prop_name_hmc = prop_name.replace('_', '-')
+        if prop_name_hmc in PARTITION_CONDITIONAL_PROPS:
+            # TODO: Do better than just skipping them - they are present under
+            # certain conditions.
+            continue
+        assert prop_name_hmc in partition_props
+
+    # Assert presence of the artificial properties in the output
+
+    assert 'hbas' in partition_props
+    hba_props_list = partition_props['hbas']
+    if hba_props_list is not None:
+        assert isinstance(hba_props_list, list)  # List of HBAs
+        for hba_props in hba_props_list:
+            assert isinstance(hba_props, dict)  # Dict of HBA properties
+
+    assert 'nics' in partition_props
+    nic_props_list = partition_props['nics']
+    if nic_props_list is not None:
+        assert isinstance(nic_props_list, list)  # List of NICs
+        for nic_props in nic_props_list:
+            assert isinstance(nic_props, dict)  # Dict of NIC properties
+
+    assert 'virtual-functions' in partition_props
+    vf_props_list = partition_props['virtual-functions']
+    if vf_props_list is not None:
+        assert isinstance(vf_props_list, list)  # List of VFs
+        for vf_props in vf_props_list:
+            assert isinstance(vf_props, dict)  # Dict of VF properties
+
+
+@pytest.mark.parametrize(
+    "check_mode", [False, True])
+@mock.patch("zhmc_ansible_modules.zhmc_partition.AnsibleModule", autospec=True)
+def test_partition_facts(ansible_mod_cls, check_mode, hmc_session):  # noqa: F811, E501
+    """
+    Test fact gathering on a partition.
+    """
+
+    hd = hmc_session.hmc_definition
+
+    # Determine one of the CPCs in the HMC definition file to test
+    cpc_names = hd.cpcs.keys()
+    assert len(cpc_names) >= 1
+    cpc_name = cpc_names[0]
+
+    # Determine an existing partition to test. This also validates that
+    # the CPC defined in the HMC definition file actually exists.
+    client = zhmcclient.Client(hmc_session)
+    cpc = client.cpcs.find_by_name(cpc_name)
+    partitions = cpc.partitions.list()
+    assert len(partitions) >= 1
+    partition = partitions[0]  # Pick first partition in list
+
+    # Prepare module input parameters
+    params = {
+        'hmc_host': hd.hmc_host,
+        'hmc_auth': dict(userid=hd.hmc_userid, password=hd.hmc_password),
+        'cpc_name': cpc_name,
+        'name': partition.name,
+        'state': 'facts',
+        'log_file': None,
+        'faked_session': None,
+    }
+
+    # Prepare mocks for AnsibleModule object
+    mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+    # Exercise the code to be tested
+    with pytest.raises(SystemExit) as exc_info:
+        zhmc_partition.main()
+    exit_code = exc_info.value.args[0]
+
+    # Assert module exit code
+    assert exit_code == 0, \
+        "Module unexpectedly failed with this message:\n{}". \
+        format(get_failure_msg(mod_obj))
+
+    # Assert module output
+    changed, partition_props = get_module_output(mod_obj)
+    assert changed is False
+    assert_partition_props(partition_props)

--- a/tests/end2end/utils.py
+++ b/tests/end2end/utils.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utility functions for end2end testing.
+"""
+
+
+def mock_ansible_module(ansible_mod_cls, params, check_mode):
+    """
+    Prepare mocks for AnsibleModule object.
+    """
+    mod_obj = ansible_mod_cls.return_value
+    mod_obj.params = params
+    mod_obj.check_mode = check_mode
+    mod_obj.fail_json.configure_mock(side_effect=SystemExit(1))
+    mod_obj.exit_json.configure_mock(side_effect=SystemExit(0))
+    return mod_obj
+
+
+def get_failure_msg(mod_obj):
+    """
+    Return the module failure message, as a string (i.e. the 'msg' argument
+    of the call to fail_json()).
+    If the module succeeded, return None.
+    """
+
+    def func(msg):
+        return msg
+
+    if not mod_obj.fail_json.called:
+        return None
+    call_args = mod_obj.fail_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])
+
+
+def get_module_output(mod_obj):
+    """
+    Return the module output as a tuple (changed, partition_properties) (i.e.
+    the arguments of the call to exit_json()).
+    If the module failed, return None.
+    """
+
+    def func(changed, partition):
+        return changed, partition
+
+    if not mod_obj.exit_json.called:
+        return None
+    call_args = mod_obj.exit_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])


### PR DESCRIPTION
This depends on PR https://github.com/zhmcclient/python-zhmcclient/pull/573 in the zhmcclient project.
For details, see the commit message.