### PR TITLE
Added zhmc_lpar module

### DIFF
--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -59,7 +59,11 @@ Modules supported only with CPCs in DPM operational mode:
 
 Modules supported only with CPCs in classic operational mode:
 
-* None
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   modules/zhmc_lpar
 
 You can also access the documentation of each module from the command line by
 using the `ansible-doc`_ command, for example:

--- a/docs/source/modules/zhmc_lpar.rst
+++ b/docs/source/modules/zhmc_lpar.rst
@@ -1,0 +1,413 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_core/blob/dev/plugins/modules/zhmc_lpar.py
+
+.. _zhmc_lpar_module:
+
+
+zhmc_lpar -- Manage LPARs
+=========================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Gather facts about an LPAR of a CPC (Z system) in classic mode.
+- Update modifiable properties of an active LPAR.
+- Activate an LPAR and update its properties.
+- Deactivate an LPAR.
+
+
+Requirements
+------------
+
+- Access to the WS API of the HMC of the targeted CPC (see :term:`HMC API`).
+- The targeted CPC must be in the classic operational mode.
+- The HMC userid must have the following HMC permissions:
+- Object-access permission to the target LPAR and its parent CPC.
+- If the 'next-activation-profile-name' property is to be updated, task permission for the 'Change Object Options' task or the 'Customize/Delete Activation Profiles' task.
+- If any of the 'zaware-...' properties is to be updated, task permission for the 'Firmware Details' task.
+- If any of the numbers of allocated or reserved cores is is to be updated, task permission for the 'Logical Processor Add' task.
+- If the LPAR needs to be activated, task permission for the 'Activate' task.
+- If the LPAR needs to be deactivated, task permission for the 'Deactivate' task.
+
+
+
+
+Parameters
+----------
+
+
+hmc_host
+  The hostname or IP address of the HMC.
+
+  | **required**: True
+  | **type**: str
+
+
+hmc_auth
+  The authentication credentials for the HMC.
+
+  | **required**: True
+  | **type**: dict
+
+
+  userid
+    The userid (username) for authenticating with the HMC.
+
+    | **required**: True
+    | **type**: str
+
+
+  password
+    The password for authenticating with the HMC.
+
+    | **required**: True
+    | **type**: str
+
+
+  ca_certs
+    Path name of certificate file or certificate directory to be used for verifying the HMC certificate. If null (default), the path name in the 'REQUESTS_CA_BUNDLE' environment variable or the path name in the 'CURL_CA_BUNDLE' environment variable is used, or if neither of these variables is set, the certificates in the Mozilla CA Certificate List provided by the 'certifi' Python package are used for verifying the HMC certificate.
+
+    | **required**: False
+    | **type**: str
+
+
+  verify
+    If True (default), verify the HMC certificate as specified in the ``ca_certs`` parameter. If False, ignore what is specified in the ``ca_certs`` parameter and do not verify the HMC certificate.
+
+    | **required**: False
+    | **type**: bool
+    | **default**: True
+
+
+
+cpc_name
+  The name of the CPC with the target LPAR.
+
+  | **required**: True
+  | **type**: str
+
+
+name
+  The name of the target LPAR.
+
+  | **required**: True
+  | **type**: str
+
+
+state
+  The desired state for the LPAR:
+
+  * ``inactive``: Ensures that the LPAR is inactive (i.e. status is 'not-activated'). Properties cannot be updated.
+
+  * ``operating``: Ensures that the LPAR is operating (i.e. status is 'operating' or 'acceptable'), and then ensures that the LPAR properties have the specified values.
+
+  * ``updated``: Ensures that the LPAR properties have the specified values. Requires that the LPAR is operating but does not activate it if that is not the case.
+
+  * ``facts``: Returns the current LPAR properties.
+
+  In all cases, the LPAR must exist.
+
+  | **required**: True
+  | **type**: str
+  | **choices**: inactive, operating, updated, facts
+
+
+activation_profile_name
+  The name of the image activation profile to be used when activating the LPAR, for ``state=operating``. This parameter is ignored when the LPAR was already operating.
+
+  Default: The image activation profile specified in the 'next-activation-profile-name' property of the LPAR.
+
+  This parameter is not allowed for the other ``state`` values.
+
+  | **required**: False
+  | **type**: str
+
+
+properties
+  Dictionary with new values for the LPAR properties, for ``state=operating`` and ``state=updated``. Key is the property name with underscores instead of hyphens, and value is the property value in YAML syntax. Integer properties may also be provided as decimal strings.
+
+  The possible input properties in this dictionary are the properties defined as writeable in the data model for LPAR resources (where the property names contain underscores instead of hyphens).
+
+  Properties omitted in this dictionary will not be updated.
+
+  This parameter is not allowed for the other ``state`` values.
+
+  | **required**: False
+  | **type**: dict
+
+
+log_file
+  File path of a log file to which the logic flow of this module as well as interactions with the HMC are logged. If null, logging will be propagated to the Python root logger.
+
+  | **required**: False
+  | **type**: str
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   ---
+   # Note: The following examples assume that some variables named 'my_*' are set.
+
+   - name: Ensure the LPAR is inactive
+     zhmc_lpar:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       cpc_name: "{{ my_cpc_name }}"
+       name: "{{ my_lpar_name }}"
+       state: inactive
+     register: lpar1
+
+   - name: Ensure the LPAR is operating (using the default image profile when it needs to be activated), and then set the CP sharing weight to 20
+     zhmc_lpar:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       cpc_name: "{{ my_cpc_name }}"
+       name: "{{ my_lpar_name }}"
+       state: operating
+       properties:
+         initial_processing_weight: 20
+     register: lpar1
+
+   - name: Ensure the LPAR is operating (using image profile IMAGE1 when it needs to be activated)
+     zhmc_lpar:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       cpc_name: "{{ my_cpc_name }}"
+       name: "{{ my_lpar_name }}"
+       state: operating
+       activation_profile_name: IMAGE1
+     register: lpar1
+
+   - name: Ensure the CP sharing weight of the LPAR is 30
+     zhmc_lpar:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       cpc_name: "{{ my_cpc_name }}"
+       name: "{{ my_lpar_name }}"
+       state: updated
+       properties:
+         initial_processing_weight: 30
+     register: lpar1
+
+   - name: Gather facts about the LPAR
+     zhmc_lpar:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       cpc_name: "{{ my_cpc_name }}"
+       name: "{{ my_lpar_name }}"
+       state: facts
+     register: lpar1
+
+
+
+
+
+
+
+
+
+
+
+Return Values
+-------------
+
+
+changed
+  Indicates if any change has been made by the module. For ``state=facts``, always will be false.
+
+  | **returned**: always
+  | **type**: bool
+
+msg
+  An error message that describes the failure.
+
+  | **returned**: failure
+  | **type**: str
+
+lpar
+  The resource properties of the LPAR, after the specified updates have been applied.
+
+  Note that the returned properties may show different values than the ones that were specified as input for the update. For example, memory properties may be rounded up, hexadecimal strings may be shown with a different representation format, and other properties may change as a result of updating some properties. For details, see the data model of the 'Logical Partition' object in the :term:`HMC API` book.
+
+  | **returned**: success
+  | **type**: dict
+  | **sample**:
+
+    .. code-block:: json
+
+        {
+            "absolute-aap-capping": {
+                "type": "none"
+            },
+            "absolute-cbp-capping": {
+                "type": "none"
+            },
+            "absolute-cf-capping": {
+                "type": "none"
+            },
+            "absolute-ifl-capping": {
+                "type": "none"
+            },
+            "absolute-processing-capping": {
+                "type": "none"
+            },
+            "absolute-ziip-capping": {
+                "type": "none"
+            },
+            "acceptable-status": [
+                "operating"
+            ],
+            "activation-mode": "ssc",
+            "additional-status": "",
+            "class": "logical-partition",
+            "cluster-name": "",
+            "current-aap-processing-weight": null,
+            "current-aap-processing-weight-capped": null,
+            "current-cbp-processing-weight": null,
+            "current-cbp-processing-weight-capped": null,
+            "current-cf-processing-weight": null,
+            "current-cf-processing-weight-capped": null,
+            "current-ifl-processing-weight": null,
+            "current-ifl-processing-weight-capped": null,
+            "current-processing-weight": 10,
+            "current-processing-weight-capped": false,
+            "current-vfm-storage": 0,
+            "current-ziip-processing-weight": null,
+            "current-ziip-processing-weight-capped": null,
+            "defined-capacity": 0,
+            "description": "LPAR Image",
+            "group-profile-capacity": null,
+            "group-profile-uri": null,
+            "has-operating-system-messages": true,
+            "has-unacceptable-status": false,
+            "initial-aap-processing-weight": null,
+            "initial-aap-processing-weight-capped": null,
+            "initial-cbp-processing-weight": null,
+            "initial-cbp-processing-weight-capped": null,
+            "initial-cf-processing-weight": null,
+            "initial-cf-processing-weight-capped": null,
+            "initial-ifl-processing-weight": null,
+            "initial-ifl-processing-weight-capped": null,
+            "initial-processing-weight": 10,
+            "initial-processing-weight-capped": false,
+            "initial-vfm-storage": 0,
+            "initial-ziip-processing-weight": null,
+            "initial-ziip-processing-weight-capped": null,
+            "is-locked": false,
+            "last-used-activation-profile": "ANGEL",
+            "last-used-boot-record-logical-block-address": "0",
+            "last-used-disk-partition-id": 0,
+            "last-used-load-address": "00000",
+            "last-used-load-parameter": "",
+            "last-used-logical-unit-number": "0",
+            "last-used-operating-system-specific-load-parameters": "",
+            "last-used-world-wide-port-name": "0",
+            "maximum-aap-processing-weight": null,
+            "maximum-cbp-processing-weight": null,
+            "maximum-cf-processing-weight": null,
+            "maximum-ifl-processing-weight": null,
+            "maximum-processing-weight": 0,
+            "maximum-vfm-storage": 0,
+            "maximum-ziip-processing-weight": null,
+            "minimum-aap-processing-weight": null,
+            "minimum-cbp-processing-weight": null,
+            "minimum-cf-processing-weight": null,
+            "minimum-ifl-processing-weight": null,
+            "minimum-processing-weight": 0,
+            "minimum-ziip-processing-weight": null,
+            "name": "ANGEL",
+            "next-activation-profile-name": "ANGEL",
+            "object-id": "10fa8489-4e06-3601-9170-eee82e26937c",
+            "object-uri": "/api/logical-partitions/10fa8489-4e06-3601-9170-eee82e26937c",
+            "os-ipl-token": "0000000000000000",
+            "os-level": "1.0.0",
+            "os-name": "INSTALL",
+            "os-type": "SSC",
+            "parent": "/api/cpcs/4f01576a-c3f6-3224-a951-b1bf361886a4",
+            "partition-identifier": "33",
+            "partition-number": "2f",
+            "program-status-word-information": [
+                {
+                    "cpid": "00",
+                    "psw": "0706C00180000000000000000070E050"
+                },
+                {
+                    "cpid": "01",
+                    "psw": "0706C00180000000000000000070E050"
+                },
+                {
+                    "cpid": "02",
+                    "psw": "0706C00180000000000000000070E050"
+                },
+                {
+                    "cpid": "03",
+                    "psw": "0706C00180000000000000000070E050"
+                },
+                {
+                    "cpid": "04",
+                    "psw": "0706C00180000000000000000070E050"
+                },
+                {
+                    "cpid": "05",
+                    "psw": "0706C00180000000000000000070E050"
+                },
+                {
+                    "cpid": "06",
+                    "psw": "0706C00180000000000000000070E050"
+                },
+                {
+                    "cpid": "07",
+                    "psw": "0706C00180000000000000000070E050"
+                },
+                {
+                    "cpid": "08",
+                    "psw": "0706C00180000000000000000070E050"
+                },
+                {
+                    "cpid": "09",
+                    "psw": "0706C00180000000000000000070E050"
+                }
+            ],
+            "ssc-dns-info": null,
+            "ssc-gateway-info": null,
+            "ssc-host-name": null,
+            "ssc-master-userid": null,
+            "ssc-network-info": null,
+            "status": "operating",
+            "storage-central-allocation": [
+                {
+                    "current": 8192,
+                    "gap": 102400,
+                    "initial": 8192,
+                    "maximum": 8192,
+                    "origin": 127322112,
+                    "storage-element-type": "central"
+                }
+            ],
+            "storage-expanded-allocation": [],
+            "sysplex-name": null,
+            "workload-manager-enabled": false
+        }
+
+  name
+    LPAR name
+
+    | **type**: str
+
+  {property}
+    Additional properties of the LPAR, as described in the data model of the 'Logical Partition' object in the :term:`HMC API` book. The property names have hyphens (-) as described in that book.
+
+
+

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -49,6 +49,9 @@ Released: not yet
 
 **Enhancements:**
 
