### PR TITLE
Fixed linked dep to coveralls-python with new pip version

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -76,7 +76,7 @@ pytest==4.4.0; python_version >= '3.7'
 # We exclude Python 3.4 from coverage testing and reporting.
 coverage==5.0; python_version == '2.7' or python_version >= '3.5'
 pytest-cov==2.7.0; python_version == '2.7' or python_version >= '3.5'
-git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
+# handled by dev-requirements.txt: git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
 coveralls==2.1.2; python_version >= '3.5'
 
 # Sphinx (no imports, invoked via sphinx-build script):


### PR DESCRIPTION
Rolls back PR #324 into 0.8.4.