### PR TITLE
Accomodated DictView properties of zhmcclient

### DIFF
--- a/plugins/modules/zhmc_adapter.py
+++ b/plugins/modules/zhmc_adapter.py
@@ -540,7 +540,7 @@ def ensure_set(params, check_mode):
         # The default exception handling is sufficient for the above.
 
         adapter.pull_full_properties()
-        result = adapter.properties
+        result = adapter.properties.copy()
 
         # It was identified by name or match properties, so it does exist.
         # Update its properties and change adapter and crypto type, if
@@ -571,7 +571,7 @@ def ensure_set(params, check_mode):
 
         if changed and not check_mode:
             adapter.pull_full_properties()
-            result = adapter.properties  # from actual values
+            result = adapter.properties.copy()  # from actual values
 
         ports = adapter.ports.list()
         result_ports = list()
@@ -579,7 +579,7 @@ def ensure_set(params, check_mode):
             # TODO: Disabling the following line mitigates the recent issue
             #       with HTTP error 404,4 when retrieving port properties.
             # port.pull_full_properties()
-            result_ports.append(port.properties)
+            result_ports.append(port.properties.copy())
         result['ports'] = result_ports
 
         return changed, result
@@ -665,7 +665,7 @@ def ensure_present(params, check_mode):
             if not check_mode:
                 adapter = cpc.adapters.create_hipersocket(create_props)
                 adapter.pull_full_properties()
-                result = adapter.properties  # from actual values
+                result = adapter.properties.copy()  # from actual values
             else:
                 adapter = None
                 result = dict()
@@ -677,7 +677,7 @@ def ensure_present(params, check_mode):
             # needed.
 
             adapter.pull_full_properties()
-            result = adapter.properties
+            result = adapter.properties.copy()
 
             create_props, update_props, chg_adapter_type, chg_crypto_type = \
                 process_properties(adapter, params)
@@ -705,14 +705,14 @@ def ensure_present(params, check_mode):
 
             if changed and not check_mode:
                 adapter.pull_full_properties()
-                result = adapter.properties  # from actual values
+                result = adapter.properties.copy()  # from actual values
 
         if adapter:
             ports = adapter.ports.list()
             result_ports = list()
             for port in ports:
                 port.pull_full_properties()
-                result_ports.append(port.properties)
+                result_ports.append(port.properties.copy())
             result['ports'] = result_ports
         else:
             # For now, we return no ports when creating in check mode
@@ -789,13 +789,13 @@ def facts(params, check_mode):
         # The default exception handling is sufficient for the above.
 
         adapter.pull_full_properties()
-        result = adapter.properties
+        result = adapter.properties.copy()
 
         ports = adapter.ports.list()
         result_ports = list()
         for port in ports:
             port.pull_full_properties()
-            result_ports.append(port.properties)
+            result_ports.append(port.properties.copy())
         result['ports'] = result_ports
 
         return False, result

--- a/plugins/modules/zhmc_crypto_attachment.py
+++ b/plugins/modules/zhmc_crypto_attachment.py
@@ -399,7 +399,7 @@ def get_partition_config(partition, all_adapters):
         adapter_uris = partition_config['crypto-adapter-uris']
         for a in all_adapters:
             if a.uri in adapter_uris:
-                adapters[a.name] = a.properties
+                adapters[a.name] = a.properties.copy()
         for dc in partition_config['crypto-domain-configurations']:
             di = int(dc['domain-index'])
             am = ACCESS_MODES_HMC2MOD[dc['access-mode']]

--- a/plugins/modules/zhmc_hba.py
+++ b/plugins/modules/zhmc_hba.py
@@ -485,7 +485,7 @@ def ensure_present(params, check_mode):
                 changed = True
 
         if hba:
-            result = hba.properties
+            result = hba.properties.copy()
 
         return changed, result
 

--- a/plugins/modules/zhmc_nic.py
+++ b/plugins/modules/zhmc_nic.py
@@ -563,7 +563,7 @@ def ensure_present(params, check_mode):
                 changed = True
 
         if nic:
