### PR TITLE
1.6: Moved 'make safety' to the end of the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,11 +247,6 @@ jobs:
       run: |
         echo "Package dependency tree of installed Python packages:"
         pipdeptree --all
-    - name: Run safety
-      env:
-        PACKAGE_LEVEL: ${{ matrix.package_level }}
-      run: |
-        make safety
     - name: Run check_reqs
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
@@ -300,6 +295,11 @@ jobs:
         COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
       run: |
         coveralls
+    - name: Run safety
+      env:
+        PACKAGE_LEVEL: ${{ matrix.package_level }}
+      run: |
+        make safety
 
   test_finish:
     needs: test


### PR DESCRIPTION
Rolls back PR #770 into 1.6.1.