### PR TITLE
Added support for Python 3.9; Fixed an issue with installing typed-ast 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,26 @@ jobs:
 #        - PACKAGE_LEVEL=latest
 #      cache: pip
 
+#    - os: linux
+#      dist: xenial
+#      language: python
+#      python: "3.8"
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#      cache: pip
+
+#    - os: linux
+#      dist: xenial
+#      language: python
+#      python: "3.8"
+#      env:
+#        - PACKAGE_LEVEL=latest
+#      cache: pip
+
     - os: linux
       dist: xenial
       language: python
-      python: "3.8"
+      python: "3.9"
       env:
         - PACKAGE_LEVEL=minimum
       cache: pip
@@ -81,7 +97,7 @@ jobs:
     - os: linux
       dist: xenial
       language: python
-      python: "3.8"
+      python: "3.9"
       env:
         - PACKAGE_LEVEL=latest
       cache: pip
@@ -208,12 +224,13 @@ install:
   - pip list
 
 # commands to run builds & tests
+# Note: make sanity is excluded on Ansible 2.9 and Python 3.9 (or higher) because it is not supported.
 script:
   - make docs
   - make test
-  - make sanity
+  - if [[ "$PACKAGE_LEVEL" == "latest" || $(python --version 2>&1) =~ ([[:space:]])(2\.7|3\.[45678])(\.[0-9]) ]]; then make sanity; fi
 
 after_success:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "3.8" && "$PACKAGE_LEVEL" == "latest" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$PACKAGE_LEVEL" == "latest" ]]; then
       coveralls;
     fi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -92,12 +92,9 @@ pylint>=2.4.4; python_version >= '3.5'
 astroid>=1.4.9,<2.0.0; python_version == '2.7'
 astroid>=2.1.0,<2.3; python_version == '3.4'
 astroid>=2.3.3; python_version >= '3.5'
-# Pinning typed-ast to <1.4.0 for Python 3.4 because it started removing
-# Python 3.4 support.
-# Requiring typed-ast>=1.4.0 for Python 3.8 since it addresses compile errors
-# with missing pgenheaders.h and duplicate definition of a struct.
-typed-ast>=1.3.0,<1.4.0; python_version == '3.4' and implementation_name == "cpython"
-typed-ast>=1.3.0; python_version >= '3.5' and python_version < '3.8' and implementation_name == "cpython"
+# typed-ast 1.4.0 removed support for Python 3.4.
+typed-ast>=1.3.2,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
+typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 typed-ast>=1.4.0; python_version >= '3.8' and implementation_name == "cpython"
 
 # Flake8 and dependents (no imports, invoked via flake8 script):

--- a/docs_source/intro.rst
+++ b/docs_source/intro.rst
@@ -75,6 +75,7 @@ The following versions of Python are currently supported:
 - Python 3.6
 - Python 3.7
 - Python 3.8
+- Python 3.9
 
 Higher versions of Python 3.x have not been tested at this point, but are
 expected to work.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -168,8 +168,8 @@ pylint==2.4.4; python_version >= '3.5'
 astroid==1.4.9; python_version == '2.7'
 astroid==2.1.0; python_version == '3.4'
 astroid==2.3.3; python_version >= '3.5'
-typed-ast==1.3.0; python_version >= '3.4' and python_version < '3.8' and implementation_name == "cpython"
-typed-ast==1.4.0; python_version >= '3.8' and implementation_name == "cpython"
+typed-ast==1.3.2; python_version == '3.4' and implementation_name=='cpython'
+typed-ast==1.4.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 flake8==3.7.9


### PR DESCRIPTION
At this point, it seems all issues have been fixed but the sanity test checks does not support python 3.9 yet.
Need to wait until it supports that.

Update: Disabled the sanity tests for Ansible 2.9 and Python 3.9 (or higher) because that combination is not supported by Ansible and is not likely to be added.