### PR TITLE
1.7: Fixed that 'name' property was missing in result of 'zhmc_nic_list'

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -35,6 +35,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Fixed link to Ansible Galaxy on README page. (issue #785)
 
+* Fixed that the 'name' property was missing in result of the 'zhmc_nic_list'
+  module.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/plugins/modules/zhmc_nic_list.py
+++ b/plugins/modules/zhmc_nic_list.py
@@ -236,7 +236,8 @@ def perform_list(params):
         # The default exception handling is sufficient for the above.
 
         LOGGER.debug("Listing NICs of partition %s", partition.name)
-        nics = partition.nics.list(full_properties=full_properties)
+        # We need to specify full_properties in order to get 'name'
+        nics = partition.nics.list(full_properties=True)
 
         nic_list = []
         for nic in nics:
@@ -244,10 +245,12 @@ def perform_list(params):
             nic_properties = {
                 "partition_name": partition_name,
                 "cpc_name": cpc_name,
+                "name": nic.name,
             }
-            for pname_hmc, pvalue in nic.properties.items():
-                pname = pname_hmc.replace('-', '_')
-                nic_properties[pname] = pvalue
+            if full_properties:
+                for pname_hmc, pvalue in nic.properties.items():
+                    pname = pname_hmc.replace('-', '_')
+                    nic_properties[pname] = pvalue
 
             nic_list.append(nic_properties)
 


### PR DESCRIPTION
Rolls back PR #791 into 1.7.1.