### PR TITLE
Fixed accomodation of immutable zhmcclient properties

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -90,6 +90,8 @@ Released: not yet
   from that page to better fit the unified documentation for the IBM Z
   collections.
 
+* Accomodated the immutable properties introduced with zhmcclient 0.31.0.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/plugins/modules/zhmc_adapter.py
+++ b/plugins/modules/zhmc_adapter.py
@@ -560,7 +560,7 @@ def ensure_set(params, check_mode):
         # The default exception handling is sufficient for the above.
 
         adapter.pull_full_properties()
-        result = adapter.properties.copy()
+        result = dict(adapter.properties)
 
         # It was identified by name or match properties, so it does exist.
         # Update its properties and change adapter and crypto type, if
@@ -591,7 +591,7 @@ def ensure_set(params, check_mode):
 
         if changed and not check_mode:
             adapter.pull_full_properties()
-            result = adapter.properties.copy()  # from actual values
+            result = dict(adapter.properties)  # from actual values
 
         ports = adapter.ports.list()
         result_ports = list()
@@ -599,7 +599,7 @@ def ensure_set(params, check_mode):
             # TODO: Disabling the following line mitigates the recent issue
             #       with HTTP error 404,4 when retrieving port properties.
             # port.pull_full_properties()
-            result_ports.append(port.properties.copy())
+            result_ports.append(dict(port.properties))
         result['ports'] = result_ports
 
         return changed, result
@@ -686,7 +686,7 @@ def ensure_present(params, check_mode):
             if not check_mode:
                 adapter = cpc.adapters.create_hipersocket(create_props)
                 adapter.pull_full_properties()
-                result = adapter.properties.copy()  # from actual values
+                result = dict(adapter.properties)  # from actual values
             else:
                 adapter = None
                 result = dict()
@@ -698,7 +698,7 @@ def ensure_present(params, check_mode):
             # needed.
 
             adapter.pull_full_properties()
-            result = adapter.properties.copy()
+            result = dict(adapter.properties)
 
             create_props, update_props, chg_adapter_type, chg_crypto_type = \
                 process_properties(adapter, params)
@@ -726,14 +726,14 @@ def ensure_present(params, check_mode):
 
             if changed and not check_mode:
                 adapter.pull_full_properties()
-                result = adapter.properties.copy()  # from actual values
+                result = dict(adapter.properties)  # from actual values
 
         if adapter:
             ports = adapter.ports.list()
             result_ports = list()
             for port in ports:
                 port.pull_full_properties()
-                result_ports.append(port.properties.copy())
+                result_ports.append(dict(port.properties))
             result['ports'] = result_ports
         else:
             # For now, we return no ports when creating in check mode
@@ -812,13 +812,13 @@ def facts(params, check_mode):
         # The default exception handling is sufficient for the above.
 
         adapter.pull_full_properties()
-        result = adapter.properties.copy()
+        result = dict(adapter.properties)
 
         ports = adapter.ports.list()
         result_ports = list()
         for port in ports:
             port.pull_full_properties()
-            result_ports.append(port.properties.copy())
+            result_ports.append(dict(port.properties))
         result['ports'] = result_ports
 
         return False, result

