### PR TITLE
0.9: Docs: Stated that ansible-core 2.11 is supported

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -221,8 +221,9 @@ The following operating systems are supported:
 
 The following versions of Ansible are supported:
 
-- Ansible 2.9
-- Ansible 2.10
+- ansible 2.9
+- ansible 2.10
+- ansible-core 2.11
 
 The following Z and LinuxONE machine generations are supported:
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -52,6 +52,8 @@ Released: not yet
 
 **Enhancements:**
 
+* Docs: Stated that ansible-core 2.11 is supported.
+
 **Cleanup:**
 
 **Known issues:**


### PR DESCRIPTION
Rolls back PR #409 into 0.9.2.