### PR TITLE
Fixed bug when displaying end2end test details

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -35,6 +35,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Bug fixes:**
 
+* Test: Fixed a bug when displaying details on failed end2end testcases in
+  test_zhmc_password_rule.py and test_zhmc_user.py.
+
 **Enhancements:**
 
 * Dev: Added package dependency checking for the remaining Python-based tools

--- a/tests/end2end/test_zhmc_password_rule.py
+++ b/tests/end2end/test_zhmc_password_rule.py
@@ -337,9 +337,9 @@ def test_zhmc_password_rule_absent_present(
                 "Module input properties:\n{3}\n"
                 "Resulting password rule properties:\n{4}".
                 format(changed, exp_changed,
-                       pformat(pwrule_props_sorted.items(), indent=2),
-                       pformat(input_props_sorted.items(), indent=2),
-                       pformat(output_props_sorted.items(), indent=2)))
+                       pformat(pwrule_props_sorted, indent=2),
+                       pformat(input_props_sorted, indent=2),
+                       pformat(output_props_sorted, indent=2)))
         if input_state == 'present':
             assert_pwrule_props(output_props, where)
 

--- a/tests/end2end/test_zhmc_user.py
+++ b/tests/end2end/test_zhmc_user.py
@@ -485,9 +485,9 @@ def test_zhmc_user_absent_present(
                 "Module input properties:\n{3}\n"
                 "Resulting user properties:\n{4}".
                 format(changed, exp_changed,
-                       pformat(user_props_sorted.items(), indent=2),
-                       pformat(input_props_sorted.items(), indent=2),
-                       pformat(output_props_sorted.items(), indent=2)))
+                       pformat(user_props_sorted, indent=2),
+                       pformat(input_props_sorted, indent=2),
+                       pformat(output_props_sorted, indent=2)))
         if input_state == 'present':
             assert_user_props(output_props, expand, where)
 


### PR DESCRIPTION
For details, see the commit message.
No review needed.