### PR TITLE
1.6: Bump cryptography from 41.0.3 to 41.0.4 for Python>=3.7

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -138,7 +138,7 @@ MarkupSafe==2.0.0; python_version >= '3.9'   # ansible >= 6
 cryptography==3.3.2; python_version == '2.7'
 cryptography==3.0; python_version == '3.5'
 cryptography==3.4.7; python_version == '3.6'
-cryptography==41.0.3; python_version >= '3.7'
+cryptography==41.0.4; python_version >= '3.7'
 
 importlib-metadata==0.12; python_version <= '3.7'
 importlib-metadata==1.1.0; python_version >= '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ MarkupSafe>=2.0.0; python_version >= '3.9'   # ansible >= 6
 cryptography>=3.3.2; python_version == '2.7'
 cryptography>=3.0,<3.1; python_version == '3.5'
 cryptography>=3.4.7,<37.0.0; python_version == '3.6'
-cryptography>=41.0.3; python_version >= '3.7'
+cryptography>=41.0.4; python_version >= '3.7'
 
 # importlib-metadata is used by jsonschema which is used by zhmcclient
 importlib-metadata>=0.12,<5.0.0; python_version <= '3.7'


### PR DESCRIPTION
Rolls back PR #761 into 1.6.1.