### PR TITLE
Docs: Fixed instructions to release a version

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -299,6 +299,16 @@ local clone of the zhmc-ansible-modules Git repo.
           git tag -f ${MNU}
           git push -f --tags
 
+    * Wait for the docs workflow named "Release M.N.U" to complete, on
+      https://github.com/zhmcclient/zhmc-ansible-modules/actions/workflows/docs.yml,
+      and once it is complete, double check whether you see the new version
+      in the release notes at
+      https://zhmcclient.github.io/zhmc-ansible-modules/release_notes.html.
+
+      If you do not see the new release notes, the build was faster than the
+      pushing of the new tag, and this can be fixed by simply re-running
+      the docs workflow via the corresponding button in GitHub Actions.
+
 11. Clean up the local repo:
 
     .. code-block:: sh

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -72,6 +72,9 @@ Released: 2021-06-17
   wins. Since PRs are merged in the order earlier first, their docs build should
   also finish first. (issue #417)
 
+* Docs: Fixed instructions to release a version to cover for the case where
+  the docs build does not show the new verison in the release notes.
+
 **Enhancements:**
 
 * Docs: The idempotency of each module and possible limitations are now


### PR DESCRIPTION
Small development docs fix that should still go into 0.10.0 before being released.
No further review needed.