-            result = nic.properties
+            result = nic.properties.copy()
 
         return changed, result
 

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -946,12 +946,13 @@ def change_crypto_config(partition, crypto_changes, check_mode):
 
 
 def add_artificial_properties(
-        partition, expand_storage_groups, expand_crypto_adapters):
+        partition_properties, partition, expand_storage_groups,
+        expand_crypto_adapters):
     """
-    Add artificial properties to the partition object.
+    Add artificial properties to the partition_properties dict.
 
-    Upon return, the properties of the partition object have been
-    extended by these artificial properties:
+    Upon return, the partition_properties dict has been extended by these
+    artificial properties:
 
     * 'hbas': List of Hba objects of the partition.
 
@@ -995,14 +996,14 @@ def add_artificial_properties(
     hbas_prop = list()
     if partition.hbas is not None:
         for hba in partition.hbas.list(full_properties=True):
-            hbas_prop.append(hba.properties)
-    partition.properties['hbas'] = hbas_prop
+            hbas_prop.append(hba.properties.copy())
+    partition_properties['hbas'] = hbas_prop
 
     # Get the NIC child elements of the partition
     nics_prop = list()
     for nic in partition.nics.list(full_properties=True):
         nic_props = OrderedDict()
-        nic_props.update(nic.properties)
+        nic_props.update(nic.properties.copy())
         # Add artificial properties adapter-name/-port/-id:
         vswitch_uri = nic.prop("virtual-switch-uri", None)
         if vswitch_uri:
@@ -1024,30 +1025,31 @@ def add_artificial_properties(
             nic_props['adapter-port'] = port_props['index']
             nic_props['adapter-id'] = adapter.get_property('adapter-id')
         nics_prop.append(nic_props)
-    partition.properties['nics'] = nics_prop
+    partition_properties['nics'] = nics_prop
 
     # Get the VF child elements of the partition
-    vf_prop = list()
+    vfs_prop = list()
     for vf in partition.virtual_functions.list(full_properties=True):
-        vf_prop.append(vf.properties)
-    partition.properties['virtual-functions'] = vf_prop
+        vfs_prop.append(vf.properties.copy())
+    partition_properties['virtual-functions'] = vfs_prop
 
     if expand_storage_groups:
-        sg_prop = list()
+        sgs_prop = list()
         for sg_uri in partition.properties['storage-group-uris']:
             storage_group = console.storage_groups.resource_object(sg_uri)
             storage_group.pull_full_properties()
-            sg_prop.append(storage_group.properties)
+            sg_properties = storage_group.properties.copy()
 
             # Candidate adapter ports and their adapters (full set of props)
             caps_prop = list()
             for cap in storage_group.list_candidate_adapter_ports(
                     full_properties=True):
+                cap_properties = cap.properties.copy()
                 adapter = cap.manager.adapter
                 adapter.pull_full_properties()
-                cap.properties['parent-adapter'] = adapter.properties
-                caps_prop.append(cap.properties)
-            storage_group.properties['candidate-adapter-ports'] = caps_prop
+                cap_properties['parent-adapter'] = adapter.properties.copy()
+                caps_prop.append(cap_properties)
+            sg_properties['candidate-adapter-ports'] = caps_prop
 
             # Storage volumes (full set of properties).
             # Note: We create the storage volumes from the
@@ -1059,8 +1061,8 @@ def add_artificial_properties(
             for sv_uri in sv_uris:
                 sv = storage_group.storage_volumes.resource_object(sv_uri)
                 sv.pull_full_properties()
-                svs_prop.append(sv.properties)
-            storage_group.properties['storage-volumes'] = svs_prop
+                svs_prop.append(sv.properties.copy())
+            sg_properties['storage-volumes'] = svs_prop
 
             # Virtual storage resources (full set of properties).
             vsrs_prop = list()
@@ -1070,21 +1072,29 @@ def add_artificial_properties(
                 vsr = storage_group.virtual_storage_resources.resource_object(
                     vsr_uri)
                 vsr.pull_full_properties()
-                vsrs_prop.append(vsr.properties)
-            storage_group.properties['virtual-storage-resources'] = vsrs_prop
+                vsrs_prop.append(vsr.properties.copy())
+            sg_properties['virtual-storage-resources'] = vsrs_prop
 
-        partition.properties['storage-groups'] = sg_prop
+            sgs_prop.append(sg_properties)
+
+        partition_properties['storage-groups'] = sgs_prop
 
     if expand_crypto_adapters:
 
-        cc = partition.properties['crypto-configuration']
+        cc = partition_properties['crypto-configuration']
         if cc:
-            ca_prop = list()
+            # partition_properties is only a shallow copy of the
+            # Partition.properties dict, so cc is still a dict within the
+            # original Partition.properties dict. Therefore, we copy cc
+            # since we modify it.
+            cc = cc.copy()
+            cas_prop = list()
             for ca_uri in cc['crypto-adapter-uris']:
                 ca = cpc.adapters.resource_object(ca_uri)
                 ca.pull_full_properties()
-                ca_prop.append(ca.properties)
-            cc['crypto-adapters'] = ca_prop
+                cas_prop.append(ca.properties.copy())
+            cc['crypto-adapters'] = cas_prop
+            partition_properties['crypto-configuration'] = cc
 
 
 def ensure_active(params, check_mode):
@@ -1181,9 +1191,10 @@ def ensure_active(params, check_mode):
                     "status is: {1!r}".format(partition.name, status))
 
         if partition:
+            result = partition.properties.copy()
             add_artificial_properties(
-                partition, expand_storage_groups, expand_crypto_adapters)
-            result = partition.properties
+                result, partition, expand_storage_groups,
+                expand_crypto_adapters)
 
         return changed, result
 
@@ -1263,9 +1274,10 @@ def ensure_stopped(params, check_mode):
                     "status is: {1!r}".format(partition.name, status))
 
         if partition:
+            result = partition.properties.copy()
             add_artificial_properties(
-                partition, expand_storage_groups, expand_crypto_adapters)
-            result = partition.properties
+                result, partition, expand_storage_groups,
+                expand_crypto_adapters)
 
         return changed, result
 
@@ -1344,9 +1356,10 @@ def facts(params, check_mode):
         partition = cpc.partitions.find(name=partition_name)
         partition.pull_full_properties()
 
+        result = partition.properties.copy()
         add_artificial_properties(
-            partition, expand_storage_groups, expand_crypto_adapters)
-        result = partition.properties
+            result, partition, expand_storage_groups, expand_crypto_adapters)
+
         return changed, result
 
     finally:

--- a/plugins/modules/zhmc_storage_group.py
+++ b/plugins/modules/zhmc_storage_group.py
@@ -683,12 +683,11 @@ def process_properties(cpc, storage_group, params):
     return create_props, update_props
 
 
-def add_artificial_properties(storage_group, expand):
+def add_artificial_properties(sg_properties, storage_group, expand):
     """
     Add artificial properties to the storage_group object.
 
