### PR TITLE
1.6: Test: Changed identification of adapters in end2end test to use PCHID

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -41,6 +41,11 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Cleanup:**
 
+* Test: Changed identification of adapters in end2end test module
+  test_zhmc_adapter_list.py to be based on adapter IDs (PCHIDs) instead of
+  adapter names to accomodate a system on the test floor that currently has
+  that bug.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
Rolls back PR #739 into 1.6.1.