### PR TITLE
Fixed issues with parameters in exception messages

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,9 @@ Released: not yet
   because the dependency management did not work with our minimum
   package versions.
 
+* Fixed issues with parameters in exception messages raised in
+  zhmc_storage_group and zhmc_user.
+
 **Enhancements:**
 
 * Added end2end test support, against real HMCs.

--- a/zhmc_ansible_modules/zhmc_storage_group.py
+++ b/zhmc_ansible_modules/zhmc_storage_group.py
@@ -362,7 +362,7 @@ def process_properties(cpc, storage_group, params):
         if sg_cpc.uri != cpc.uri:
             raise ParameterError(
                 "Storage group {!r} is not associated with the specified "
-                "CPC %r, but with CPC %r.".
+                "CPC {!r}, but with CPC {!r}.".
                 format(sg_name, cpc.name, sg_cpc.name))
 
     # handle the other properties
@@ -599,7 +599,7 @@ def ensure_absent(params, check_mode):
         if sg_cpc.uri != cpc.uri:
             raise ParameterError(
                 "Storage group {!r} is not associated with the specified "
-                "CPC %r, but with CPC %r.".
+                "CPC {!r}, but with CPC {!r}.".
                 format(storage_group_name, cpc.name, sg_cpc.name))
 
         if not check_mode:
@@ -652,7 +652,7 @@ def facts(params, check_mode):
         if sg_cpc.uri != cpc.uri:
             raise ParameterError(
                 "Storage group {!r} is not associated with the specified "
-                "CPC %r, but with CPC %r.".
+                "CPC {!r}, but with CPC {!r}.".
                 format(storage_group_name, cpc.name, sg_cpc.name))
 
         add_artificial_properties(storage_group, expand)

--- a/zhmc_ansible_modules/zhmc_storage_volume.py
+++ b/zhmc_ansible_modules/zhmc_storage_volume.py
@@ -399,7 +399,7 @@ def ensure_present(params, check_mode):
         if sg_cpc.uri != cpc.uri:
             raise ParameterError(
                 "Storage group {!r} is not associated with the specified "
-                "CPC %r, but with CPC %r.".
+                "CPC {!r}, but with CPC {!r}.".
                 format(storage_group_name, cpc.name, sg_cpc.name))
 
         try:
@@ -496,7 +496,7 @@ def ensure_absent(params, check_mode):
         if sg_cpc.uri != cpc.uri:
             raise ParameterError(
                 "Storage group {!r} is not associated with the specified "
-                "CPC %r, but with CPC %r.".
+                "CPC {!r}, but with CPC {!r}.".
                 format(storage_group_name, cpc.name, sg_cpc.name))
 
         try:
@@ -550,7 +550,7 @@ def facts(params, check_mode):
         if sg_cpc.uri != cpc.uri:
             raise ParameterError(
                 "Storage group {!r} is not associated with the specified "
-                "CPC %r, but with CPC %r.".
+                "CPC {!r}, but with CPC {!r}.".
                 format(storage_group_name, cpc.name, sg_cpc.name))
 
         try:

--- a/zhmc_ansible_modules/zhmc_user.py
+++ b/zhmc_ansible_modules/zhmc_user.py
@@ -818,7 +818,7 @@ def main():
     # by showing the traceback.
 
     LOGGER.debug(
-        "Module exit (success): changed: {!r}".
+        "Module exit (success): changed: {!r}, user: {!r}".
         format(changed, result))
     module.exit_json(changed=changed, user=result)
 


### PR DESCRIPTION
See commit message.
These were reported by a new version of flake8 and were real errors.