### PR TITLE
1.2: Fixed sphinx-versions local fork to be PEP 440 compliant

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -119,7 +119,7 @@ ansible-doc-extractor>=0.1.8; python_version >= '3.6'
 sphinx-rtd-theme>=0.5.0; python_version >= '3.6'
 # Getting sphinx-versions from this git repo addresses some issues.
 # TODO: Remove getting sphinx-versions from this git repo.
-git+https://github.com/andy-maier/sphinx-versions.git@1.1.3.post-am2#egg=sphinx-versions; python_version >= '3.6'
+git+https://github.com/andy-maier/sphinx-versions.git@1.1.3.post2#egg=sphinx-versions; python_version >= '3.6'
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -37,6 +37,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Cleanup:**
 
+* Docs/dev: Changed sphinx-versions to use the PEP 440 compliant tag 1.1.3.post2
+  from our fork.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
Rolls back PR #618 into 1.2.2.