### PR TITLE
Docs: Fixed and improved requirements section for control and managed nodes

### DIFF
--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -19,21 +19,29 @@
 Requirements
 ============
 
-For the **IBM Z HMC collection**, the managed node is the control node, i.e. the
-playbook has its ``hosts`` and ``connection`` properties set accordingly:
+The **IBM Z HMC collection** runs on the control node and communicates with the
+targeted HMC via the IP or host name input parameters of the Ansible modules.
+
+In playbooks, this looks as follows:
 
 .. code-block:: text
 
-   - hosts: localhost
-     connection: local
-
-The location of the HMC is defined with input parameters to the modules.
+   - hosts: localhost  # required: target host
+     connection: local  # required
+     collections:
+       - ibm.ibm_zhmc
+     tasks:
+       - zhmc_adapter:
+           hmc_host: 9.10.11.12
+           hmc_auth: "{{ hmc_auth }}"
+           . . .
 
 Control node
 ============
 
-Besides having Ansible and the **IBM Z HMC collection** installed, there are no
-additional requirements for the control node.
+Requirements for the Ansible control node are:
+
+* The control node must have network connectivity to the targeted HMC.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/source/requirements_managed.rst
+++ b/docs/source/requirements_managed.rst
@@ -17,5 +17,11 @@
 Managed node
 ============
 
-For the **IBM Z HMC collection**, the managed node is the control node, so there
-are no additional requirements for the managed node.
+The managed node for the **IBM Z HMC collection** is the targeted HMC. The
+Z systems managed by the HMC are not visible on the network because the HMC
+encapsulates them. In addition, there is a number of resources that are owned
+by the HMC itself, such as users or password rules.
+
+Requirements for the targeted HMC are:
+
+* The HMC must have its Web Services API enabled.


### PR DESCRIPTION
This is in response to issue 2 by Demetri.

This is still based on the current design with hosts=localhost, not using delegate_to. The use of delegate_to is left for a future PR.

For details, see the commit message.