+* Added a new zhmc_lpar Ansible module for managing LPARs on CPCs in classic
+  mode. (issue #418)
+
 **Cleanup:**
 
 **Known issues:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -90,7 +90,8 @@ wheel==0.33.5; python_version >= '3.8'
 ansible==2.9.0.0
 requests==2.22.0; python_version <= '3.9'
 requests==2.25.0; python_version >= '3.10'
-zhmcclient==0.31.0
+# TODO: Use zhmcclient package from Pypi again once released
+# zhmcclient==1.1.1
 
 # Indirect dependencies for installation (must be consistent with requirements.txt)
 

--- a/plugins/modules/zhmc_lpar.py
+++ b/plugins/modules/zhmc_lpar.py
@@ -1,0 +1,976 @@
+#!/usr/bin/python
+# Copyright 2022 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# For information on the format of the ANSIBLE_METADATA, DOCUMENTATION,
+# EXAMPLES, and RETURN strings, see
+# http://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['stableinterface'],
+    'supported_by': 'community',
+    'shipped_by': 'other',
+    'other_repo_url': 'https://github.com/zhmcclient/zhmc-ansible-modules'
+}
+
+DOCUMENTATION = """
+---
+module: zhmc_lpar
+version_added: "2.9.0"
+short_description: Manage LPARs
+description:
+  - Gather facts about an LPAR of a CPC (Z system) in classic mode.
+  - Update modifiable properties of an active LPAR.
+  - Activate an LPAR and update its properties.
+  - Deactivate an LPAR.
+author:
+  - Andreas Maier (@andy-maier)
+requirements:
+  - Access to the WS API of the HMC of the targeted CPC (see :term:`HMC API`).
+  - The targeted CPC must be in the classic operational mode.
+  - "The HMC userid must have the following HMC permissions:"
+  - Object-access permission to the target LPAR and its parent CPC.
+  - If the 'next-activation-profile-name' property is to be updated, task
+    permission for the 'Change Object Options' task or the 'Customize/Delete
+    Activation Profiles' task.
+  - If any of the 'zaware-...' properties is to be updated, task permission for
+    the 'Firmware Details' task.
+  - If any of the numbers of allocated or reserved cores is is to be updated,
+    task permission for the 'Logical Processor Add' task.
+  - If the LPAR needs to be activated, task permission for the 'Activate' task.
+  - If the LPAR needs to be deactivated, task permission for the 'Deactivate'
+    task.
+options:
+  hmc_host:
+    description:
+      - The hostname or IP address of the HMC.
+    type: str
+    required: true
+  hmc_auth:
+    description:
+      - The authentication credentials for the HMC.
+    type: dict
+    required: true
+    suboptions:
+      userid:
+        description:
+          - The userid (username) for authenticating with the HMC.
+        type: str
+        required: true
+      password:
+        description:
+          - The password for authenticating with the HMC.
+        type: str
+        required: true
+      ca_certs:
+        description:
+          - Path name of certificate file or certificate directory to be used
+            for verifying the HMC certificate. If null (default), the path name
+            in the 'REQUESTS_CA_BUNDLE' environment variable or the path name
+            in the 'CURL_CA_BUNDLE' environment variable is used, or if neither
+            of these variables is set, the certificates in the Mozilla CA
+            Certificate List provided by the 'certifi' Python package are used
+            for verifying the HMC certificate.
+        type: str
+        required: false
+        default: null
+      verify:
+        description:
+          - If True (default), verify the HMC certificate as specified in the
+            C(ca_certs) parameter. If False, ignore what is specified in the
+            C(ca_certs) parameter and do not verify the HMC certificate.
+        type: bool
+        required: false
+        default: true
+  cpc_name:
+    description:
+      - The name of the CPC with the target LPAR.
+    type: str
+    required: true
+  name:
+    description:
+      - The name of the target LPAR.
+    type: str
+    required: true
+  state:
+    description:
+      - "The desired state for the LPAR:"
+      - "* C(inactive): Ensures that the LPAR is inactive (i.e. status is
+         'not-activated'). Properties cannot be updated. The LPAR is
+         deactivated if needed."
+      - "* C(operating): Ensures that the LPAR is operating (i.e. status is
+         'operating' or 'acceptable'), and then ensures that the LPAR properties
+         have the specified values. The LPAR is first activated if needed, and
+         then loaded if needed (when auto-load is not set)."
+      - "* C(updated): Ensures that the LPAR properties have the specified
+         values. Requires that the LPAR is at least active (i.e. status is
+         'not-operating', 'operating' or 'acceptable') but does not activate
+         the LPAR if that is not the case."
+      - "* C(facts): Returns the current LPAR properties."
+      - "In all cases, the LPAR must exist."
+    type: str
+    required: true
+    choices: ['inactive', 'operating', 'updated', 'facts']
+  activation_profile_name:
+    description:
+      - "The name of the image activation profile to be used when activating the
+         LPAR, for C(state=operating). This parameter is ignored when the LPAR
+         was already operating."
+      - "Default: The image activation profile specified in the
+         'next-activation-profile-name' property of the LPAR."
+      - "This parameter is not allowed for the other C(state) values."
+    type: str
+    required: false
+  properties:
+    description:
+      - "Dictionary with new values for the LPAR properties, for
+         C(state=operating) and C(state=updated). Key is the property name with
+         underscores instead of hyphens, and value is the property value in
+         YAML syntax. Integer properties may also be provided as decimal
+         strings."
+      - "The possible input properties in this dictionary are the properties
+         defined as writeable in the data model for LPAR resources
+         (where the property names contain underscores instead of hyphens)."
+      - "Properties omitted in this dictionary will not be updated."
+      - "This parameter is not allowed for the other C(state) values."
+    type: dict
+    required: false
+    default: null
+  log_file:
+    description:
+      - "File path of a log file to which the logic flow of this module as well
+         as interactions with the HMC are logged. If null, logging will be
+         propagated to the Python root logger."
+    type: str
+    required: false
+    default: null
+  _faked_session:
+    description:
+      - "An internal parameter used for testing the module."
+    required: false
+    type: raw
+    default: null
+"""
+
+EXAMPLES = """
+---
+# Note: The following examples assume that some variables named 'my_*' are set.
+
+- name: Ensure the LPAR is inactive
+  zhmc_lpar:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    cpc_name: "{{ my_cpc_name }}"
+    name: "{{ my_lpar_name }}"
+    state: inactive
+  register: lpar1
+
+- name: Ensure the LPAR is operating (using the default image profile when it needs to be activated), and then set the CP sharing weight to 20
+  zhmc_lpar:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    cpc_name: "{{ my_cpc_name }}"
+    name: "{{ my_lpar_name }}"
+    state: operating
+    properties:
+      initial_processing_weight: 20
+  register: lpar1
+
+- name: Ensure the LPAR is operating (using image profile IMAGE1 when it needs to be activated)
+  zhmc_lpar:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    cpc_name: "{{ my_cpc_name }}"
+    name: "{{ my_lpar_name }}"
+    state: operating
+    activation_profile_name: IMAGE1
+  register: lpar1
+
+- name: Ensure the CP sharing weight of the LPAR is 30
+  zhmc_lpar:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    cpc_name: "{{ my_cpc_name }}"
+    name: "{{ my_lpar_name }}"
+    state: updated
+    properties:
+      initial_processing_weight: 30
+  register: lpar1
+
+- name: Gather facts about the LPAR
+  zhmc_lpar:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    cpc_name: "{{ my_cpc_name }}"
+    name: "{{ my_lpar_name }}"
+    state: facts
+  register: lpar1
+
+"""
+
+RETURN = """
+changed:
+  description: Indicates if any change has been made by the module.
+    For C(state=facts), always will be false.
+  returned: always
+  type: bool
+msg:
+  description: An error message that describes the failure.
+  returned: failure
+  type: str
+lpar:
+  description:
+    - "The resource properties of the LPAR, after the specified updates have
+       been applied."
+    - "Note that the returned properties may show different values than the ones
+       that were specified as input for the update. For example, memory
+       properties may be rounded up, hexadecimal strings may be shown with a
+       different representation format, and other properties may change as a
+       result of updating some properties. For details, see the data model of
+       the 'Logical Partition' object in the :term:`HMC API` book."
+  returned: success
+  type: dict
+  contains:
+    name:
+      description: "LPAR name"
+      type: str
+    "{property}":
+      description: "Additional properties of the LPAR, as described in
+        the data model of the 'Logical Partition' object in the
+        :term:`HMC API` book.
+        The property names have hyphens (-) as described in that book."
+  sample:
+    {
+        "absolute-aap-capping": {
+            "type": "none"
+        },
+        "absolute-cbp-capping": {
+            "type": "none"
+        },
+        "absolute-cf-capping": {
+            "type": "none"
+        },
+        "absolute-ifl-capping": {
+            "type": "none"
+        },
+        "absolute-processing-capping": {
+            "type": "none"
+        },
+        "absolute-ziip-capping": {
+            "type": "none"
+        },
+        "acceptable-status": [
+            "operating"
+        ],
+        "activation-mode": "ssc",
+        "additional-status": "",
+        "class": "logical-partition",
+        "cluster-name": "",
+        "current-aap-processing-weight": null,
+        "current-aap-processing-weight-capped": null,
+        "current-cbp-processing-weight": null,
+        "current-cbp-processing-weight-capped": null,
+        "current-cf-processing-weight": null,
+        "current-cf-processing-weight-capped": null,
+        "current-ifl-processing-weight": null,
+        "current-ifl-processing-weight-capped": null,
+        "current-processing-weight": 10,
+        "current-processing-weight-capped": false,
+        "current-vfm-storage": 0,
+        "current-ziip-processing-weight": null,
+        "current-ziip-processing-weight-capped": null,
+        "defined-capacity": 0,
+        "description": "LPAR Image",
+        "group-profile-capacity": null,
+        "group-profile-uri": null,
+        "has-operating-system-messages": true,
+        "has-unacceptable-status": false,
+        "initial-aap-processing-weight": null,
+        "initial-aap-processing-weight-capped": null,
+        "initial-cbp-processing-weight": null,
+        "initial-cbp-processing-weight-capped": null,
+        "initial-cf-processing-weight": null,
+        "initial-cf-processing-weight-capped": null,
+        "initial-ifl-processing-weight": null,
+        "initial-ifl-processing-weight-capped": null,
+        "initial-processing-weight": 10,
+        "initial-processing-weight-capped": false,
+        "initial-vfm-storage": 0,
+        "initial-ziip-processing-weight": null,
+        "initial-ziip-processing-weight-capped": null,
+        "is-locked": false,
+        "last-used-activation-profile": "ANGEL",
+        "last-used-boot-record-logical-block-address": "0",
+        "last-used-disk-partition-id": 0,
+        "last-used-load-address": "00000",
+        "last-used-load-parameter": "",
+        "last-used-logical-unit-number": "0",
+        "last-used-operating-system-specific-load-parameters": "",
+        "last-used-world-wide-port-name": "0",
+        "maximum-aap-processing-weight": null,
+        "maximum-cbp-processing-weight": null,
+        "maximum-cf-processing-weight": null,
+        "maximum-ifl-processing-weight": null,
+        "maximum-processing-weight": 0,
+        "maximum-vfm-storage": 0,
+        "maximum-ziip-processing-weight": null,
+        "minimum-aap-processing-weight": null,
+        "minimum-cbp-processing-weight": null,
+        "minimum-cf-processing-weight": null,
+        "minimum-ifl-processing-weight": null,
+        "minimum-processing-weight": 0,
+        "minimum-ziip-processing-weight": null,
+        "name": "ANGEL",
+        "next-activation-profile-name": "ANGEL",
+        "object-id": "10fa8489-4e06-3601-9170-eee82e26937c",
+        "object-uri": "/api/logical-partitions/10fa8489-4e06-3601-9170-eee82e26937c",
+        "os-ipl-token": "0000000000000000",
+        "os-level": "1.0.0",
+        "os-name": "INSTALL",
+        "os-type": "SSC",
+        "parent": "/api/cpcs/4f01576a-c3f6-3224-a951-b1bf361886a4",
+        "partition-identifier": "33",
+        "partition-number": "2f",
+        "program-status-word-information": [
+            {
+                "cpid": "00",
+                "psw": "0706C00180000000000000000070E050"
+            },
+            {
+                "cpid": "01",
+                "psw": "0706C00180000000000000000070E050"
+            },
+            {
+                "cpid": "02",
+                "psw": "0706C00180000000000000000070E050"
+            },
+            {
+                "cpid": "03",
+                "psw": "0706C00180000000000000000070E050"
+            },
+            {
+                "cpid": "04",
+                "psw": "0706C00180000000000000000070E050"
+            },
+            {
+                "cpid": "05",
+                "psw": "0706C00180000000000000000070E050"
+            },
+            {
+                "cpid": "06",
+                "psw": "0706C00180000000000000000070E050"
+            },
+            {
+                "cpid": "07",
+                "psw": "0706C00180000000000000000070E050"
+            },
+            {
+                "cpid": "08",
+                "psw": "0706C00180000000000000000070E050"
+            },
+            {
+                "cpid": "09",
+                "psw": "0706C00180000000000000000070E050"
+            }
+        ],
+        "ssc-dns-info": null,
+        "ssc-gateway-info": null,
+        "ssc-host-name": null,
+        "ssc-master-userid": null,
+        "ssc-network-info": null,
+        "status": "operating",
+        "storage-central-allocation": [
+            {
+                "current": 8192,
+                "gap": 102400,
+                "initial": 8192,
+                "maximum": 8192,
+                "origin": 127322112,
+                "storage-element-type": "central"
+            }
+        ],
+        "storage-expanded-allocation": [],
+        "sysplex-name": null,
+        "workload-manager-enabled": false
+    }
+"""
+
+from collections import OrderedDict  # noqa: E402
+import logging  # noqa: E402
+import traceback  # noqa: E402
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+from operator import itemgetter  # noqa: E402
+
+from ..module_utils.common import log_init, Error, ParameterError, \
+    StatusError, make_lpar_inactive, make_lpar_operating, \
+    eq_hex, get_hmc_auth, get_session, \
+    to_unicode, process_normal_property, missing_required_lib  # noqa: E402
+
+try:
+    import requests.packages.urllib3
+    IMP_URLLIB3 = True
+except ImportError:
+    IMP_URLLIB3 = False
+    IMP_URLLIB3_ERR = traceback.format_exc()
+
+try:
+    import zhmcclient
+    IMP_ZHMCCLIENT = True
+except ImportError:
+    IMP_ZHMCCLIENT = False
+    IMP_ZHMCCLIENT_ERR = traceback.format_exc()
+
+# Python logger name for this module
+LOGGER_NAME = 'zhmc_lpar'
+
+LOGGER = logging.getLogger(LOGGER_NAME)
+
+# Dictionary of properties of LPAR resources, in this format:
+#   name: (allowed, create, update, update_while_active, eq_func, type_cast)
+# where:
+#   name: Name of the property according to the data model, with hyphens
+#     replaced by underscores (this is how it is or would be specified in
+#     the 'properties' module parameter).
+#   allowed: Indicates whether it is allowed in the 'properties' module
+#     parameter.
+#   create: Always False because LPARs cannot be created - still defined for
+#     consistency with other modules.
+#   update: Indicates whether it can be specified for the "Update Logical
+#     Partition Properties" operation (at all).
+#   update_while_active: Indicates whether it can be specified for the "Update
+#     Logical Partition Properties" operation while the LPAR is operating. None
+#     means "not applicable" (i.e. update=False).
+#   eq_func: Equality test function for two values of the property; None means
+#     to use Python equality.
+#   type_cast: Type cast function for an input value of the property; None
+#     means to use it directly. This can be used for example to convert
+#     integers provided as strings by Ansible back into integers (that is a
+#     current deficiency of Ansible).
+ZHMC_LPAR_PROPERTIES = {
+
+    # create-only properties: None - LPARs cannot be created
+
+    # update-only properties:
+    'acceptable_status': (True, False, True, True, None, None),
+    'next_activation_profile_name': (True, False, True, True, None, None),
+    'initial_processing_weight': (True, False, True, True, None, int),
+    'initial_processing_weight_capped': (True, False, True, True, None, None),
+    'minimum_processing_weight': (True, False, True, True, None, int),
+    'maximum_processing_weight': (True, False, True, True, None, int),
+    'workload_manager_enabled': (True, False, True, True, None, None),
+    'absolute_processing_capping': (True, False, True, True, None, None),  # absolute_capping object
+    'defined_capacity': (True, False, True, True, None, int),
+    'number_general_purpose_cores': (True, False, True, True, None, int),
+    'number_reserved_general_purpose_cores': (True, False, True, True, None, int),
+    'number_icf_cores': (True, False, True, True, None, int),
+    'number_reserved_icf_cores': (True, False, True, True, None, int),
+    'number_ifl_cores': (True, False, True, True, None, int),
+    'number_reserved_ifl_cores': (True, False, True, True, None, int),
+    'number_ziip_cores': (True, False, True, True, None, int),
+    'number_reserved_ziip_cores': (True, False, True, True, None, int),
+    'number_aap_cores': (True, False, True, True, None, int),
+    'number_reserved_aap_cores': (True, False, True, True, None, int),
+    'initial_aap_processing_weight': (True, False, True, True, None, int),
+    'initial_aap_processing_weight_capped': (True, False, True, True, None, None),
+    'minimum_aap_processing_weight': (True, False, True, True, None, int),
+    'maximum_aap_processing_weight': (True, False, True, True, None, int),
+    'absolute_aap_capping': (True, False, True, True, None, None),  # absolute_capping object
+    'initial_ifl_processing_weight': (True, False, True, True, None, int),
+    'initial_ifl_processing_weight_capped': (True, False, True, True, None, None),
+    'minimum_ifl_processing_weight': (True, False, True, True, None, int),
+    'maximum_ifl_processing_weight': (True, False, True, True, None, int),
+    'absolute_ifl_capping': (True, False, True, True, None, None),  # absolute_capping object
+    'initial_cbp_processing_weight': (True, False, True, True, None, int),
+    'initial_cbp_processing_weight_capped': (True, False, True, True, None, None),
+    'minimum_cbp_processing_weight': (True, False, True, True, None, int),
+    'maximum_cbp_processing_weight': (True, False, True, True, None, int),
+    'absolute_cbp_capping': (True, False, True, True, None, None),  # absolute_capping object
+    'initial_ziip_processing_weight': (True, False, True, True, None, int),
+    'initial_ziip_processing_weight_capped': (True, False, True, True, None, None),
+    'minimum_ziip_processing_weight': (True, False, True, True, None, int),
+    'maximum_ziip_processing_weight': (True, False, True, True, None, int),
+    'absolute_ziip_capping': (True, False, True, True, None, None),  # absolute_capping object
+    'initial_cf_processing_weight': (True, False, True, True, None, int),
+    'initial_cf_processing_weight_capped': (True, False, True, True, None, None),
+    'minimum_cf_processing_weight': (True, False, True, True, None, int),
+    'maximum_cf_processing_weight': (True, False, True, True, None, int),
+    'absolute_cf_capping': (True, False, True, True, None, None),  # absolute_capping object
+    'zaware_hostname': (True, False, True, True, None, None),
+    'zaware_master_userid': (True, False, True, True, None, None),
+    'zaware_master_pw': (True, False, True, True, None, None),
+    'zaware_network_info': (True, False, True, True, None, None),  # Array of zaware_network objects
+    'zaware_gateway_info': (True, False, True, True, None, None),  # ip_info object
+    'zaware_dns_info': (True, False, True, True, None, None),  # Array of ip_info objects
+
+    # read_only properties:
+    'object_uri': (False, False, False, None, None, None),
+    'object_id': (False, False, False, None, None, None),
+    'parent': (False, False, False, None, None, None),
+    'class': (False, False, False, None, None, None),
+    'name': (False, False, False, None, None, None),
+    'description': (False, False, False, None, None, None),
+    'is_locked': (False, False, False, None, None, None),
+    'effective_properties_apply': (False, False, False, None, None, None),
+    'status': (False, False, False, None, None, None),
+    'os_name': (False, False, False, None, None, None),
+    'os_type': (False, False, False, None, None, None),
+    'os_version': (False, False, False, None, None, None),
+    'sysplex_name': (False, False, False, None, None, None),
+    'is_sub_capacity_boost_active': (False, False, False, None, None, None),
+    'is_secure_execution_enabled': (False, False, False, None, None, None),
+    'is_ziip_capacity_boost_active': (False, False, False, None, None, None),
+    'has_operating_system_messages': (False, False, False, None, None, None),
+    'has_important_unviewed_operating_system_messages': (False, False, False, None, None, None),
+    'activation_mode': (False, False, False, None, None, None),
+    'last_used_activation_profile': (False, False, False, None, None, None),
+    'last_used_load_type': (False, False, False, None, None, None),
+    'last_used_load_address': (False, False, False, None, None, None),
+    'last_used_load_parameter': (False, False, False, None, None, None),
+    'last_used_secure_boot': (False, False, False, None, None, None),
+    'last_used_world_wide_port_name': (False, False, False, None, None, None),
+    'last_used_logical_unit_number': (False, False, False, None, None, None),
+    'last_used_disk_partition_id': (False, False, False, None, None, None),
+    'last_used_operating_system_specific_load_parameters': (False, False, False, None, None, None),
+    'last_used_boot_record_logical_block_address': (False, False, False, None, None, None),
+    'current_processing_weight': (False, False, False, None, None, None),
+    'current_processing_weight_capped': (False, False, False, None, None, None),
+    'processor_usage': (False, False, False, None, None, None),
+    'number_general_purpose_processors': (False, False, False, None, None, None),
+    'number_reserved_general_purpose_processors': (False, False, False, None, None, None),
+    'number_icf_processors': (False, False, False, None, None, None),
+    'number_reserved_icf_processors': (False, False, False, None, None, None),
+    'number_ifl_processors': (False, False, False, None, None, None),
+    'number_reserved_ifl_processors': (False, False, False, None, None, None),
+    'number_ziip_processors': (False, False, False, None, None, None),
+    'number_reserved_ziip_processors': (False, False, False, None, None, None),
+    'number_aap_processors': (False, False, False, None, None, None),
+    'number_reserved_aap_processors': (False, False, False, None, None, None),
+    'current_ifl_processing_weight': (False, False, False, None, None, None),
+    'current_ifl_processing_weight_capped': (False, False, False, None, None, None),
+    'current_cbp_processing_weight': (False, False, False, None, None, None),
+    'current_cbp_processing_weight_capped': (False, False, False, None, None, None),
+    'current_ziip_processing_weight': (False, False, False, None, None, None),
+    'current_ziip_processing_weight_capped': (False, False, False, None, None, None),
+    'current_cf_processing_weight': (False, False, False, None, None, None),
+    'current_cf_processing_weight_capped': (False, False, False, None, None, None),
+    'program_status_word_information': (False, False, False, None, None, None),  # Array of psw_description objects
+    'initial_vfm_storage': (False, False, False, None, None, None),
+    'maximum_vfm_storage': (False, False, False, None, None, None),
+    'current_vfm_storage': (False, False, False, None, None, None),
+    'os_ipl_token': (False, False, False, None, None, None),
+    'group_profile_capacity': (False, False, False, None, None, None),
+    'group_profile_uri': (False, False, False, None, None, None),
+    # ssc_* properties are not supported; they were removed starting with z14.
+    'storage_central_allocation': (False, False, False, None, None, None),  # Array of central_storage_allocation objects
+    'storage_expanded_allocation': (False, False, False, None, None, None),  # Array of expanded_storage_allocation objects
+    'target_name': (False, False, False, None, None, None),
+    'request_origin': (False, False, False, None, None, None),
+}
+
+
+def process_properties(cpc, lpar, params):
+    """
+    Process the properties specified in the 'properties' module parameter,
+    and return a dictionarys (update_props) that contains the properties that
+    can be updated. If the resource exists, the input property values are
+    compared with the existing resource property values and the returned set
+    of properties is the minimal set of properties that need to be changed.
+
+    - Underscores in the property names are translated into hyphens.
+    - The presence of read-only properties, invalid properties (i.e. not
+      defined in the data model for LPARs), and properties that are not
+      allowed because of restrictions or because they are auto-created from
+      an artificial property is surfaced by raising ParameterError.
+    - The properties resulting from handling artificial properties are
+      added to the returned dictionaries.
+
+    Parameters:
+
+      cpc (zhmcclient.Cpc): CPC with the LPAR to be updated.
+
+      lpar (zhmcclient.Lpar): LPAR to be updated with the full
+        set of current properties, or `None` if it did not previously exist.
+
+      params (dict): Module input parameters.
+
+    Returns:
+      update_props: dict of properties for zhmcclient.Lpar.update_properties()
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+    """
+    create_props = {}
+    update_props = {}
+    stop = False
+
+    # handle 'name' property
+    # We looked up the LPAR by name, so we will never have to update
+    # the LPAR name
+    lpar_name = to_unicode(params['name'])
+
+    # handle the other properties
+    input_props = params.get('properties', {})
+    if input_props is None:
+        input_props = {}
+    for prop_name in input_props:
+
+        if prop_name not in ZHMC_LPAR_PROPERTIES:
+            raise ParameterError(
+                "Property {0!r} is not defined in the data model for "
+                "LPARs.".format(prop_name))
+
+        allowed, create, update, update_while_active, eq_func, type_cast = \
+            ZHMC_LPAR_PROPERTIES[prop_name]
+
+        if not allowed:
+            raise ParameterError(
+                "Property {0!r} is not allowed in the 'properties' module "
+                "parameter.".format(prop_name))
+
+        else:
+            # Process a normal (= non-artificial) property
+            _create_props, _update_props, _stop = process_normal_property(
+                prop_name, ZHMC_LPAR_PROPERTIES, input_props, lpar)
+            create_props.update(_create_props)
+            update_props.update(_update_props)
+            if _stop:
+                stop = True
+
+    if create_props:
+        raise AssertionError(
+            "create_props not empty for LPAR {0!r}".format(lpar_name))
+
+    if stop:
+        raise AssertionError(
+            "stop set for LPAR {0!r}".format(lpar_name))
+
+    return update_props
+
+
+def add_artificial_properties(lpar_properties, lpar):
+    """
+    Add artificial properties to the lpar_properties dict.
+
+    Upon return, the lpar_properties dict has been extended by these
+    artificial properties:
+
+    None - This module does not add any artificial properties.
+    """
+    pass
+
+
+def ensure_operating(params, check_mode):
+    """
+    Ensure that the LPAR is in an operating state and has the specified
+    properties.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      StatusError: An issue with the LPAR status.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    host = params['hmc_host']
+    userid, password, ca_certs, verify = get_hmc_auth(params['hmc_auth'])
+    cpc_name = params['cpc_name']
+    lpar_name = params['name']
+    activation_profile_name = params['activation_profile_name']
+    _faked_session = params.get('_faked_session', None)
+
+    changed = False
+    result = {}
+
+    session = get_session(
+        _faked_session, host, userid, password, ca_certs, verify)
+    try:
+        client = zhmcclient.Client(session)
+        cpc = client.cpcs.find(name=cpc_name)
+        lpar = cpc.lpars.find(name=lpar_name)
+        # The default exception handling is sufficient for the above.
+
+        # If we got here, the LPAR exists.
+
+        # Bring the LPAR into the operating status.
+        changed |= make_lpar_operating(
+            LOGGER, lpar, check_mode,
+            activation_profile_name=activation_profile_name)
+
+        # Update the properties of the LPAR.
+        lpar.pull_full_properties()
+        lpar_properties = dict(lpar.properties)
+        update_props = process_properties(cpc, lpar, params)
+        if update_props:
+            if not check_mode:
+                lpar.update_properties(update_props)
+                # We refresh the properties after the update, in case an
+                # input property value gets changed.
+                lpar.pull_full_properties()
+                lpar_properties = dict(lpar.properties)
+            else:
+                lpar_properties.update(update_props)
+            changed = True
+
+        result = lpar_properties
+        add_artificial_properties(result, lpar)
+
+        return changed, result
+
+    finally:
+        session.logoff()
+
+
+def ensure_inactive(params, check_mode):
+    """
+    Ensure that the LPAR is inactive. No properties are updated.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      StatusError: An issue with the LPAR status.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    host = params['hmc_host']
+    userid, password, ca_certs, verify = get_hmc_auth(params['hmc_auth'])
+    cpc_name = params['cpc_name']
+    lpar_name = params['name']
+    _faked_session = params.get('_faked_session', None)
+
+    properties = params.get('properties', None)
+    if properties:
+        raise ParameterError(
+            "Properties must not be specified for state=inactive with "
+            "LPAR {0!r}.".format(lpar_name))
+
+    changed = False
+    result = {}
+
+    session = get_session(
+        _faked_session, host, userid, password, ca_certs, verify)
+    try:
+        client = zhmcclient.Client(session)
+        cpc = client.cpcs.find(name=cpc_name)
+        lpar = cpc.lpars.find(name=lpar_name)
+        # The default exception handling is sufficient for the above.
+
+        # If we got here, the LPAR exists.
+
+        # Deactivate the LPAR.
+        changed |= make_lpar_inactive(LOGGER, lpar, check_mode)
+
+        return changed, result
+
+    finally:
+        session.logoff()
+
+
+def ensure_updated(params, check_mode):
+    """
+    Ensure that the LPAR properties have been updated, without activating
+    or deactivating the LPAR.
+
+    This requires the LPAR to be in an operating status.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      StatusError: An issue with the LPAR status.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    host = params['hmc_host']
+    userid, password, ca_certs, verify = get_hmc_auth(params['hmc_auth'])
+    cpc_name = params['cpc_name']
+    lpar_name = params['name']
+    _faked_session = params.get('_faked_session', None)
+
+    changed = False
+    result = {}
+
+    session = get_session(
+        _faked_session, host, userid, password, ca_certs, verify)
+    try:
+        client = zhmcclient.Client(session)
+        cpc = client.cpcs.find(name=cpc_name)
+        lpar = cpc.lpars.find(name=lpar_name)
+        # The default exception handling is sufficient for the above.
+
+        # If we got here, the LPAR exists.
+
+        # Update the properties of the LPAR.
+        lpar.pull_full_properties()
+        lpar_properties = dict(lpar.properties)
+        update_props = process_properties(cpc, lpar, params)
+        if update_props:
+            if not check_mode:
+                lpar.update_properties(update_props)
+                # We refresh the properties after the update, in case an
+                # input property value gets changed.
+                lpar.pull_full_properties()
+                lpar_properties = dict(lpar.properties)
+            else:
+                # Simulate the update behavior in check mode
+                status = lpar.properties.get('status', None)
+                if status not in ('not-operating', 'operating', 'acceptable'):
+                    raise StatusError(
+                        "LPAR {0!r} has status {1} and cannot be updated.".
+                        format(lpar_name, status))
+                lpar_properties.update(update_props)
+            changed = True
+
+        result = lpar_properties
+        add_artificial_properties(result, lpar)
+
+        return changed, result
+
+    finally:
+        session.logoff()
+
+
+def facts(params, check_mode):
+    """
+    Return LPAR facts.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    host = params['hmc_host']
+    userid, password, ca_certs, verify = get_hmc_auth(params['hmc_auth'])
+    cpc_name = params['cpc_name']
+    lpar_name = params['name']
+    _faked_session = params.get('_faked_session', None)
+
+    properties = params.get('properties', None)
+    if properties:
+        raise ParameterError(
+            "Properties must not be specified for state=facts with "
+            "LPAR {0!r}.".format(lpar_name))
+
+    changed = False
+    result = {}
+
+    session = get_session(
+        _faked_session, host, userid, password, ca_certs, verify)
+    try:
+        # The default exception handling is sufficient for this code
+        client = zhmcclient.Client(session)
+        cpc = client.cpcs.find(name=cpc_name)
+
+        lpar = cpc.lpars.find(name=lpar_name)
+        lpar.pull_full_properties()
+
+        result = dict(lpar.properties)
+        add_artificial_properties(result, lpar)
+
+        return changed, result
+
+    finally:
+        session.logoff()
+
+
+def perform_task(params, check_mode):
+    """
+    Perform the task for this module, dependent on the 'state' module
+    parameter.
+
+    If check_mode is True, check whether changes would occur, but don't
+    actually perform any changes.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      StatusError: An issue with the LPAR status.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+    actions = {
+        'operating': ensure_operating,
+        'inactive': ensure_inactive,
+        'updated': ensure_updated,
+        'facts': facts,
+    }
+    return actions[params['state']](params, check_mode)
+
+
+def main():
+
+    # The following definition of module input parameters must match the
+    # description of the options in the DOCUMENTATION string.
+    argument_spec = dict(
+        hmc_host=dict(required=True, type='str'),
+        hmc_auth=dict(
+            required=True,
+            type='dict',
+            options=dict(
+                userid=dict(required=True, type='str'),
+                password=dict(required=True, type='str', no_log=True),
+                ca_certs=dict(required=False, type='str', default=None),
+                verify=dict(required=False, type='bool', default=True),
+            ),
+        ),
+        cpc_name=dict(required=True, type='str'),
+        name=dict(required=True, type='str'),
+        state=dict(required=True, type='str',
+                   choices=['inactive', 'operating', 'updated', 'facts']),
+        activation_profile_name=dict(required=False, type='str'),
+        properties=dict(required=False, type='dict', default={}),
+        log_file=dict(required=False, type='str', default=None),
+        _faked_session=dict(required=False, type='raw'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True)
+
+    if not IMP_URLLIB3:
+        module.fail_json(msg=missing_required_lib("requests"),
+                         exception=IMP_URLLIB3_ERR)
+
+    requests.packages.urllib3.disable_warnings()
+
+    if not IMP_ZHMCCLIENT:
+        module.fail_json(msg=missing_required_lib("zhmcclient"),
+                         exception=IMP_ZHMCCLIENT_ERR)
+
+    log_file = module.params['log_file']
+    log_init(LOGGER_NAME, log_file)
+
+    _params = dict(module.params)
+    del _params['hmc_auth']
+    LOGGER.debug("Module entry: params: %r", _params)
+
+    try:
+
+        changed, result = perform_task(module.params, module.check_mode)
+
+    except (Error, zhmcclient.Error) as exc:
+        # These exceptions are considered errors in the environment or in user
+        # input. They have a proper message that stands on its own, so we
+        # simply pass that message on and will not need a traceback.
+        msg = "{0}: {1}".format(exc.__class__.__name__, exc)
+        LOGGER.debug(
+            "Module exit (failure): msg: %s", msg)
+        module.fail_json(msg=msg)
+    # Other exceptions are considered module errors and are handled by Ansible
+    # by showing the traceback.
+
+    LOGGER.debug(
+        "Module exit (success): changed: %r, cpc: %r", changed, result)
+    module.exit_json(changed=changed, lpar=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,9 @@ ansible>=2.9.0.0
 requests>=2.22.0; python_version <= '3.9'
 requests>=2.25.0; python_version >= '3.10'
 
-# git+https://github.com/zhmcclient/python-zhmcclient@master#egg=zhmcclient
-zhmcclient>=0.31.0
+# TODO: Use zhmcclient package from Pypi again once released
+git+https://github.com/zhmcclient/python-zhmcclient@1.1/andy/fix-lpar-update-mock#egg=zhmcclient
+# zhmcclient>=1.1.1
 
 
 # Indirect dependencies are not specified in this file, unless needed to solve versioning issues:

--- a/tests/function/test_func_lpar.py
+++ b/tests/function/test_func_lpar.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python
+# Copyright 2022 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function tests for the 'zhmc_lpar' Ansible module.
+"""
+
+# pylint: disable=bad-option-value,redundant-u-string-prefix
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+import mock
+import re
+
+from zhmcclient import Client
+from zhmcclient_mock import FakedSession
+
+from plugins.modules import zhmc_lpar
+
+from .func_utils import mock_ansible_module
+
+# FakedSession() init arguments
+FAKED_SESSION_KWARGS = dict(
+    host='fake-host',
+    hmc_name='faked-hmc-name',
+    hmc_version='2.13.1',
+    api_version='1.8'
+)
+
+# Faked Console that is used for all tests
+# (with property names as specified in HMC data model)
+FAKED_CONSOLE_URI = '/api/console'
+FAKED_CONSOLE = {
+    'object-uri': FAKED_CONSOLE_URI,
+    'class': 'console',
+    'name': 'hmc-1',
+    'description': 'Console HMC1',
+    'version': '2.13.0',
+}
+
+# Faked CPC in classic mode that is used for all tests
+# (with property names as specified in HMC data model)
+FAKED_CPC_1_OID = 'fake-cpc-1'
+FAKED_CPC_1_URI = '/api/cpcs/' + FAKED_CPC_1_OID
+FAKED_CPC_1 = {
+    'object-id': FAKED_CPC_1_OID,
+    'object-uri': FAKED_CPC_1_URI,
+    'class': 'cpc',
+    'name': 'cpc-name-1',
+    'description': 'CPC #1 in classic mode',
+    'status': 'active',
+    'dpm-enabled': False,
+    'is-ensemble-member': False,
+    'iml-mode': 'lpar',
+}
+
+# Faked LPAR that is used for these tests.
+# The LPAR is an SSC type LPAR with properties from z14.
+# The included properties are all standard properties (such as 'object-id'),
+# a subset of the modifiable properties, and a subset of the read-only
+# properties.
+# The 'ssc*'' properties that had been removed with z14 are not included.
+FAKED_LPAR_1_NAME = 'LPAR1'
+FAKED_LPAR_1_PROFILE = FAKED_LPAR_1_NAME
+FAKED_LPAR_1_OID = 'fake-lpar1'
+FAKED_LPAR_1_URI = '/api/logical-partitions/' + FAKED_LPAR_1_OID
+FAKED_LPAR_1_BASE = {
+    'object-id': FAKED_LPAR_1_OID,
+    'object-uri': FAKED_LPAR_1_URI,
+    'parent': FAKED_CPC_1_URI,
+    'class': 'logical-partition',
+    'name': FAKED_LPAR_1_NAME,
+    'description': 'Lpar #1',
+    'acceptable-status': ['operating'],
+    # Additional properties will be added by FAKED_LPAR_1_DELTA_*
+}
+FAKED_LPAR_1_DELTA_NOT_ACTIVATED = {
+    'activation-mode': 'not-set',
+    'additional-status': '',
+    'defined-capacity': None,
+    'has-operating-system-messages': None,
+    'has-unacceptable-status': True,
+    'is-locked': False,
+    'last-used-activation-profile': None,
+    'last-used-boot-record-logical-block-address': '0',
+    'last-used-disk-partition-id': 0,
+    'last-used-load-address': '00000',
+    'last-used-load-parameter': '',
+    'last-used-logical-unit-number': '0',
+    'last-used-operating-system-specific-load-parameters': '',
+    'last-used-world-wide-port-name': '0',
+    'next-activation-profile-name': FAKED_LPAR_1_PROFILE,
+    'os-ipl-token': None,
+    'os-level': None,
+    'os-name': None,
+    'os-type': None,
+    'partition-identifier': None,
+    'partition-number': None,
+    'status': 'not-activated',
+    'storage-central-allocation': [],
+    'storage-expanded-allocation': [],
+
+    # CPU related properties
+    'absolute-processing-capping': {'type': 'none'},
+    'initial-processing-weight': None,
+    'initial-processing-weight-capped': None,
+    'minimum-processing-weight': None,
+    'maximum-processing-weight': None,
+    'current-processing-weight': None,
+    'current-processing-weight-capped': None,
+}
+FAKED_LPAR_1_DELTA_OPERATING = {
+    'activation-mode': 'ssc',
+    'additional-status': '',
+    'defined-capacity': 0,
+    'has-operating-system-messages': True,
+    'has-unacceptable-status': False,
+    'is-locked': False,
+    'last-used-activation-profile': FAKED_LPAR_1_PROFILE,
+    'last-used-boot-record-logical-block-address': '0',
+    'last-used-disk-partition-id': 0,
+    'last-used-load-address': '00000',
+    'last-used-load-parameter': '',
+    'last-used-logical-unit-number': '0',
+    'last-used-operating-system-specific-load-parameters': '',
+    'last-used-world-wide-port-name': '0',
+    'next-activation-profile-name': FAKED_LPAR_1_PROFILE,
+    'os-ipl-token': '0000000000000000',
+    'os-level': '1.0.0',
+    'os-name': 'INSTALL',
+    'os-type': 'SSC',
+    'partition-identifier': '33',
+    'partition-number': '2f',
+    'status': 'operating',
+    'storage-central-allocation': [
+        {
+            'current': 8192,
+            'gap': 102400,
+            'initial': 8192,
+            'maximum': 8192,
+            'origin': 127322112,
+            'storage-element-type': 'central',
+        },
+    ],
+    'storage-expanded-allocation': [],
+
+    # CPU related properties
+    'absolute-processing-capping': {'type': 'none'},
+    'current-processing-weight': 10,
+    'current-processing-weight-capped': False,
+    'initial-processing-weight': 10,
+    'initial-processing-weight-capped': False,
+    'minimum-processing-weight': 0,
+    'maximum-processing-weight': 999,
+}
+
+# Translation table from 'state' module input parameter to the corresponding
+# desired LPAR 'status' property value.
+LPAR_STATUS_FROM_STATE = {
+    'inactive': 'not-activated',
+    'operating': 'operating',
+    'updated': None,  # Any
+    'facts': None,  # Any
+}
+
+
+def get_failure_msg(mod_obj):
+    """
+    Return the module failure message, as a string (i.e. the 'msg' argument
+    of the call to fail_json()).
+    If the module succeeded, return None.
+    """
+
+    def func(msg):
+        return msg
+
+    if not mod_obj.fail_json.called:
+        return None
+    call_args = mod_obj.fail_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])
+
+
+def get_module_output(mod_obj):
+    """
+    Return the module output as a tuple (changed, lpar_properties) (i.e.
+    the arguments of the call to exit_json()).
+    If the module failed, return None.
+    """
+
+    def func(changed, lpar):
+        return changed, lpar
+
+    if not mod_obj.exit_json.called:
+        return None
+    call_args = mod_obj.exit_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])
+
+
+class TestLpar(object):
+    """
+    All tests for LPARs.
+    """
+
+    def setup_method(self):
+        """
+        Using the zhmcclient mock support, set up a CPC in classic mode, that
+        has no LPARs.
+        """
+        self.session = FakedSession(**FAKED_SESSION_KWARGS)
+        self.client = Client(self.session)
+        self.console = self.session.hmc.consoles.add(FAKED_CONSOLE)
+        self.faked_cpc = self.session.hmc.cpcs.add(FAKED_CPC_1)
+        cpcs = self.client.cpcs.list()
+        assert len(cpcs) == 1
+        self.cpc = cpcs[0]
+        self.faked_crypto_adapters = []
+        self.faked_crypto_adapter_names = []
+
+    def setup_lpar(self, initial_state, additional_props=None):
+        """
+        Prepare the faked LPAR, on top of the CPC created by setup_method().
+        """
+        self.lpar_name = FAKED_LPAR_1_NAME
+        lpar_props = FAKED_LPAR_1_BASE.copy()
+        if initial_state == 'inactive':
+            lpar_props.update(FAKED_LPAR_1_DELTA_NOT_ACTIVATED)
+        elif initial_state == 'operating':
+            lpar_props.update(FAKED_LPAR_1_DELTA_OPERATING)
+        else:
+            raise AssertionError(
+                "Invalid initial_state={0!r}".format(initial_state))
+        if additional_props:
+            lpar_props.update(additional_props)
+        self.faked_lpar = self.faked_cpc.lpars.add(lpar_props)
+        lpars = self.cpc.lpars.list()
+        assert len(lpars) == 1
+        self.lpar = lpars[0]
+        self.lpar.pull_full_properties()
+
+    @pytest.mark.parametrize(
+        "check_mode", [False, True])
+    @pytest.mark.parametrize(
+        "initial_state", ['inactive', 'operating'])
+    @pytest.mark.parametrize(
+        "desired_state", ['inactive', 'operating', 'updated'])
+    @pytest.mark.parametrize(
+        "properties, props_changed", [
+            # Note: properties is a dict of property values, with the property
+            # names as keys (with underscores, as needed for the 'properties'
+            # Ansible module input parameter). If a dict value is a tuple, its
+            # first item is the input value, and its second item is the
+            # expected value. Otherwise, the dict value is both input value and
+            # expected value.
+
+            # Special cases:
+            ({}, False),
+
+            # All modifiable properties in the subset defined for LPAR_1
+            ({'acceptable_status': ['operating', 'exceptions']}, True),
+            # 'next_activation_profile_name' must be same as LPAR name
+            ({'defined_capacity': 1}, True),
+            ({'absolute_processing_capping': {'type': 'none'}}, False),
+            ({'initial_processing_weight': 50}, True),
+            ({'initial_processing_weight_capped': True}, True),
+            ({'minimum_processing_weight': 10}, True),
+            ({'maximum_processing_weight': 200}, True),
+        ])
+    @mock.patch("plugins.modules.zhmc_lpar.AnsibleModule", autospec=True)
+    def test_lpar_success(
+            self, ansible_mod_cls, properties, props_changed, desired_state,
+            initial_state, check_mode):
+        """
+        Tests for successful operations on LPAR, dependent on
+        parametrization. The fact gathering is not tested here.
+        """
+
+        # Prepare the initial LPAR before the test is run
+        self.setup_lpar(initial_state)
+
+        # Set some expectations for this test from its parametrization#
+        if initial_state == 'inactive' and desired_state == 'updated' \
+                and properties and props_changed:
+            exp_exit_code = 1
+        elif desired_state == 'inactive' and properties:
+            exp_exit_code = 1
+        else:
+            exp_exit_code = 0
+
+        if exp_exit_code == 0:
+
+            if check_mode:
+                exp_status = LPAR_STATUS_FROM_STATE[initial_state]
+            elif desired_state == 'updated':
+                exp_status = LPAR_STATUS_FROM_STATE[initial_state]
+            else:
+                exp_status = LPAR_STATUS_FROM_STATE[desired_state]
+
+            exp_lpar_returned = (desired_state in ('operating', 'updated'))
+
+            if desired_state != 'updated' and initial_state != desired_state:
+                exp_changed = True
+            elif properties and props_changed:
+                exp_changed = True
+            else:
+                exp_changed = False
+
+        input_props = {}
+        exp_props = {}
+        for prop_name in properties:
+            hmc_prop_name = prop_name.replace('_', '-')
+            value = properties[prop_name]
+            if isinstance(value, tuple):
+                assert len(value) == 2
+                input_props[prop_name] = value[0]
+                exp_props[hmc_prop_name] = value[1]
+            else:
+                input_props[prop_name] = value
+                exp_props[hmc_prop_name] = value
+
+        # Prepare module input parameters
+        params = {
+            'hmc_host': 'fake-host',
+            'hmc_auth': dict(userid='fake-userid',
+                             password='fake-password'),
+            'cpc_name': self.cpc.name,
+            'name': self.lpar_name,
+            'state': desired_state,
+            'activation_profile_name': None,  # TODO: Add to tests
+            'properties': input_props,
+            'log_file': None,
+            '_faked_session': self.session,
+        }
+
+        # Prepare mocks for AnsibleModule object
+        mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+        # Exercise the code to be tested
+        with pytest.raises(SystemExit) as exc_info:
+            zhmc_lpar.main()
+        exit_code = exc_info.value.args[0]
+
+        # Assert module exit code
+        assert exit_code == exp_exit_code, \
+            "Unexpected module exit code {0} (expected {1}), message:\n{2}". \
+            format(exit_code, exp_exit_code, get_failure_msg(mod_obj))
+
+        if exp_exit_code == 0:
+
+            # Assert module output
+            changed, lpar_props = get_module_output(mod_obj)
+            assert changed == exp_changed
+            if exp_lpar_returned:
+                assert lpar_props != {}
+                if not check_mode:
+                    assert lpar_props['status'] == exp_status
+                    assert lpar_props['name'] == params['name']
+                    if exp_props:
+                        for hmc_prop_name, exp_value in exp_props.items():
+                            assert lpar_props[hmc_prop_name] == exp_value, \
+                                "Property: {0}".format(hmc_prop_name)
+            else:
+                assert lpar_props == {}
+
+            # Assert the LPAR resource
+            if not check_mode:
+                lpars = self.cpc.lpars.list()
+                assert len(lpars) == 1
+                lpar = lpars[0]
+                lpar.pull_full_properties()
+                assert lpar.properties['status'] == exp_status
+                assert lpar.properties['name'] == params['name']
+                if properties:
+                    for hmc_prop_name, exp_value in exp_props.items():
+                        assert lpar.properties[hmc_prop_name] == exp_value, \
+                            "Property: {0}".format(hmc_prop_name)
+
+    @pytest.mark.parametrize(
+        "check_mode", [False, True])
+    @pytest.mark.parametrize(
+        "initial_state", ['inactive', 'operating'])
+    @pytest.mark.parametrize(
+        "desired_state", ['facts'])
+    @mock.patch("plugins.modules.zhmc_lpar.AnsibleModule",
+                autospec=True)
+    def test_lpar_facts_success(
+            self, ansible_mod_cls, desired_state, initial_state, check_mode):
+        """
+        Tests for successful fact gathering on LPARs, dependent on
+        parametrization.
+        """
+
+        # Prepare the initial LPAR before the test is run
+        self.setup_lpar(initial_state)
+
+        # Set some expectations for this test from its parametrization#
+        exp_exit_code = 0
+
+        # Prepare module input parameters
+        params = {
+            'hmc_host': 'fake-host',
+            'hmc_auth': dict(userid='fake-userid',
+                             password='fake-password'),
+            'cpc_name': self.cpc.name,
+            'name': self.lpar_name,
+            'state': desired_state,
+            'activation_profile_name': None,  # TODO: Add to tests
+            'log_file': None,
+            '_faked_session': self.session,
+        }
+
+        # Prepare mocks for AnsibleModule object
+        mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+        # Exercise the code to be tested
+        with pytest.raises(SystemExit) as exc_info:
+            zhmc_lpar.main()
+        exit_code = exc_info.value.args[0]
+
+        # Assert module exit code
+        assert exit_code == exp_exit_code, \
+            "Unexpected module exit code {0} (expected {1}), message:\n{2}". \
+            format(exit_code, exp_exit_code, get_failure_msg(mod_obj))
+
+        # Assert module output
+        changed, lpar_props = get_module_output(mod_obj)
+        assert changed is False
+        assert isinstance(lpar_props, dict)
+
+        for pname in lpar_props:
+            pvalue = lpar_props[pname]
+            exp_value = self.lpar.properties[pname]
+            assert pvalue == exp_value
+
+# TODO: Add tests for updating read-only properties

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -4,6 +4,7 @@ plugins/modules/zhmc_cpc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/zhmc_hba.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_nic.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_partition.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_group.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_group_attachment.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_volume.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
@@ -22,6 +23,7 @@ plugins/modules/zhmc_crypto_attachment.py validate-modules:return-syntax-error  
 plugins/modules/zhmc_hba.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_nic.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_partition.py validate-modules:return-syntax-error  # Missing type on generic {property}