--- a/plugins/modules/zhmc_cpc.py
+++ b/plugins/modules/zhmc_cpc.py
@@ -439,14 +439,14 @@ def add_artificial_properties(cpc_properties, cpc):
       the list subset of their properties.
     """
     partitions = cpc.partitions.list()
-    cpc_properties['partitions'] = [p.properties.copy() for p in partitions]
+    cpc_properties['partitions'] = [dict(p.properties) for p in partitions]
 
     adapters = cpc.adapters.list()
-    cpc_properties['adapters'] = [a.properties.copy() for a in adapters]
+    cpc_properties['adapters'] = [dict(a.properties) for a in adapters]
 
     storage_groups = cpc.manager.console.storage_groups.list(
         filter_args={'cpc-uri': cpc.uri})
-    cpc_properties['storage-groups'] = [sg.properties.copy()
+    cpc_properties['storage-groups'] = [dict(sg.properties)
                                         for sg in storage_groups]
 
 
@@ -477,7 +477,7 @@ def ensure_set(params, check_mode):
         # The default exception handling is sufficient for the above.
 
         cpc.pull_full_properties()
-        result = cpc.properties.copy()
+        result = dict(cpc.properties)
         update_props = process_properties(cpc, params)
         if update_props:
             if not check_mode:
@@ -521,7 +521,7 @@ def facts(params, check_mode):
         # The default exception handling is sufficient for the above.
 
         cpc.pull_full_properties()
-        result = cpc.properties.copy()
+        result = dict(cpc.properties)
         add_artificial_properties(result, cpc)
 
         return False, result

--- a/plugins/modules/zhmc_crypto_attachment.py
+++ b/plugins/modules/zhmc_crypto_attachment.py
@@ -418,7 +418,7 @@ def get_partition_config(partition, all_adapters):
         adapter_uris = partition_config['crypto-adapter-uris']
         for a in all_adapters:
             if a.uri in adapter_uris:
-                adapters[a.name] = a.properties.copy()
+                adapters[a.name] = dict(a.properties)
         for dc in partition_config['crypto-domain-configurations']:
             di = int(dc['domain-index'])
             am = ACCESS_MODES_HMC2MOD[dc['access-mode']]

--- a/plugins/modules/zhmc_hba.py
+++ b/plugins/modules/zhmc_hba.py
@@ -505,7 +505,7 @@ def ensure_present(params, check_mode):
                 changed = True
 
         if hba:
-            result = hba.properties.copy()
+            result = dict(hba.properties)
 
         return changed, result
 

--- a/plugins/modules/zhmc_nic.py
+++ b/plugins/modules/zhmc_nic.py
@@ -583,7 +583,7 @@ def ensure_present(params, check_mode):
                 changed = True
 
         if nic:
-            result = nic.properties.copy()
+            result = dict(nic.properties)
 
         return changed, result
 

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -1015,14 +1015,14 @@ def add_artificial_properties(
     hbas_prop = list()
     if partition.hbas is not None:
         for hba in partition.hbas.list(full_properties=True):
-            hbas_prop.append(hba.properties.copy())
+            hbas_prop.append(dict(hba.properties))
     partition_properties['hbas'] = hbas_prop
 
     # Get the NIC child elements of the partition
     nics_prop = list()
     for nic in partition.nics.list(full_properties=True):
         nic_props = OrderedDict()
-        nic_props.update(nic.properties.copy())
+        nic_props.update(nic.properties)
         # Add artificial properties adapter-name/-port/-id:
         vswitch_uri = nic.prop("virtual-switch-uri", None)
         if vswitch_uri:
@@ -1049,7 +1049,7 @@ def add_artificial_properties(
     # Get the VF child elements of the partition
     vfs_prop = list()
     for vf in partition.virtual_functions.list(full_properties=True):
-        vfs_prop.append(vf.properties.copy())
+        vfs_prop.append(dict(vf.properties))
     partition_properties['virtual-functions'] = vfs_prop
 
     if expand_storage_groups:
@@ -1057,16 +1057,16 @@ def add_artificial_properties(
         for sg_uri in partition.properties['storage-group-uris']:
             storage_group = console.storage_groups.resource_object(sg_uri)
             storage_group.pull_full_properties()
-            sg_properties = storage_group.properties.copy()
+            sg_properties = dict(storage_group.properties)
 
             # Candidate adapter ports and their adapters (full set of props)
             caps_prop = list()
             for cap in storage_group.list_candidate_adapter_ports(
                     full_properties=True):
-                cap_properties = cap.properties.copy()
+                cap_properties = dict(cap.properties)
                 adapter = cap.manager.adapter
                 adapter.pull_full_properties()
-                cap_properties['parent-adapter'] = adapter.properties.copy()
+                cap_properties['parent-adapter'] = dict(adapter.properties)
                 caps_prop.append(cap_properties)
             sg_properties['candidate-adapter-ports'] = caps_prop
 
@@ -1080,7 +1080,7 @@ def add_artificial_properties(
             for sv_uri in sv_uris:
                 sv = storage_group.storage_volumes.resource_object(sv_uri)
                 sv.pull_full_properties()
-                svs_prop.append(sv.properties.copy())
+                svs_prop.append(dict(sv.properties))
             sg_properties['storage-volumes'] = svs_prop
 
             # Virtual storage resources (full set of properties).
@@ -1091,7 +1091,7 @@ def add_artificial_properties(
                 vsr = storage_group.virtual_storage_resources.resource_object(
                     vsr_uri)
                 vsr.pull_full_properties()
-                vsrs_prop.append(vsr.properties.copy())
+                vsrs_prop.append(dict(vsr.properties))
             sg_properties['virtual-storage-resources'] = vsrs_prop
 
             sgs_prop.append(sg_properties)
@@ -1111,7 +1111,7 @@ def add_artificial_properties(
             for ca_uri in cc['crypto-adapter-uris']:
                 ca = cpc.adapters.resource_object(ca_uri)
                 ca.pull_full_properties()
-                cas_prop.append(ca.properties.copy())
+                cas_prop.append(dict(ca.properties))
             cc['crypto-adapters'] = cas_prop
             partition_properties['crypto-configuration'] = cc
 
@@ -1211,7 +1211,7 @@ def ensure_active(params, check_mode):
                     "status is: {1!r}".format(partition.name, status))
 
         if partition:
-            result = partition.properties.copy()
+            result = dict(partition.properties)
             add_artificial_properties(
                 result, partition, expand_storage_groups,
                 expand_crypto_adapters)
@@ -1295,7 +1295,7 @@ def ensure_stopped(params, check_mode):
                     "status is: {1!r}".format(partition.name, status))
 
         if partition:
-            result = partition.properties.copy()
+            result = dict(partition.properties)
             add_artificial_properties(
                 result, partition, expand_storage_groups,
                 expand_crypto_adapters)
@@ -1379,7 +1379,7 @@ def facts(params, check_mode):
         partition = cpc.partitions.find(name=partition_name)
         partition.pull_full_properties()
 
-        result = partition.properties.copy()
+        result = dict(partition.properties)
         add_artificial_properties(
             result, partition, expand_storage_groups, expand_crypto_adapters)
 

--- a/plugins/modules/zhmc_storage_group.py
+++ b/plugins/modules/zhmc_storage_group.py
@@ -750,8 +750,8 @@ def add_artificial_properties(sg_properties, storage_group, expand):
                 full_properties=True):
             adapter = cap.manager.adapter
             adapter.pull_full_properties()
-            cap_properties = cap.properties.copy()
-            cap_properties['parent-adapter'] = adapter.properties.copy()
+            cap_properties = dict(cap.properties)
+            cap_properties['parent-adapter'] = dict(adapter.properties)
             caps_prop.append(cap_properties)
         sg_properties['candidate-adapter-ports'] = caps_prop
 
@@ -764,7 +764,7 @@ def add_artificial_properties(sg_properties, storage_group, expand):
         for sv_uri in sv_uris:
             sv = storage_group.storage_volumes.resource_object(sv_uri)
             sv.pull_full_properties()
-            svs_prop.append(sv.properties.copy())
+            svs_prop.append(dict(sv.properties))
         sg_properties['storage-volumes'] = svs_prop
 
         # Virtual storage resources (full set of properties).
@@ -774,7 +774,7 @@ def add_artificial_properties(sg_properties, storage_group, expand):
             vsr = storage_group.virtual_storage_resources.resource_object(
                 vsr_uri)
             vsr.pull_full_properties()
-            vsrs_prop.append(vsr.properties.copy())
+            vsrs_prop.append(dict(vsr.properties))
         sg_properties['virtual-storage-resources'] = vsrs_prop
 
         # List of attached partitions (full set of properties).
@@ -782,7 +782,7 @@ def add_artificial_properties(sg_properties, storage_group, expand):
         parts_prop = list()
         for part in parts:
             part.pull_full_properties()
-            parts_prop.append(part.properties.copy())
+            parts_prop.append(dict(part.properties))
         sg_properties['attached-partitions'] = parts_prop
 
 
@@ -865,7 +865,7 @@ def ensure_present(params, check_mode):
         if not check_mode:
             if not storage_group:
                 raise AssertionError()
-            result = storage_group.properties.copy()
+            result = dict(storage_group.properties)
             add_artificial_properties(result, storage_group, expand)
 
         return changed, result
@@ -967,7 +967,7 @@ def facts(params, check_mode):
                 "CPC {1!r}, but with CPC {2!r}.".
                 format(storage_group_name, cpc.name, sg_cpc.name))
 
-        result = storage_group.properties.copy()
+        result = dict(storage_group.properties)
         add_artificial_properties(result, storage_group, expand)
 
         return changed, result

--- a/plugins/modules/zhmc_storage_volume.py
+++ b/plugins/modules/zhmc_storage_volume.py
@@ -526,7 +526,7 @@ def ensure_present(params, check_mode):
                 raise AssertionError()
 
         if storage_volume:
-            result = storage_volume.properties.copy()
+            result = dict(storage_volume.properties)
             add_artificial_properties(result, storage_volume)
 
         return changed, result
@@ -634,7 +634,7 @@ def facts(params, check_mode):
             raise
 
         storage_volume.pull_full_properties()
-        result = storage_volume.properties.copy()
+        result = dict(storage_volume.properties)
         add_artificial_properties(result, storage_volume)
 
         return changed, result

--- a/plugins/modules/zhmc_user.py
+++ b/plugins/modules/zhmc_user.py
@@ -696,7 +696,7 @@ def add_artificial_properties(
             user_pattern.pull_full_properties()
             user_properties['user-pattern-name'] = user_pattern.name
             if expand:
-                user_properties['user-pattern'] = user_pattern.properties.copy()
+                user_properties['user-pattern'] = dict(user_pattern.properties)
 
     if auth_type == 'local':
         # For that auth type, the property exists and is non-null.
@@ -716,7 +716,7 @@ def add_artificial_properties(
             user_properties['password-rule-name'] = password_rule.name
             if expand:
                 user_properties['password-rule'] = \
-                    password_rule.properties.copy()
+                    dict(password_rule.properties)
 
     if auth_type == 'ldap':
         # For that auth type, the property exists and is non-null.
@@ -734,7 +734,7 @@ def add_artificial_properties(
             user_properties['ldap-server-definition-name'] = ldap_srv_def.name
             if expand:
                 user_properties['ldap-server-definition'] = \
-                    ldap_srv_def.properties.copy()
+                    dict(ldap_srv_def.properties)
 
     user_roles = list()
     user_role_uris = user.properties['user-roles']
@@ -746,7 +746,7 @@ def add_artificial_properties(
     user_properties['user-role-names'] = [ur.name for ur in user_roles]
     if expand:
         user_properties['user-role-objects'] = \
-            [ur.properties.copy() for ur in user_roles]
+            [dict(ur.properties) for ur in user_roles]
 
 
 def create_check_mode_user(console, create_props, update_props):
@@ -823,12 +823,12 @@ def ensure_present(params, check_mode):
                 # Create a User object locally
                 user = create_check_mode_user(
                     console, create_props, update2_props)
-            result = user.properties.copy()
+            result = dict(user.properties)
             changed = True
         else:
             # It exists. Update its properties.
             user.pull_full_properties()
-            result = user.properties.copy()
+            result = dict(user.properties)
             create_props, update_props = process_properties(
                 console, user, params)
             if create_props:
@@ -843,7 +843,7 @@ def ensure_present(params, check_mode):
                     # We refresh the properties after the update, in case an
                     # input property value gets changed.
                     user.pull_full_properties()
-                    result = user.properties.copy()
+                    result = dict(user.properties)
                 else:
                     # Update the local User object's properties
                     result.update(update_props)
@@ -928,7 +928,7 @@ def facts(params, check_mode):
         user = console.users.find(name=user_name)
         user.pull_full_properties()
 
-        result = user.properties.copy()
+        result = dict(user.properties)
         add_artificial_properties(result, console, user, expand, check_mode)
 
         return changed, result

--- a/plugins/modules/zhmc_virtual_function.py
+++ b/plugins/modules/zhmc_virtual_function.py
@@ -481,7 +481,7 @@ def ensure_present(params, check_mode):
                 changed = True
 
         if vfunction:
-            result = vfunction.properties.copy()
+            result = dict(vfunction.properties)
 
         return changed, result
 

--- a/tests/function/test_func_partition.py
+++ b/tests/function/test_func_partition.py
@@ -1611,7 +1611,7 @@ class TestPartition(object):
 
         if self.partition:
             self.partition.pull_full_properties()
-            exp_properties = self.partition.properties.copy()
+            exp_properties = dict(self.partition.properties)
         else:
             exp_properties = {}
         exp_properties['crypto-configuration'] = exp_config


### PR DESCRIPTION
This PR fixes the immutability accomodation in PR #395, which worked only with zhmcclient versions before immutability was introduced.