### PR TITLE
0.8: Bumped cryptography to 3.2 on py36+

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -28,12 +28,14 @@ zhmcclient===0.20.0
 
 # Indirect dependencies for runtime (must be consistent with requirements.txt)
 
+cryptography==3.0; python_version <= '3.5'
+cryptography==3.2; python_version >= '3.6'
+packaging==20.0
 asn1crypto===0.23.0
 bcrypt===3.0.0
 certifi===2016.9.26
 cffi===1.7.0
 chardet===3.0.3
-cryptography===2.0
 decorator===4.0.10
 docopt===0.6.2
 enum34===1.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,12 +21,17 @@ zhmcclient>=0.20.0 # Apache-2.0
 
 # Indirect dependencies (commented out, only listed to document their license):
 
+# cryptography 3.1 has deprecated Python 3.5 support and issues a deprecation
+# warning that causes ansible-test to fail
+# cryptography 3.2 addresses a dependabot security issue
+cryptography==3.0,<3.1; python_version <= '3.5'  # BSD, from paramiko -> ansible
+cryptography==3.2; python_version >= '3.6'  # BSD, from paramiko -> ansible
+
 # asn1crypto  # MIT, from cryptography -> ansible
 # bcrypt # Apache 2.0, from paramiko -> ansible
 # certifi # ISC, from requests
 # cffi # MIT, from cryptography -> paramiko -> ansible
 # chardet # LGPL, from requests
-# cryptography # BSD, from paramiko -> ansible
 # decorator # new BSD, from zhmcclient
 # docopt # MIT, from stomp.py -> zhmcclient
 # enum34 # BSD, from cryptography -> paramiko -> ansible and flake8 for py<3.4


### PR DESCRIPTION
Rolls back PR #180 into 0.8.3.
No further review needed.