### PR TITLE
Docs: Added HMC setup and HMC userid reqs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -195,6 +195,60 @@ control system. The instructions are written for a bash shell.
         $ pip install -r $anco_dir/ibm/ibm_zhmc/requirements.txt
 
 
+.. _`Setting up the HMC`:
+
+Setting up the HMC
+------------------
+
+Usage of this collection requires that the HMC in question is prepared
+accordingly:
+
+* The Web Services API must be enabled on the HMC.
+
+  You can do that in the HMC GUI by selecting "HMC Management" in the left pane,
+  then opening the "Configure API Settings" icon on the pain pane,
+  then selecting the "Web Services" tab on the page that comes up, and
+  finally enabling the Web Services API on that page.
+
+  The above is on a z16 HMC, it may be different on older HMCs.
+
+  If you cannot find this icon, then your userid does not have permission
+  for the respective task on the HMC. In that case, there should be some
+  other HMC admin you can go to to get the Web Services API enabled.
+
+
+.. _`HMC userid requirements`:
+
+HMC userid requirements
+-----------------------
+
+The HMC userid used for running the modules of this collection must have the
+following task permissions:
+
+  * Use of the Web Services API
+
+The HMC userid used for running the modules of this collection must in
+addition have the permissions documented in the description of each module
+(see :ref:`Modules`). These descriptions document the complete set of
+permissions needed for all operations of the module.
+
+
+.. _`Setting up firewalls or proxies`:
+
+Setting up firewalls or proxies
+-------------------------------
+
+If you have to configure firewalls or proxies between the system where you
+run the ``zhmc_prometheus_exporter`` command and the HMC, the following ports
+need to be opened:
+
+* 6794 (TCP) - for the HMC API HTTP server
+* 61612 (TCP) - for the HMC API message broker via JMS over STOMP
+
+For details, see sections "Connecting to the API HTTP server" and
+"Connecting to the API message broker" in the :term:`HMC API` book.
+
+
 .. _`Supported environments`:
 
 Supported environments

--- a/docs/source/modules/zhmc_adapter.rst
+++ b/docs/source/modules/zhmc_adapter.rst
@@ -24,8 +24,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
 - The targeted Z system must be in the Dynamic Partition Manager (DPM) operational mode.
+- The HMC userid must have these task permissions: 'Adapter Details', 'Create HiperSockets Adapter', 'Delete HiperSockets Adapter', 'Configure Storage - System Programmer'.
+- The HMC userid must have object-access permissions to these objects: Target adapters, CPCs of target adapters.
 
 
 
@@ -86,7 +87,7 @@ name
 
 
 cpc_name
-  The name of the target CPC.
+  The name of the CPC with the target adapter.
 
   | **required**: True
   | **type**: str
@@ -219,6 +220,12 @@ Examples
 
 
 
+See Also
+--------
+
+.. seealso::
+
+   - :ref:`zhmc_adapter_list_module`
 
 
 

--- a/docs/source/modules/zhmc_adapter_list.rst
+++ b/docs/source/modules/zhmc_adapter_list.rst
@@ -24,7 +24,7 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC (see :term:`HMC API`).
+- The HMC userid must have object-access permissions to these objects: Target adapters, CPCs of target adapters (only for z13 and older).
 
 
 
@@ -166,6 +166,12 @@ Examples
 
 
 
+See Also
+--------
+
+.. seealso::
+
+   - :ref:`zhmc_adapter_module`
 
 
 

--- a/docs/source/modules/zhmc_cpc.rst
+++ b/docs/source/modules/zhmc_cpc.rst
@@ -16,8 +16,8 @@ zhmc_cpc -- Manage CPCs
 
 Synopsis
 --------
-- Deactivate a CPC (Z system).
-- Activate a CPC and update its properties.
+- Deactivate/Stop a CPC (Z system).
+- Activate/Start a CPC and update its properties.
 - Gather facts about a CPC, and for DPM operational mode, including its adapters, partitions and storage groups.
 - Update the properties of a CPC.
 
@@ -25,8 +25,8 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted CPC (see :term:`HMC API`).
-- The targeted CPC can be in any operational mode (classic, DPM).
+- The HMC userid must have these task permissions: 'CPC Details'. For CPCs in DMP mode: 'Start', 'Stop'. For CPCs in classic mode: 'Activate', 'Deactivate'.
+- The HMC userid must have object-access permissions to these objects: Target CPCs. For CPCs in DMP mode: Adapters, partitions, storage groups of target CPCs. For CPCs in classic mode: LPARs, activation profiles of target CPCs.
 
 
 

