### PR TITLE
0.8: Extended .gitignore with new docs build dirs from master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ tmp_*
 *.done
 /dist/
 /docs_linkcheck/
+/docs_local/
+/docs_build/
 vars.yml
 vault.yml
 /python-zhmcclient


### PR DESCRIPTION
No review needed.