-    Upon return, the properties of the storage_group object have been
-    extended by these properties:
+    Upon return, the sg_properties dict has been extended by these properties:
 
     Regardless of expand:
 
@@ -722,7 +721,7 @@ def add_artificial_properties(storage_group, expand):
     part_names_prop = list()
     for part in parts:
         part_names_prop.append(part.get_property('name'))
-    storage_group.properties['attached-partition-names'] = part_names_prop
+    sg_properties['attached-partition-names'] = part_names_prop
 
     if expand:
 
@@ -732,9 +731,10 @@ def add_artificial_properties(storage_group, expand):
                 full_properties=True):
             adapter = cap.manager.adapter
             adapter.pull_full_properties()
-            cap.properties['parent-adapter'] = adapter.properties
-            caps_prop.append(cap.properties)
-        storage_group.properties['candidate-adapter-ports'] = caps_prop
+            cap_properties = cap.properties.copy()
+            cap_properties['parent-adapter'] = adapter.properties.copy()
+            caps_prop.append(cap_properties)
+        sg_properties['candidate-adapter-ports'] = caps_prop
 
         # Storage volumes (full set of properties).
         # Note: We create the storage volumes from the 'storage-volume-uris'
@@ -745,8 +745,8 @@ def add_artificial_properties(storage_group, expand):
         for sv_uri in sv_uris:
             sv = storage_group.storage_volumes.resource_object(sv_uri)
             sv.pull_full_properties()
-            svs_prop.append(sv.properties)
-        storage_group.properties['storage-volumes'] = svs_prop
+            svs_prop.append(sv.properties.copy())
+        sg_properties['storage-volumes'] = svs_prop
 
         # Virtual storage resources (full set of properties).
         vsrs_prop = list()
@@ -755,16 +755,16 @@ def add_artificial_properties(storage_group, expand):
             vsr = storage_group.virtual_storage_resources.resource_object(
                 vsr_uri)
             vsr.pull_full_properties()
-            vsrs_prop.append(vsr.properties)
-        storage_group.properties['virtual-storage-resources'] = vsrs_prop
+            vsrs_prop.append(vsr.properties.copy())
+        sg_properties['virtual-storage-resources'] = vsrs_prop
 
         # List of attached partitions (full set of properties).
         parts = storage_group.list_attached_partitions()
         parts_prop = list()
         for part in parts:
             part.pull_full_properties()