--- a/docs/source/modules/zhmc_cpc_list.rst
+++ b/docs/source/modules/zhmc_cpc_list.rst
@@ -22,7 +22,7 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC (see :term:`HMC API`).
+- The HMC userid must have object-access permissions to these objects: Target CPCs.
 
 
 

--- a/docs/source/modules/zhmc_crypto_attachment.rst
+++ b/docs/source/modules/zhmc_crypto_attachment.rst
@@ -24,8 +24,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
 - The targeted Z system must be in the Dynamic Partition Manager (DPM) operational mode.
+- The HMC userid must have these task permissions: 'Partition Details'.
+- The HMC userid must have object-access permissions to these objects: Target partitions, target crypto adapters, CPC with target partitions and adapters.
 
 
 

--- a/docs/source/modules/zhmc_hba.rst
+++ b/docs/source/modules/zhmc_hba.rst
@@ -23,8 +23,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
 - The targeted Z system must be a z13 generation and must be in the Dynamic Partition Manager (DPM) operational mode. The z14 and later generations in DPM mode manage HBAs automatically via the "dpm-storage-management" firmware feature.
+- The HMC userid must have these task permissions: 'Partition Details'.
+- The HMC userid must have object-access permissions to these objects: Partitions of the target HBAs, CPCs of these partitions, storage adapters backing the target HBAs.
 
 
 

--- a/docs/source/modules/zhmc_lpar.rst
+++ b/docs/source/modules/zhmc_lpar.rst
@@ -27,15 +27,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted CPC (see :term:`HMC API`).
 - The targeted CPC must be in the classic operational mode.
-- The HMC userid must have the following HMC permissions:
-- Object-access permission to the target LPAR and its parent CPC.
-- If the 'next-activation-profile-name' property is to be updated, task permission for the 'Change Object Options' task or the 'Customize/Delete Activation Profiles' task.
-- If any of the 'zaware-...' properties is to be updated, task permission for the 'Firmware Details' task.
-- If any of the numbers of allocated or reserved cores is is to be updated, task permission for the 'Logical Processor Add' task.
-- If the LPAR needs to be activated, task permission for the 'Activate' task.
-- If the LPAR needs to be deactivated, task permission for the 'Deactivate' task.
+- The HMC userid must have these task permissions: 'Activate', 'Deactivate', 'Logical Processor Add' (if cores are updated), 'Firmware Details' (if 'zaware-...' properties are updated), 'Change Object Options' or 'Customize/Delete Activation Profiles' (if 'next-activation-profile-name' property is updated).
+- The HMC userid must have object-access permissions to these objects: Target LPARs, CPCs of target LPARs.
 
 
 

--- a/docs/source/modules/zhmc_lpar_list.rst
+++ b/docs/source/modules/zhmc_lpar_list.rst
@@ -25,7 +25,7 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC (see :term:`HMC API`).
+- The HMC userid must have object-access permissions to these objects: Target LPArs, CPCs of target LPARs (only for z13 and older).
 
 
 

--- a/docs/source/modules/zhmc_nic.rst
+++ b/docs/source/modules/zhmc_nic.rst
@@ -23,8 +23,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
 - The targeted Z system must be in the Dynamic Partition Manager (DPM) operational mode.
+- The HMC userid must have these task permissions: 'Partition Details'.
+- The HMC userid must have object-access permissions to these objects: Partitions of the target NICs, CPCs of these partitions, network adapters backing the target NICs.
 
 
 

--- a/docs/source/modules/zhmc_partition.rst
+++ b/docs/source/modules/zhmc_partition.rst
@@ -16,7 +16,7 @@ zhmc_partition -- Create partitions
 
 Synopsis
 --------
-- Gather facts about a partition of a CPC (Z system), including its HBAs, NICs, and virtual functions.
+- Gather facts about a partition of a CPC (Z system), including its HBAs, NICs, virtual functions, and crypto configuration including crypto adapters.
 - Create, update, or delete a partition. The HBAs, NICs, and virtual functions of the partition are managed by separate Ansible modules.
 - Start or stop a partition.
 
@@ -24,8 +24,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
 - The targeted Z system must be in the Dynamic Partition Manager (DPM) operational mode.
