### PR TITLE
0.8: Docs: Increased supported Ansible versions to be 2.4 or higher

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,9 @@ Released: not yet
 * Fixed percent-encoding in the 'zhmc_storage_group' and 'zhmc_storage_volume'
   modules.
 
+* Docs: Increased supported Ansible versions from 2.0 or higher to be 2.4 or
+  higher. This is what is currently tested. See issue #209.
+
 **Enhancements:**
 
 * In the zhmc_nic module, updated the definition of NIC properties to the z15

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -72,7 +72,7 @@ Supported environments
 The Ansible modules in the zhmc-ansible-modules package are supported in these
 environments:
 
-* Ansible versions: 2.0 or higher
+* Ansible versions: 2.4 or higher
 
 * Operating systems running Ansible: Linux, OS-X
 


### PR DESCRIPTION
See commit message.