### PR TITLE
1.7: Fixed missing 'operating-mode' in Image Profile setup for mocked LPAR fct tests

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -106,6 +106,8 @@ security:
             reason: Fixed gitpython version 3.1.33 requires Python>=3.7 and is used there
         60841:
             reason: Fixed gitpython version 3.1.35 requires Python>=3.7 and is used there
+        61601:
+            reason: Fixed urllib3 version 1.26.17 requires Python>=3.6 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -148,7 +148,9 @@ PyYAML==5.3.1
 
 python-dateutil==2.8.2
 jsonschema==3.0.1
-urllib3==1.26.17
+urllib3==1.26.17; python_version == '2.7'
+urllib3==1.26.9; python_version == '3.5'
+urllib3==1.26.17; python_version >= '3.6'
 
 
 # Direct dependencies for development (must be consistent with dev-requirements.txt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,4 +84,7 @@ PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
 
 python-dateutil>=2.8.2
 jsonschema>=3.0.1,!=4.0.0,!=4.18.1
-urllib3>=1.26.17
+# urllib3 1.26.10 removed support for py35
+urllib3>=1.26.17; python_version == '2.7'
+urllib3>=1.26.9; python_version == '3.5'
+urllib3>=1.26.17; python_version >= '3.6'

--- a/tests/function/test_func_lpar.py
+++ b/tests/function/test_func_lpar.py
@@ -234,6 +234,7 @@ FAKED_IMAGRPROFILE_1_PROPS = {
     'ipl-parameter': '',
     'ipl-type': 'ipltype-standard',
     'load-at-activation': False,
+    'operating-mode': 'general',
 }
 
 


### PR DESCRIPTION
Rolls back PR #817 into 1.7.2.