### PR TITLE
0.9: Pinned zhmcclient version to <0.31

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -31,6 +31,18 @@ Released: not yet
 
 **Bug fixes:**
 
+* Pinned zhmcclient version to <0.31 for two reasons:
+
+  - zhmcclient 0.31.0 introduces a new Session parameter 'verify_cert' that
+    by default verifies HMC certificates, so self-signed HMC certificates
+    will fail. The ibm_zhmc collection 0.10.0 introduces the support for this
+    new parameter, but versions 0.9.x do not have that yet.
+
+  - zhmcclient 0.31.0 introduces that the properties attribute of resource
+    objects are immutable. The ibm_zhmc collection needs to accomodate that,
+    and that support is also in ibm_zhmc collection 0.10.0, but versions 0.9.x
+    do not have that yet.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
 ansible>=2.9.0.0
 requests>=2.20.1
 # git+https://github.com/zhmcclient/python-zhmcclient@master#egg=zhmcclient
-zhmcclient>=0.26.0 # Apache-2.0
+zhmcclient>=0.26.0,<0.31.0 # Apache-2.0
 
 
 # Indirect dependencies are not specified in this file, unless needed to solve versioning issues:


### PR DESCRIPTION
See commit message.
Set to priority because a release with that fix should be made very quickly.