### PR TITLE
Docs: Fixed missing link target for 'modules'

### DIFF
--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -13,6 +13,8 @@
 .. limitations under the License.
 ..
 
+.. _`Modules`:
+
 Modules
 =======
 


### PR DESCRIPTION
No review needed.