### PR TITLE
Circumvented removal of Python 2.7 support in setup-python action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,17 +88,20 @@ jobs:
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"2.7\", \
-                \"package_level\": \"minimum\" \
+                \"package_level\": \"minimum\", \
+                \"container\": {\"image\": \"python:2.7.18-buster\"} \
               }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"2.7\", \
-                \"package_level\": \"latest\" \
+                \"package_level\": \"latest\", \
+                \"container\": {\"image\": \"python:2.7.18-buster\"} \
               }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"2.7\", \
-                \"package_level\": \"ansible\" \
+                \"package_level\": \"ansible\", \
+                \"container\": {\"image\": \"python:2.7.18-buster\"} \
               }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
@@ -141,12 +144,14 @@ jobs:
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"2.7\", \
-                \"package_level\": \"minimum\" \
+                \"package_level\": \"minimum\", \
+                \"container\": {\"image\": \"python:2.7.18-buster\"} \
               }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"2.7\", \
-                \"package_level\": \"latest\" \
+                \"package_level\": \"latest\", \
+                \"container\": {\"image\": \"python:2.7.18-buster\"} \
               }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
@@ -211,6 +216,7 @@ jobs:
       max-parallel: 20
       matrix: ${{ fromJson(needs.set_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
       PIP_NO_PYTHON_VERSION_WARNING: 1
@@ -220,6 +226,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
+      if: ${{ ! ( matrix.python-version == '2.7' ) }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -43,6 +43,11 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Test: Fixed a bug when displaying details on failed end2end testcases in
   test_zhmc_password_rule.py and test_zhmc_user.py.
 
+* Circumvented the removal of Python 2.7 from the Github Actions plugin
+  setup-python, by using the Docker container python:2.7.18-buster instead,
+  and by adjusting the os_setup.sh script to accomodate the absence of sudo
+  in that container.
+
 **Enhancements:**
 
 * Dev: Added package dependency checking for the remaining Python-based tools

--- a/tools/os_setup.sh
+++ b/tools/os_setup.sh
@@ -51,8 +51,19 @@ if [[ -n $(command -v yum 2>/dev/null) ]]; then
   sudo yum makecache fast
   sudo yum -y install libffi-devel
 elif [[ -n $(command -v apt-get 2>/dev/null) ]]; then
-  sudo apt-get --quiet update
-  sudo apt-get --yes install libffi-dev
+  # Note: The python:2.7.18-buster Docker container has no sudo
+  apt -qq list libffi-dev
+  if [[ "$(apt -qq list libffi-dev)" != *"installed"* ]]; then
+    if which sudo >/dev/null; then
+      echo "Installing libffi-dev package"
+      sudo apt-get --quiet update
+      sudo apt-get --yes install libffi-dev
+    else
+      echo "Warning: Not installing libffi-dev package due to missing sudo"
+    fi
+  else
+    echo "libffi-dev package is already installed"
+  fi
 elif [[ -n $(command -v choco 2>/dev/null) ]]; then
   echo "Nothing to install for platform $platform"
 else


### PR DESCRIPTION
The setup-python actions module removed Python 2.7, see https://github.com/actions/setup-python/issues/672
This PR circumvents that by using Python 2.7 from a Docker container, instead.
No review needed.