+- The HMC userid must have these task permissions: 'New Partition', 'Delete Partition', 'Partition Details', 'Start Partition', 'Stop Partition', 'Dump Partition', 'PSW Restart'.
+- The HMC userid must have object-access permissions to these objects: Target partitions, CPCs of target partitions, Crypto adapters of target partitions.
 
 
 
@@ -251,6 +252,7 @@ See Also
 
 .. seealso::
 
+   - :ref:`zhmc_partition_list_module`
    - :ref:`zhmc_hba_module`
    - :ref:`zhmc_nic_module`
    - :ref:`zhmc_virtual_function_module`

--- a/docs/source/modules/zhmc_partition_list.rst
+++ b/docs/source/modules/zhmc_partition_list.rst
@@ -25,7 +25,7 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC (see :term:`HMC API`).
+- The HMC userid must have object-access permissions to these objects: Target partitions, CPCs of target partitions (only for z13 and older).
 
 
 
@@ -124,6 +124,12 @@ Examples
 
 
 
+See Also
+--------
+
+.. seealso::
+
+   - :ref:`zhmc_partition_module`
 
 
 

--- a/docs/source/modules/zhmc_password_rule.rst
+++ b/docs/source/modules/zhmc_password_rule.rst
@@ -23,8 +23,7 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
-- The targeted Z system can be in any operational mode (classic, DPM)
+- The HMC userid must have these task permissions: 'Manage Password Rules'.
 
 
 

--- a/docs/source/modules/zhmc_password_rule_list.rst
+++ b/docs/source/modules/zhmc_password_rule_list.rst
@@ -22,7 +22,7 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC (see :term:`HMC API`).
+- The HMC userid must have object-access permission to the target password rules, or task permission to the 'Manage Password Rules' task.
 
 
 

--- a/docs/source/modules/zhmc_storage_group.rst
+++ b/docs/source/modules/zhmc_storage_group.rst
@@ -23,8 +23,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
 - The targeted Z system must be of generation z14 or later (to have the "dpm-storage-management" firmware feature) and must be in the Dynamic Partition Manager (DPM) operational mode.
+- The HMC userid must have these task permissions: 'Configure Storage - System Programmer'.
+- The HMC userid must have object-access permissions to these objects: Target storage groups, target CPCs, target storage adapters.
 
 
 

--- a/docs/source/modules/zhmc_storage_group_attachment.rst
+++ b/docs/source/modules/zhmc_storage_group_attachment.rst
@@ -23,8 +23,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
 - The targeted Z system must be of generation z14 or later (to have the "dpm-storage-management" firmware feature) and must be in the Dynamic Partition Manager (DPM) operational mode.
+- The HMC userid must have these task permissions: 'Configure Storage - System Programmer', 'Partition Details'.
+- The HMC userid must have object-access permissions to these objects: Target partitions, target storage groups, target CPCs.
 
 
 

--- a/docs/source/modules/zhmc_storage_volume.rst
+++ b/docs/source/modules/zhmc_storage_volume.rst
@@ -23,8 +23,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
 - The targeted Z system must be of generation z14 or later (to have the "dpm-storage-management" firmware feature) and must be in the Dynamic Partition Manager (DPM) operational mode.
+- The HMC userid must have these task permissions: 'Configure Storage - System Programmer'.
+- The HMC userid must have object-access permissions to these objects: Target storage groups.
 
 
 

--- a/docs/source/modules/zhmc_user.rst
+++ b/docs/source/modules/zhmc_user.rst
@@ -23,8 +23,8 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
-- The targeted Z system can be in any operational mode (classic, DPM)
+- The HMC userid must have these task permissions: 'Manage Users' (for standard users), 'Manage User Templates' (for template users).
+- For updating its own HMC password, it is sufficient if the HMC userid has task permission for Manage Users or object-access permission for its own User object.
 
 
 

--- a/docs/source/modules/zhmc_user_role.rst
+++ b/docs/source/modules/zhmc_user_role.rst
@@ -23,8 +23,7 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
-- The targeted Z system can be in any operational mode (classic, DPM)
+- The HMC userid must have these task permissions: 'Manage User Roles'.
 
 
 

--- a/docs/source/modules/zhmc_user_role_list.rst
+++ b/docs/source/modules/zhmc_user_role_list.rst
@@ -22,7 +22,7 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC (see :term:`HMC API`).
+- The HMC userid must have object-access permission to the target user roles, or task permission to the 'Manage User Roles' task.
 
 
 

