### PR TITLE
Content/unified doc updates

### DIFF
--- a/docs/ansible_content.rst
+++ b/docs/ansible_content.rst
@@ -36,7 +36,7 @@ to be managed.
    :maxdepth: 1
    :caption: Collection Content
 
-   modules
+   source/modules
 
 .. _ibm_zhmc:
    https://galaxy.ansible.com/ibm/ibm_zhmc/

--- a/docs/ansible_content.rst
+++ b/docs/ansible_content.rst
@@ -13,122 +13,33 @@
 .. limitations under the License.
 ..
 
-====================
-IBM Z HMC collection
-====================
+=====
+Z HMC
+=====
+
+The **IBM Z® HMC collection**, also represented as
+`ibm_zhmc`_ in this document, is  part of the broader
+initiative to bring Ansible® Automation to IBM Z through the offering
+**Red Hat® Ansible Certified Content for IBM Z**.
 
 The **IBM Z HMC collection** provides `Ansible`_ modules that can manage
-platform resources on `IBM Z`_ and `LinuxONE`_ machines.
-
-The goal of this collection is to be able to utilize the power and ease of use
-of Ansible for the management of IBM Z platform resources.
-
-The IBM Z platform resources that can be managed include for example partitions,
+platform resources on `IBM Z`_ and `LinuxONE`_ machines. The IBM Z platform
+resources that can be managed include for example partitions,
 I/O adapters, the Z system itself, or various resources on its Hardware
 Management Console (HMC).
-
-The Ansible modules in this collection are fully
-`idempotent <http://docs.ansible.com/ansible/latest/glossary.html#term-idempotency>`_,
-following an important principle for Ansible modules.
-The idempotency of a module allows Ansible playbooks to specify the desired end
-state for a resource, regardless of what the current state is. For example, an
-IBM Z partition can be specified to have ``state=active`` which means that
-it must exist and be in the active operational status. Depending on the current
-state of the partition, actions will be taken by the module to reach this
-desired end state: If the partition does not exist, it will be created and
-started. If it exists but is not active, it will be started. If it is already
-active, nothing will be done. Other initial states including transitional
-states such as starting or stopping also will be taken care of.
-The idempotency of modules makes Ansible playbooks restartable: If an error
-happens and some things have been changed already, the playbook can simply be
-re-run and will automatically do the right thing, because the initial state
-does not matter for reaching the desired end state.
 
 The Ansible modules in this collection are written in Python and interact with
 the Web Services API of the Hardware Management Console (HMC) of the Z machines
 to be managed.
 
-Note: Before version 0.9.0, the Ansible modules in this collection have been
-distributed as the `zhmc-ansible-modules package on Pypi`_.
-Starting with version 0.9.0, the Ansible modules are no longer distributed on
-Pypi, but as the `ibm.ibm_zhmc collection on Ansible Galaxy`_.
-
-Note that at this point, version 0.9.0 has not been released yet, so please
-continue using the latest released version on Pypi.
-
-Features
-========
-
-The **IBM Z HMC collection** includes :ref:`modules` to automate the management of
-IBM Z platform resources. There are :ref:`sample playbooks` that show how to
-invoke these modules in playbook tasks.
-
 .. toctree::
-   :maxdepth: 4
-   :caption: Getting Started
-
-   installation
-
-.. toctree::
-   :maxdepth: 3
-   :caption: References
+   :maxdepth: 1
+   :caption: Collection Content
 
    modules
-   playbooks
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Community Guides
-
-   community_guides
-   development
-
-.. toctree::
-   :maxdepth: 3
-   :caption: Requirements
-
-   requirements
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Appendices
-
-   release_notes
-   versioning
-   bibliography
-
-Copyright
-=========
-
-Copyright IBM Corporation 2016-2020
-
-License
-=======
-
-This collection is licensed under the `Apache 2.0 License`_.
-
-Author Information
-==================
-
-The **IBM Z HMC collection** is maintained by the IBM Z development team.
-
-.. _`Reporting issues`:
-
-Reporting issues
-================
-
-If you encounter any problem with this collection, or if you have questions of
-any kind related to this collection (even when they are not about a problem),
-please open an issue in the `issue tracker`_.
-
-.. _`issue tracker`:
-   https://github.com/zhmcclient/zhmc-ansible-modules/issues
-.. _Apache 2.0 License:
-   https://opensource.org/licenses/Apache-2.0
-.. _ibm.ibm_zhmc collection on Ansible Galaxy:
+.. _ibm_zhmc:
    https://galaxy.ansible.com/ibm/ibm_zhmc/
-.. _zhmc-ansible-modules package on Pypi:
-   https://pypi.org/project/zhmc-ansible-modules/
 .. _Ansible:
    https://www.ansible.com/
 .. _IBM Z:

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -13,29 +13,15 @@
 .. limitations under the License.
 ..
 
-
-.. _`Modules`:
-
 Modules
 =======
 
-Modules can be used from the command line or in a playbook task or in a role task.
+Ansible® modules can be used from the command line, in a playbook or in
+an role.
 
-Module Reference
-----------------
-
-The **IBM Z HMC collection** provides several modules. Reference material for
+The **IBM Z® HMC collection** provides several modules. Reference material for
 each module contains documentation on what parameters the module accepts and
 what will returned.
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   modules/*
-
-Module Documentation
---------------------
 
 You can also access the documentation of each module from the command line by
 using the `ansible-doc`_ command, for example:
@@ -46,3 +32,9 @@ using the `ansible-doc`_ command, for example:
 
 .. _ansible-doc:
    https://docs.ansible.com/ansible/latest/cli/ansible-doc.html#ansible-doc
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   modules/*


### PR DESCRIPTION
This pull request corrects some of the excessive doc its inability to successfully integrate with the unified doc. 

ansible_content.rst is meant only to give the unified doc access to the collections content, not the entire doc site thus it has been scaled back to a more minimal state.

modules.rst had a subheading causing and an unnecessary indentation in the unified doc navigation, with some minor tweaks all the content was preserved and only shuffled in a different order.  