+plugins/modules/zhmc_lpar.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_storage_group.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_storage_volume.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_user.py validate-modules:return-syntax-error  # Missing type on generic {property}

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -4,6 +4,7 @@ plugins/modules/zhmc_cpc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/zhmc_hba.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_nic.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_partition.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_group.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_group_attachment.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_volume.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
@@ -16,6 +17,7 @@ plugins/modules/zhmc_crypto_attachment.py validate-modules:return-syntax-error  
 plugins/modules/zhmc_hba.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_nic.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_partition.py validate-modules:return-syntax-error  # Missing type on generic {property}
+plugins/modules/zhmc_lpar.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_storage_group.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_storage_volume.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_user.py validate-modules:return-syntax-error  # Missing type on generic {property}

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -4,6 +4,7 @@ plugins/modules/zhmc_cpc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/zhmc_hba.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_nic.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_partition.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_group.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_group_attachment.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_volume.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
@@ -16,6 +17,7 @@ plugins/modules/zhmc_crypto_attachment.py validate-modules:return-syntax-error  
 plugins/modules/zhmc_hba.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_nic.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_partition.py validate-modules:return-syntax-error  # Missing type on generic {property}
+plugins/modules/zhmc_lpar.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_storage_group.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_storage_volume.py validate-modules:return-syntax-error  # Missing type on generic {property}
 plugins/modules/zhmc_user.py validate-modules:return-syntax-error  # Missing type on generic {property}

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -4,6 +4,7 @@ plugins/modules/zhmc_cpc.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/zhmc_hba.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_nic.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_partition.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_group.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_group_attachment.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_volume.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
@@ -39,6 +40,7 @@ plugins/modules/zhmc_crypto_attachment.py validate-modules:import-error # Was br
 plugins/modules/zhmc_hba.py validate-modules:import-error # Was broken in Ansible 2.9, fixed in 2.10 via PR 63932
 plugins/modules/zhmc_nic.py validate-modules:import-error # Was broken in Ansible 2.9, fixed in 2.10 via PR 63932
 plugins/modules/zhmc_partition.py validate-modules:import-error # Was broken in Ansible 2.9, fixed in 2.10 via PR 63932
+plugins/modules/zhmc_lpar.py validate-modules:import-error # Was broken in Ansible 2.9, fixed in 2.10 via PR 63932
 plugins/modules/zhmc_storage_group.py validate-modules:import-error # Was broken in Ansible 2.9, fixed in 2.10 via PR 63932
 plugins/modules/zhmc_storage_group_attachment.py validate-modules:import-error # Was broken in Ansible 2.9, fixed in 2.10 via PR 63932
 plugins/modules/zhmc_storage_volume.py validate-modules:import-error # Was broken in Ansible 2.9, fixed in 2.10 via PR 63932


### PR DESCRIPTION
For details, see commit message.

Particular review points are:
* the "state" values that are supported by the new zhmc_lpar module, and what they do. See their [description in the zhmc_lpar.py module](https://github.com/zhmcclient/zhmc-ansible-modules/blob/andy/lpar-module/plugins/modules/zhmc_lpar.py#L110).