--- a/docs/source/modules/zhmc_virtual_function.rst
+++ b/docs/source/modules/zhmc_virtual_function.rst
@@ -23,8 +23,9 @@ Synopsis
 Requirements
 ------------
 
-- Access to the WS API of the HMC of the targeted Z system (see :term:`HMC API`).
 - The targeted Z system must be in the Dynamic Partition Manager (DPM) operational mode.
+- The HMC userid must have these task permissions: 'Partition Details'.
+- The HMC userid must have object-access permissions to these objects: Backing accelerator adapters of the target virtual functions, partitions of the target virtual functions, CPCs of these partitions.
 
 
 

--- a/plugins/modules/zhmc_adapter.py
+++ b/plugins/modules/zhmc_adapter.py
@@ -37,14 +37,19 @@ description:
   - Gather facts about an adapter of a CPC (Z system), including its ports.
   - Update the properties of an adapter and its ports.
   - Create or delete a Hipersocket adapter.
+seealso:
+  - module: zhmc_adapter_list
 author:
   - Andreas Maier (@andy-maier)
   - Andreas Scheuring (@scheuran)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
   - The targeted Z system must be in the Dynamic Partition Manager (DPM)
     operational mode.
+  - "The HMC userid must have these task permissions:
+    'Adapter Details', 'Create HiperSockets Adapter',
+    'Delete HiperSockets Adapter', 'Configure Storage - System Programmer'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Target adapters, CPCs of target adapters."
 options:
   hmc_host:
     description:
@@ -95,7 +100,7 @@ options:
     required: true
   cpc_name:
     description:
-      - The name of the target CPC.
+      - The name of the CPC with the target adapter.
     type: str
     required: true
   match:

--- a/plugins/modules/zhmc_adapter_list.py
+++ b/plugins/modules/zhmc_adapter_list.py
@@ -42,10 +42,13 @@ description:
   - CPCs in classic mode are ignored (i.e. do not lead to a failure).
   - Adapters for which the user has no object access permission are ignored
     (i.e. do not lead to a failure).
+seealso:
+  - module: zhmc_adapter
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC (see :term:`HMC API`).
+  - "The HMC userid must have object-access permissions to these objects:
+    Target adapters, CPCs of target adapters (only for z13 and older)."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_cpc.py
+++ b/plugins/modules/zhmc_cpc.py
@@ -34,8 +34,8 @@ module: zhmc_cpc
 version_added: "2.9.0"
 short_description: Manage CPCs
 description:
-  - Deactivate a CPC (Z system).
-  - Activate a CPC and update its properties.
+  - Deactivate/Stop a CPC (Z system).
+  - Activate/Start a CPC and update its properties.
   - Gather facts about a CPC, and for DPM operational mode, including its
     adapters, partitions and storage groups.
   - Update the properties of a CPC.
@@ -43,8 +43,13 @@ author:
   - Andreas Maier (@andy-maier)
   - Andreas Scheuring (@scheuran)
 requirements:
-  - Access to the WS API of the HMC of the targeted CPC (see :term:`HMC API`).
-  - The targeted CPC can be in any operational mode (classic, DPM).
+  - "The HMC userid must have these task permissions:
+    'CPC Details'. For CPCs in DMP mode: 'Start', 'Stop'. For CPCs in classic
+    mode: 'Activate', 'Deactivate'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Target CPCs. For CPCs in DMP mode: Adapters, partitions, storage groups of
+    target CPCs. For CPCs in classic mode: LPARs, activation profiles of
+    target CPCs."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_cpc_list.py
+++ b/plugins/modules/zhmc_cpc_list.py
@@ -39,7 +39,8 @@ description:
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC (see :term:`HMC API`).
+  - "The HMC userid must have object-access permissions to these objects:
+    Target CPCs."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_crypto_attachment.py
+++ b/plugins/modules/zhmc_crypto_attachment.py
@@ -43,10 +43,13 @@ author:
   - Andreas Maier (@andy-maier)
   - Andreas Scheuring (@scheuran)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
   - The targeted Z system must be in the Dynamic Partition Manager (DPM)
     operational mode.
