### PR TITLE
Test: Changed identification of adapters in end2end test to use PCHID

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -49,6 +49,11 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Cleanup:**
 
+* Test: Changed identification of adapters in end2end test module
+  test_zhmc_adapter_list.py to be based on adapter IDs (PCHIDs) instead of
+  adapter names to accomodate a system on the test floor that currently has
+  that bug.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
For details, see the commit message.

I ran `TESTCASES=test_zhmc_adapter_list TESTHMC=A224 make end2end` against the HMC of the A224 system that previously failed the test (STG defect 1070648), and it now passes.