### PR TITLE
0.8: Fixed ParameterError raised when creating NICs on CNA adapter ports

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,8 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed ParameterError raised when creating NICs on CNA adapter ports.
+
 **Enhancements:**
 
 **Known issues:**

--- a/zhmc_ansible_modules/zhmc_nic.py
+++ b/zhmc_ansible_modules/zhmc_nic.py
@@ -359,7 +359,7 @@ def process_properties(partition, nic, params):
 
         # The rest of it depends on the network adapter family:
         adapter_family = adapter.get_property('adapter-family')
-        if adapter_family == 'roce':
+        if adapter_family in ('roce', 'cna'):
             # Here we perform the same logic as in the property loop, just now
             # simplified by the knowledge about the property flags (create,
             # update, etc.).


### PR DESCRIPTION
Rolls back PR #150 into 0.8.2.