+  - "The HMC userid must have these task permissions:
+    'Partition Details'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Target partitions, target crypto adapters, CPC with target partitions and
+    adapters."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_hba.py
+++ b/plugins/modules/zhmc_hba.py
@@ -43,12 +43,15 @@ author:
   - Andreas Scheuring (@scheuran)
   - Juergen Leopold (@leopoldjuergen)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
   - The targeted Z system must be a z13 generation and must be in the Dynamic
     Partition Manager (DPM) operational mode. The z14 and later generations
     in DPM mode manage HBAs automatically via the "dpm-storage-management"
     firmware feature.
+  - "The HMC userid must have these task permissions:
+    'Partition Details'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Partitions of the target HBAs, CPCs of these partitions, storage adapters
+    backing the target HBAs."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_lpar.py
+++ b/plugins/modules/zhmc_lpar.py
@@ -43,20 +43,14 @@ description:
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC of the targeted CPC (see :term:`HMC API`).
   - The targeted CPC must be in the classic operational mode.
-  - "The HMC userid must have the following HMC permissions:"
-  - Object-access permission to the target LPAR and its parent CPC.
-  - If the 'next-activation-profile-name' property is to be updated, task
-    permission for the 'Change Object Options' task or the 'Customize/Delete
-    Activation Profiles' task.
-  - If any of the 'zaware-...' properties is to be updated, task permission for
-    the 'Firmware Details' task.
-  - If any of the numbers of allocated or reserved cores is is to be updated,
-    task permission for the 'Logical Processor Add' task.
-  - If the LPAR needs to be activated, task permission for the 'Activate' task.
-  - If the LPAR needs to be deactivated, task permission for the 'Deactivate'
-    task.
+  - "The HMC userid must have these task permissions:
+    'Activate', 'Deactivate', 'Logical Processor Add' (if cores are updated),
+    'Firmware Details' (if 'zaware-...' properties are updated),
+    'Change Object Options' or 'Customize/Delete Activation Profiles' (if
+    'next-activation-profile-name' property is updated)."
+  - "The HMC userid must have object-access permissions to these objects:
+    Target LPARs, CPCs of target LPARs."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_lpar_list.py
+++ b/plugins/modules/zhmc_lpar_list.py
@@ -44,7 +44,8 @@ description:
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC (see :term:`HMC API`).
+  - "The HMC userid must have object-access permissions to these objects:
+    Target LPArs, CPCs of target LPARs (only for z13 and older)."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_nic.py
+++ b/plugins/modules/zhmc_nic.py
@@ -43,10 +43,13 @@ author:
   - Andreas Scheuring (@scheuran)
   - Juergen Leopold (@leopoldjuergen)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
   - The targeted Z system must be in the Dynamic Partition Manager (DPM)
     operational mode.
+  - "The HMC userid must have these task permissions:
+    'Partition Details'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Partitions of the target NICs, CPCs of these partitions, network adapters
+    backing the target NICs."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -35,11 +35,13 @@ version_added: "2.9.0"
 short_description: Create partitions
 description:
   - Gather facts about a partition of a CPC (Z system), including its HBAs,
-    NICs, and virtual functions.
+    NICs, virtual functions, and crypto configuration including crypto
+    adapters.
   - Create, update, or delete a partition. The HBAs, NICs, and virtual
    functions of the partition are managed by separate Ansible modules.
   - Start or stop a partition.
 seealso:
+  - module: zhmc_partition_list
   - module: zhmc_hba
   - module: zhmc_nic
   - module: zhmc_virtual_function
@@ -48,10 +50,14 @@ author:
   - Andreas Scheuring (@scheuran)
   - Juergen Leopold (@leopoldjuergen)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
   - The targeted Z system must be in the Dynamic Partition Manager (DPM)
     operational mode.
+  - "The HMC userid must have these task permissions:
+    'New Partition', 'Delete Partition', 'Partition Details',
+    'Start Partition', 'Stop Partition', 'Dump Partition', 'PSW Restart'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Target partitions, CPCs of target partitions, Crypto adapters of target
+    partitions."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_partition_list.py
+++ b/plugins/modules/zhmc_partition_list.py
@@ -41,10 +41,13 @@ description:
   - The module works for any HMC version. On HMCs with version 2.14.0 or higher,
     the "List Permitted Partitions" opration is used. On older HMCs, the
     managed CPCs are listed and the partitions on each CPC.