-            parts_prop.append(part.properties)
-        storage_group.properties['attached-partitions'] = parts_prop
+            parts_prop.append(part.properties.copy())
+        sg_properties['attached-partitions'] = parts_prop
 
 
 def ensure_present(params, check_mode):
@@ -845,8 +845,8 @@ def ensure_present(params, check_mode):
         if not check_mode:
             if not storage_group:
                 raise AssertionError()
-            add_artificial_properties(storage_group, expand)
-            result = storage_group.properties
+            result = storage_group.properties.copy()
+            add_artificial_properties(result, storage_group, expand)
 
         return changed, result
 
@@ -945,8 +945,8 @@ def facts(params, check_mode):
                 "CPC {1!r}, but with CPC {2!r}.".
                 format(storage_group_name, cpc.name, sg_cpc.name))
 
-        add_artificial_properties(storage_group, expand)
-        result = storage_group.properties
+        result = storage_group.properties.copy()
+        add_artificial_properties(result, storage_group, expand)
 
         return changed, result
 

--- a/plugins/modules/zhmc_storage_volume.py
+++ b/plugins/modules/zhmc_storage_volume.py
@@ -400,12 +400,11 @@ def process_properties(cpc, storage_group, storage_volume, params):
     return create_props, update_props
 
 
-def add_artificial_properties(storage_volume):
+def add_artificial_properties(sv_properties, storage_volume):
     """
-    Add artificial properties to the storage_volume object.
+    Add artificial properties to the sv_properties dict.
 
-    Upon return, the properties of the storage_volume object have been
-    extended by these properties:
+    Upon return, the sv_properties dict has been extended by these properties:
 
     * 'type': Type of storage group of the volume: 'fc' (for ECKD) or 'fcp'.
     """
@@ -414,7 +413,7 @@ def add_artificial_properties(storage_volume):
 
     # Type property
     type_prop = storage_group.get_property('type')
-    storage_volume.properties['type'] = type_prop
+    sv_properties['type'] = type_prop
 
 
 def ensure_present(params, check_mode):
@@ -507,8 +506,8 @@ def ensure_present(params, check_mode):
                 raise AssertionError()
 
         if storage_volume:
-            add_artificial_properties(storage_volume)
-            result = storage_volume.properties
+            result = storage_volume.properties.copy()
+            add_artificial_properties(result, storage_volume)
 
         return changed, result
 
@@ -613,8 +612,8 @@ def facts(params, check_mode):
             raise
 
         storage_volume.pull_full_properties()
-        add_artificial_properties(storage_volume)
-        result = storage_volume.properties
+        result = storage_volume.properties.copy()
+        add_artificial_properties(result, storage_volume)
 
         return changed, result
 

--- a/plugins/modules/zhmc_user.py
+++ b/plugins/modules/zhmc_user.py
@@ -608,12 +608,12 @@ def process_properties(console, user, params):
     return create_props, update_props
 
 
