### PR TITLE
1.1: zhmc_partition: Fixed check mode; fixed 'boot-storage-volume-name' in result

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -33,6 +33,22 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Bug fixes:**
 
+* In the zhmc_partition module, fixed that the artificial property
+  'boot-storage-volume-name' was not included in the result.
+  (related to issue #550)
+
+* In the zhmc_partition module, fixed the support for check mode and added
+  tests. (issue #550)
+
+* In the zhmc_partition module, added missing z14, z15 and z16 input properties:
+  'boot_storage_volume', 'boot_storage_volume_name', 'boot_load_parameters',
+  'permit_ecc_key_import_functions', 'ssc_ipv6_gateway', 'secure_boot',
+  'secure_execution', 'storage_group_uris', 'tape_link_uris',
+  'partition_link_uris', 'available_features_list'. (related to issue #550)
+
+* Test: Added missing z14 partition properties to the mock definition file
+  tests/end2end/mocked_hmc_z14.yaml. (related to issue #550)
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #557 into 1.1.2.

This PR was successfully end2end tested with test_zhmc_partition.py on: M12