+seealso:
+  - module: zhmc_partition
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC (see :term:`HMC API`).
+  - "The HMC userid must have object-access permissions to these objects:
+    Target partitions, CPCs of target partitions (only for z13 and older)."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_password_rule.py
+++ b/plugins/modules/zhmc_password_rule.py
@@ -39,9 +39,8 @@ description:
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
-  - The targeted Z system can be in any operational mode (classic, DPM)
+  - "The HMC userid must have these task permissions:
+    'Manage Password Rules'."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_password_rule_list.py
+++ b/plugins/modules/zhmc_password_rule_list.py
@@ -38,7 +38,8 @@ description:
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC (see :term:`HMC API`).
+  - "The HMC userid must have object-access permission to the target password
+    rules, or task permission to the 'Manage Password Rules' task."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_storage_group.py
+++ b/plugins/modules/zhmc_storage_group.py
@@ -48,11 +48,13 @@ author:
   - Andreas Scheuring (@scheuran)
   - Juergen Leopold (@leopoldjuergen)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
   - The targeted Z system must be of generation z14 or later (to have the
     "dpm-storage-management" firmware feature) and must be in the Dynamic
     Partition Manager (DPM) operational mode.
+  - "The HMC userid must have these task permissions:
+    'Configure Storage - System Programmer'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Target storage groups, target CPCs, target storage adapters."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_storage_group_attachment.py
+++ b/plugins/modules/zhmc_storage_group_attachment.py
@@ -46,11 +46,13 @@ author:
   - Andreas Scheuring (@scheuran)
   - Juergen Leopold (@leopoldjuergen)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
   - The targeted Z system must be of generation z14 or later (to have the
     "dpm-storage-management" firmware feature) and must be in the Dynamic
     Partition Manager (DPM) operational mode.
+  - "The HMC userid must have these task permissions:
+    'Configure Storage - System Programmer', 'Partition Details'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Target partitions, target storage groups, target CPCs."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_storage_volume.py
+++ b/plugins/modules/zhmc_storage_volume.py
@@ -47,11 +47,13 @@ author:
   - Andreas Scheuring (@scheuran)
   - Juergen Leopold (@leopoldjuergen)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
   - The targeted Z system must be of generation z14 or later (to have the
     "dpm-storage-management" firmware feature) and must be in the Dynamic
     Partition Manager (DPM) operational mode.
+  - "The HMC userid must have these task permissions:
+    'Configure Storage - System Programmer'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Target storage groups."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_user.py
+++ b/plugins/modules/zhmc_user.py
@@ -39,9 +39,12 @@ description:
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
-  - The targeted Z system can be in any operational mode (classic, DPM)
+  - "The HMC userid must have these task permissions:
+    'Manage Users' (for standard users), 'Manage User Templates' (for template
+    users)."
+  - "For updating its own HMC password, it is sufficient if the HMC userid has
+    task permission for Manage Users or object-access permission for its own
+    User object."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_user_role.py
+++ b/plugins/modules/zhmc_user_role.py
@@ -39,9 +39,8 @@ description:
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
-  - The targeted Z system can be in any operational mode (classic, DPM)
+  - "The HMC userid must have these task permissions:
+    'Manage User Roles'."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_user_role_list.py
+++ b/plugins/modules/zhmc_user_role_list.py
@@ -38,7 +38,8 @@ description:
 author:
   - Andreas Maier (@andy-maier)
 requirements:
-  - Access to the WS API of the HMC (see :term:`HMC API`).
+  - "The HMC userid must have object-access permission to the target user
+    roles, or task permission to the 'Manage User Roles' task."
 options:
   hmc_host:
     description:

--- a/plugins/modules/zhmc_virtual_function.py
+++ b/plugins/modules/zhmc_virtual_function.py
@@ -43,10 +43,13 @@ author:
   - Andreas Scheuring (@scheuran)
   - Juergen Leopold (@leopoldjuergen)
 requirements:
-  - Access to the WS API of the HMC of the targeted Z system
-    (see :term:`HMC API`).
   - The targeted Z system must be in the Dynamic Partition Manager (DPM)
     operational mode.
+  - "The HMC userid must have these task permissions:
+    'Partition Details'."
+  - "The HMC userid must have object-access permissions to these objects:
+    Backing accelerator adapters of the target virtual functions, partitions
+    of the target virtual functions, CPCs of these partitions."
 options:
   hmc_host:
     description:


### PR DESCRIPTION
For details, see the commit message.

Notes for reviewers:
* Note that the .rst files for the zhmc_* modules are generated, so make your comments on the source of the information which is in the .py source files.
* It would be good to double check the module-specific task and object-access permissions.