-def add_artificial_properties(console, user, expand, check_mode):
+def add_artificial_properties(
+        user_properties, console, user, expand, check_mode):
     """
-    Add artificial properties to the user object (class User).
+    Add artificial properties to the user_properties dict.
 
-    Upon return, the properties of the user object have been extended by these
-    properties:
+    Upon return, the user_properties dict has been extended by these properties:
 
     Regardless of expand:
 
@@ -670,14 +670,14 @@ def add_artificial_properties(console, user, expand, check_mode):
             raise AssertionError()
         user_pattern = console.user_patterns.resource_object(user_pattern_uri)
         if check_mode:
-            user.properties['user-pattern-name'] = user_pattern.oid
+            user_properties['user-pattern-name'] = user_pattern.oid
             if expand:
-                user.properties['user-pattern'] = dict()
+                user_properties['user-pattern'] = dict()
         else:
             user_pattern.pull_full_properties()
-            user.properties['user-pattern-name'] = user_pattern.name
+            user_properties['user-pattern-name'] = user_pattern.name
             if expand:
-                user.properties['user-pattern'] = user_pattern.properties
+                user_properties['user-pattern'] = user_pattern.properties.copy()
 
     if auth_type == 'local':
         # For that auth type, the property exists and is non-null.
@@ -688,15 +688,16 @@ def add_artificial_properties(console, user, expand, check_mode):
         password_rule = console.password_rules.resource_object(
             password_rule_uri)
         if check_mode:
-            user.properties['password-rule-name'] = \
+            user_properties['password-rule-name'] = \
                 password_rule.uri.split('/')[-1]
             if expand:
-                user.properties['password-rule'] = dict()
+                user_properties['password-rule'] = dict()
         else:
             password_rule.pull_full_properties()
-            user.properties['password-rule-name'] = password_rule.name
+            user_properties['password-rule-name'] = password_rule.name
             if expand:
-                user.properties['password-rule'] = password_rule.properties
+                user_properties['password-rule'] = \
+                    password_rule.properties.copy()
 
     if auth_type == 'ldap':
         # For that auth type, the property exists and is non-null.
@@ -706,15 +707,15 @@ def add_artificial_properties(console, user, expand, check_mode):
             raise AssertionError()
         ldap_srv_def = console.ldap_srv_defs.resource_object(ldap_srv_def_uri)
         if check_mode:
-            user.properties['ldap-server-definition-name'] = ldap_srv_def.oid
+            user_properties['ldap-server-definition-name'] = ldap_srv_def.oid
             if expand:
-                user.properties['ldap-server-definition'] = dict()
+                user_properties['ldap-server-definition'] = dict()
         else:
             ldap_srv_def.pull_full_properties()
-            user.properties['ldap-server-definition-name'] = ldap_srv_def.name
+            user_properties['ldap-server-definition-name'] = ldap_srv_def.name
             if expand:
-                user.properties['ldap-server-definition'] = \
-                    ldap_srv_def.properties
+                user_properties['ldap-server-definition'] = \
+                    ldap_srv_def.properties.copy()
 
     user_roles = list()
     user_role_uris = user.properties['user-roles']
@@ -723,10 +724,10 @@ def add_artificial_properties(console, user, expand, check_mode):
         if not check_mode:
             user_role.pull_full_properties()
         user_roles.append(user_role)
-    user.properties['user-role-names'] = [ur.name for ur in user_roles]
+    user_properties['user-role-names'] = [ur.name for ur in user_roles]
     if expand:
-        user.properties['user-role-objects'] = \
-            [ur.properties for ur in user_roles]
+        user_properties['user-role-objects'] = \
+            [ur.properties.copy() for ur in user_roles]
 
 
 def create_check_mode_user(console, create_props, update_props):
@@ -802,10 +803,12 @@ def ensure_present(params, check_mode):
                 # Create a User object locally
                 user = create_check_mode_user(
                     console, create_props, update2_props)
+            result = user.properties.copy()
             changed = True
         else:
             # It exists. Update its properties.
             user.pull_full_properties()
+            result = user.properties.copy()
             create_props, update_props = process_properties(
                 console, user, params)
             if create_props:
@@ -820,15 +823,16 @@ def ensure_present(params, check_mode):
                     # We refresh the properties after the update, in case an
                     # input property value gets changed.
                     user.pull_full_properties()
+                    result = user.properties.copy()
                 else:
                     # Update the local User object's properties
-                    user.properties.update(update_props)
+                    result.update(update_props)
                 changed = True
 
         if not user:
             raise AssertionError()
-        add_artificial_properties(console, user, expand, check_mode)
-        result = user.properties
+
+        add_artificial_properties(result, console, user, expand, check_mode)
 
         return changed, result
 
@@ -902,8 +906,8 @@ def facts(params, check_mode):
         user = console.users.find(name=user_name)
         user.pull_full_properties()
 
-        add_artificial_properties(console, user, expand, check_mode)
-        result = user.properties
+        result = user.properties.copy()
+        add_artificial_properties(result, console, user, expand, check_mode)
 
         return changed, result
 

--- a/plugins/modules/zhmc_virtual_function.py
+++ b/plugins/modules/zhmc_virtual_function.py
@@ -461,7 +461,7 @@ def ensure_present(params, check_mode):
                 changed = True
 
         if vfunction:
-            result = vfunction.properties
+            result = vfunction.properties.copy()
 
         return changed, result
 


### PR DESCRIPTION
This PR accomodates the changes in zhmcclient to return the resource properties as an immutable DictView (PR https://github.com/zhmcclient/python-zhmcclient/pull/768).

This PR uses the version of zhmcclient prior to the DictView change. I have tested it locally with the DictView change.

**This is for review and discussion, not yet ready to merge.**