### PR TITLE
Release 1.0.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ env:
 on:
   push:
     # PR merge to these branches triggers this workflow
-    branches: [ master, stable_0.10 ]
+    branches: [ master, stable_1.0 ]
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ on:
     - # cron (in UTC): minute hour day_of_month month day_of_week
       cron: '00 04 * * SUN'
   push:
-    branches: [ master, stable_0.10 ]
+    branches: [ master, stable_1.0 ]
   pull_request:
-    branches: [ master, stable_0.10 ]
+    branches: [ master, stable_1.0 ]
 
 jobs:
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -432,7 +432,7 @@ local clone of the zhmc-ansible-modules Git repo.
     and insert the following section before the top-most section, and update
     the version to a draft version of the version that is being started:
 
-    .. code-block:: rst
+    .. code-block:: text
 
         Version M.N.U-dev1
         ------------------
@@ -440,6 +440,8 @@ local clone of the zhmc-ansible-modules Git repo.
         This version contains all fixes up to version M.N-1.x.
 
         Released: not yet
+
+        Availability: `AnsibleHub`_, `Galaxy`_, `GitHub`_
 
         **Incompatible changes:**
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -20,16 +20,14 @@ Releases
 ========
 
 
-Version 1.0.0-dev1
-------------------
+Version 1.0.0
+-------------
 
-This version contains all fixes up to version 0.10.x.
+This version contains all fixes up to version 0.10.1.
 
-Released: not yet
+Released: 2022-04-08
 
-**Incompatible changes:**
-
-**Deprecations:**
+Availability: `AnsibleHub`_, `Galaxy`_, `GitHub`_
 
 **Bug fixes:**
 
@@ -65,14 +63,6 @@ Released: not yet
   for activating/starting and deactivating/stopping CPCs in their current
   operational mode. (issue #418)
 
-**Cleanup:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/zhmc-ansible-modules/issues
-
 
 Version 0.10.0
 --------------
@@ -80,6 +70,8 @@ Version 0.10.0
 This version contains all fixes up to version 0.9.2.
 
 Released: 2021-06-17
+
+Availability: `Galaxy`_, `GitHub`_
 
 **Incompatible changes:**
 
@@ -510,5 +502,7 @@ This is the initial release.
    https://github.com/zhmcclient/zhmc-ansible-modules/releases
 .. _Galaxy:
    https://galaxy.ansible.com/ibm/ibm_zhmc
+.. _AnsibleHub:
+   https://console.redhat.com/ansible/automation-hub/repo/published/ibm/ibm_zhmc
 .. _Pypi:
    https://pypi.org/project/zhmc-ansible-modules/

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@ namespace: ibm
 
 name: ibm_zhmc
 
-version: 1.0.0-dev1
+version: 1.0.0
 
 readme: README.md
 


### PR DESCRIPTION
Please approve the release of ibm_zhmc ansible collection 1.0.0 to Galaxy and AnsibleHub.

Link to change log: https://github.com/zhmcclient/zhmc-ansible-modules/blob/release_1.0.0/docs/source/release_notes.rst#version-100