### PR TITLE
Fixed docs build issue with missing Sphinx.add_stylesheet()

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -75,7 +75,10 @@ tox>=2.5.0
 #       Python 2.7, so we can no longer build the docs on Python 2.7.
 # Note: The docs build tools from Ansible 2.10 (in ../ansible) require
 #       antsibull, which supports only py>=3.6.
-Sphinx>=3.0.0; python_version >= '3.6'
+# Note: Sphinx 4.0 removed the deprecated Sphinx.add_stylesheet() which causes
+#       sphinx-versions to fail that uses it. A circumvention is to pin
+#       Sphinx to <4.0.
+Sphinx>=3.0.0,<4.0.0; python_version >= '3.6'
 sphinxcontrib-fulltoc>=1.2.0; python_version >= '3.6'
 sphinxcontrib-websupport>=1.1.2; python_version >= '3.6'
 Pygments>=2.1.3; python_version >= '3.6'

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -40,6 +40,10 @@ Released: not yet
   This fixes a possible inconsistency in the versions included and build
   parameters used, between stable branch and master branch (issue #350).
 
+* Docs: Pinned Sphinx to <4.0 to circumvent the issue that sphinx-versions
+  uses the deprecated Sphinx.add_stylesheet() method that was removed in
+  Sphinx 4.0. (issue #402)
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #403 into 0.9.2.