### PR TITLE
Support for retrieving OS messages from LPARs and DPM partitions 

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -37,7 +37,6 @@ colorama>=0.4.0; python_version >= '3.5'
 # mock>=2.0.0
 # requests>=2.20.1
 requests-mock>=1.6.0
-pytz>=2016.10
 
 # Unit test (indirect dependencies):
 # Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -72,6 +72,7 @@ Modules supported only with CPCs in DPM operational mode:
    modules/zhmc_nic_list
    modules/zhmc_partition
    modules/zhmc_partition_list
+   modules/zhmc_partition_messages
    modules/zhmc_storage_group
    modules/zhmc_storage_group_attachment
    modules/zhmc_storage_volume
@@ -85,6 +86,7 @@ Modules supported only with CPCs in classic operational mode:
 
    modules/zhmc_lpar
    modules/zhmc_lpar_list
+   modules/zhmc_lpar_messages
 
 You can also access the documentation of each module from the command line by
 using the `ansible-doc`_ command, for example:

--- a/docs/source/modules/zhmc_lpar_messages.rst
+++ b/docs/source/modules/zhmc_lpar_messages.rst
@@ -1,0 +1,289 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_core/blob/dev/plugins/modules/zhmc_lpar_messages.py
+
+.. _zhmc_lpar_messages_module:
+
+
+zhmc_lpar_messages -- Get console messages for OS in an LPAR
+============================================================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Get the OS console messages for the OS running in a loaded LPAR.
+
+
+Requirements
+------------
+
+- The targeted CPC must be in the classic operational mode.
+- The targeted LPAR must be loaded (i.e. running an operating system).
+- The HMC userid must have these task permissions: 'Operating System Messages' (view-only is sufficient)
+- The HMC userid must have object-access permissions to these objects: Target CPC, target LPAR.
+
+
+
+
+Parameters
+----------
+
+
+hmc_host
+  The hostname or IP address of the HMC.
+
+  | **required**: True
+  | **type**: str
+
+
+hmc_auth
+  The authentication credentials for the HMC.
+
+  | **required**: True
+  | **type**: dict
+
+
+  userid
+    The userid (username) for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  password
+    The password for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  session_id
+    HMC session ID to be used. This is mutually exclusive with providing \ :literal:`userid`\  and \ :literal:`password`\  and can be created as described in :ref:\`zhmc\_session\_module\`.
+
+    | **required**: False
+    | **type**: str
+
+
+  ca_certs
+    Path name of certificate file or certificate directory to be used for verifying the HMC certificate. If null (default), the path name in the 'REQUESTS\_CA\_BUNDLE' environment variable or the path name in the 'CURL\_CA\_BUNDLE' environment variable is used, or if neither of these variables is set, the certificates in the Mozilla CA Certificate List provided by the 'certifi' Python package are used for verifying the HMC certificate.
+
+    | **required**: False
+    | **type**: str
+
+
+  verify
+    If True (default), verify the HMC certificate as specified in the \ :literal:`ca\_certs`\  parameter. If False, ignore what is specified in the \ :literal:`ca\_certs`\  parameter and do not verify the HMC certificate.
+
+    | **required**: False
+    | **type**: bool
+    | **default**: True
+
+
+
+cpc_name
+  The name of the CPC with the target LPAR.
+
+  | **required**: True
+  | **type**: str
+
+
+name
+  The name of the target LPAR.
+
+  | **required**: True
+  | **type**: str
+
+
+begin
+  A message sequence number to limit returned messages. Messages with a sequence number less than this are omitted from the results.
+
+  If null, no such filtering is performed.
+
+  | **required**: False
+  | **type**: int
+
+
+end
+  A message sequence number to limit returned messages. Messages with a sequence number greater than this are omitted from the results.
+
+  If null, no such filtering is performed.
+
+  | **required**: False
+  | **type**: int
+
+
+max_messages
+  Limits the returned messages to the specified maximum number, starting from the begin of the sequence numbers in the result that would otherwise be returned.
+
+  If null or 0, no such filtering is performed.
+
+  | **required**: False
+  | **type**: int
+
+
+is_held
+  Limit the returned messages to only held (if true) or only non-held (if false) messages.
+
+  If null, no such filtering is performed.
+
+  | **required**: False
+  | **type**: bool
+
+
+is_priority
+  Limit the returned messages to only priority (if true) or only non-priority (if false) messages.
+
+  If null, no such filtering is performed.
+
+  | **required**: False
+  | **type**: bool
+
+
+log_file
+  File path of a log file to which the logic flow of this module as well as interactions with the HMC are logged. If null, logging will be propagated to the Python root logger.
+
+  | **required**: False
+  | **type**: str
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   ---
+   # Note: The following examples assume that some variables named 'my_*' are set.
+
+   - name: Get OS console messages for the OS in the LPAR
+     zhmc_lpar_messages:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       cpc_name: "{{ my_cpc_name }}"
+       name: "{{ my_lpar_name }}"
+     register: lpar_messages
+
+
+
+
+
+
+
+
+
+
+
+Return Values
+-------------
+
+
+changed
+  Indicates if any change has been made by the module. This will always be false.
+
+  | **returned**: always
+  | **type**: bool
+
+msg
+  An error message that describes the failure.
+
+  | **returned**: failure
+  | **type**: str
+
+messages
+  The list of operating system console messages.
+
+  | **returned**: success
+  | **type**: list
+  | **elements**: dict
+  | **sample**:
+
+    .. code-block:: json
+
+        [
+            {
+                "is_held": false,
+                "is_priority": false,
+                "message_id": 2328551,
+                "message_text": "Uncompressing Linux... ",
+                "os_name": null,
+                "prompt_text": "",
+                "sequence_number": 0,
+                "sound_alarm": false,
+                "timestamp": null
+            },
+            {
+                "is_held": false,
+                "is_priority": false,
+                "message_id": 2328552,
+                "message_text": "Ok, booting the kernel. ",
+                "os_name": null,
+                "prompt_text": "",
+                "sequence_number": 1,
+                "sound_alarm": false,
+                "timestamp": null
+            }
+        ]
+
+  sequence_number
+    The sequence number assigned to this message by the HMC.
+
+    Although sequence numbers may wrap over time, this number can be considered a unique identifier for the message.
+
+    | **type**: int
+
+  message_text
+    The text of the message
+
+    | **type**: str
+
+  message_id
+    The message identifier assigned to this message by the operating system.
+
+    | **type**: str
+
+  timestamp
+    The point in time (as an ISO 8601 date and time value) when the message was created, or null if this information is not available from the operating system.
+
+    | **type**: str
+
+  sound_alarm
+    Indicates whether the message should cause the alarm to be sounded.
+
+    | **type**: bool
+
+  is_priority
+    Indicates whether the message is a priority message.
+
+    A priority message indicates a critical condition that requires immediate attention.
+
+    | **type**: bool
+
+  is_held
+    Indicates whether the message is a held message.
+
+    A held message is one that requires a response.
+
+    | **type**: bool
+
+  prompt_text
+    The prompt text that is associated with this message, or null indicating that there is no prompt text for this message.
+
+    The prompt text is used when responding to a message. The response is to be sent as an operating system command where the command is prefixed with the prompt text and followed by the response to the message.
+
+    | **type**: str
+
+  os_name
+    The name of the operating system that generated this omessage, or null indicating there is no operating system name  associated with this message.
+
+    This name is determined by the operating system and may be unrelated to the name of the LPAR in which the operating system is running.
+
+    | **type**: str
+
+

--- a/docs/source/modules/zhmc_partition_messages.rst
+++ b/docs/source/modules/zhmc_partition_messages.rst
@@ -1,0 +1,262 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_core/blob/dev/plugins/modules/zhmc_partition_messages.py
+
+.. _zhmc_partition_messages_module:
+
+
+zhmc_partition_messages -- Get console messages for OS in a partition
+=====================================================================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Get the OS console messages for the OS running in an active partition.
+
+
+Requirements
+------------
+
+- The targeted CPC must be in the DPM operational mode.
+- The targeted partition must be active (i.e. running an operating system).
+- The HMC userid must have these task permissions: 'Operating System Messages' (view-only is sufficient)
+- The HMC userid must have object-access permissions to these objects: Target CPC, target partition.
+
+
+
+
+Parameters
+----------
+
+
+hmc_host
+  The hostname or IP address of the HMC.
+
+  | **required**: True
+  | **type**: str
+
+
+hmc_auth
+  The authentication credentials for the HMC.
+
+  | **required**: True
+  | **type**: dict
+
+
+  userid
+    The userid (username) for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  password
+    The password for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  session_id
+    HMC session ID to be used. This is mutually exclusive with providing \ :literal:`userid`\  and \ :literal:`password`\  and can be created as described in :ref:\`zhmc\_session\_module\`.
+
+    | **required**: False
+    | **type**: str
+
+
+  ca_certs
+    Path name of certificate file or certificate directory to be used for verifying the HMC certificate. If null (default), the path name in the 'REQUESTS\_CA\_BUNDLE' environment variable or the path name in the 'CURL\_CA\_BUNDLE' environment variable is used, or if neither of these variables is set, the certificates in the Mozilla CA Certificate List provided by the 'certifi' Python package are used for verifying the HMC certificate.
+
+    | **required**: False
+    | **type**: str
+
+
+  verify
+    If True (default), verify the HMC certificate as specified in the \ :literal:`ca\_certs`\  parameter. If False, ignore what is specified in the \ :literal:`ca\_certs`\  parameter and do not verify the HMC certificate.
+
+    | **required**: False
+    | **type**: bool
+    | **default**: True
+
+
+
+cpc_name
+  The name of the CPC with the target partition.
+
+  | **required**: True
+  | **type**: str
+
+
+name
+  The name of the target partition.
+
+  | **required**: True
+  | **type**: str
+
+
+begin
+  A message sequence number to limit returned messages. Messages with a sequence number less than this are omitted from the results.
+
+  If null, no such filtering is performed.
+
+  | **required**: False
+  | **type**: int
+
+
+end
+  A message sequence number to limit returned messages. Messages with a sequence number greater than this are omitted from the results.
+
+  If null, no such filtering is performed.
+
+  | **required**: False
+  | **type**: int
+
+
+log_file
+  File path of a log file to which the logic flow of this module as well as interactions with the HMC are logged. If null, logging will be propagated to the Python root logger.
+
+  | **required**: False
+  | **type**: str
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   ---
+   # Note: The following examples assume that some variables named 'my_*' are set.
+
+   - name: Get OS console messages for the OS in the partition
+     zhmc_partition_messages:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       cpc_name: "{{ my_cpc_name }}"
+       name: "{{ my_part_name }}"
+     register: part_messages
+
+
+
+
+
+
+
+
+
+
+
+Return Values
+-------------
+
+
+changed
+  Indicates if any change has been made by the module. This will always be false.
+
+  | **returned**: always
+  | **type**: bool
+
+msg
+  An error message that describes the failure.
+
+  | **returned**: failure
+  | **type**: str
+
+messages
+  The list of operating system console messages.
+
+  | **returned**: success
+  | **type**: list
+  | **elements**: dict
+  | **sample**:
+
+    .. code-block:: json
+
+        [
+            {
+                "is_held": false,
+                "is_priority": false,
+                "message_id": 2328551,
+                "message_text": "Uncompressing Linux... ",
+                "os_name": null,
+                "prompt_text": "",
+                "sequence_number": 0,
+                "sound_alarm": false,
+                "timestamp": null
+            },
+            {
+                "is_held": false,
+                "is_priority": false,
+                "message_id": 2328552,
+                "message_text": "Ok, booting the kernel. ",
+                "os_name": null,
+                "prompt_text": "",
+                "sequence_number": 1,
+                "sound_alarm": false,
+                "timestamp": null
+            }
+        ]
+
+  sequence_number
+    The sequence number assigned to this message by the HMC.
+
+    Although sequence numbers may wrap over time, this number can be considered a unique identifier for the message.
+
+    | **type**: int
+
+  message_text
+    The text of the message
+
+    | **type**: str
+
+  message_id
+    The message identifier assigned to this message by the operating system.
+
+    | **type**: str
+
+  timestamp
+    The point in time (as an ISO 8601 date and time value) when the message was created, or null if this information is not available from the operating system.
+
+    | **type**: str
+
+  sound_alarm
+    Indicates whether the message should cause the alarm to be sounded.
+
+    | **type**: bool
+
+  is_priority
+    Indicates whether the message is a priority message.
+
+    A priority message indicates a critical condition that requires immediate attention.
+
+    | **type**: bool
+
+  is_held
+    Indicates whether the message is a held message.
+
+    A held message is one that requires a response.
+
+    | **type**: bool
+
+  prompt_text
+    The prompt text that is associated with this message, or null indicating that there is no prompt text for this message.
+
+    The prompt text is used when responding to a message. The response is to be sent as an operating system command where the command is prefixed with the prompt text and followed by the response to the message.
+
+    | **type**: str
+
+  os_name
+    The name of the operating system that generated this omessage, or null indicating there is no operating system name  associated with this message.
+
+    This name is determined by the operating system and may be unrelated to the name of the partition in which the operating system is running.
+
+    | **type**: str
+
+

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -70,6 +70,10 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Increased minimum version of zhmcclient to 1.12.0 to pick up fixes and
   functionality.
 
+* Added new Ansible modules 'zhmc_lpar_messages' and 'zhmc_partition_messages'
+  that retrieve and return console messages from the operating system running
+  in an LPAR or DPM partition. (issue #565)
+
 **Cleanup:**
 
 * Removed documentation and test files (except sanity test ignore files) from

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -67,6 +67,9 @@ distlib==0.3.6
 requests==2.25.0; python_version <= '3.6'
 requests==2.31.0; python_version >= '3.7'
 
+pytz==2016.10; python_version <= '3.9'
+pytz==2019.1; python_version >= '3.10'
+
 zhmcclient==1.12.0
 
 
@@ -119,8 +122,6 @@ pytest==7.0.0; python_version >= '3.11'
 testfixtures==6.9.0
 colorama==0.3.9; python_version == '2.7'
 colorama==0.4.0; python_version >= '3.5'
-pytz==2016.10; python_version <= '3.9'
-pytz==2019.1; python_version >= '3.10'
 requests-mock==1.6.0
 requests-toolbelt==0.7.0; python_version <= '3.5'
 requests-toolbelt==0.8.0; python_version >= '3.6'

--- a/plugins/modules/zhmc_lpar_messages.py
+++ b/plugins/modules/zhmc_lpar_messages.py
@@ -1,0 +1,469 @@
+#!/usr/bin/python
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# For information on the format of the ANSIBLE_METADATA, DOCUMENTATION,
+# EXAMPLES, and RETURN strings, see
+# http://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['stableinterface'],
+    'supported_by': 'community',
+    'shipped_by': 'other',
+    'other_repo_url': 'https://github.com/zhmcclient/zhmc-ansible-modules'
+}
+
+DOCUMENTATION = """
+---
+module: zhmc_lpar_messages
+version_added: "2.9.0"
+short_description: Get console messages for OS in an LPAR
+description:
+  - Get the OS console messages for the OS running in a loaded LPAR.
+author:
+  - Andreas Maier (@andy-maier)
+requirements:
+  - The targeted CPC must be in the classic operational mode.
+  - The targeted LPAR must be loaded (i.e. running an operating system).
+  - "The HMC userid must have these task permissions:
+    'Operating System Messages' (view-only is sufficient)"
+  - "The HMC userid must have object-access permissions to these objects:
+    Target CPC, target LPAR."
+options:
+  hmc_host:
+    description:
+      - The hostname or IP address of the HMC.
+    type: str
+    required: true
+  hmc_auth:
+    description:
+      - The authentication credentials for the HMC.
+    type: dict
+    required: true
+    suboptions:
+      userid:
+        description:
+          - The userid (username) for authenticating with the HMC.
+            This is mutually exclusive with providing C(session_id).
+        type: str
+        required: false
+        default: null
+      password:
+        description:
+          - The password for authenticating with the HMC.
+            This is mutually exclusive with providing C(session_id).
+        type: str
+        required: false
+        default: null
+      session_id:
+        description:
+          - HMC session ID to be used.
+            This is mutually exclusive with providing C(userid) and C(password)
+            and can be created as described in :ref:`zhmc_session_module`.
+        type: str
+        required: false
+        default: null
+      ca_certs:
+        description:
+          - Path name of certificate file or certificate directory to be used
+            for verifying the HMC certificate. If null (default), the path name
+            in the 'REQUESTS_CA_BUNDLE' environment variable or the path name
+            in the 'CURL_CA_BUNDLE' environment variable is used, or if neither
+            of these variables is set, the certificates in the Mozilla CA
+            Certificate List provided by the 'certifi' Python package are used
+            for verifying the HMC certificate.
+        type: str
+        required: false
+        default: null
+      verify:
+        description:
+          - If True (default), verify the HMC certificate as specified in the
+            C(ca_certs) parameter. If False, ignore what is specified in the
+            C(ca_certs) parameter and do not verify the HMC certificate.
+        type: bool
+        required: false
+        default: true
+  cpc_name:
+    description:
+      - The name of the CPC with the target LPAR.
+    type: str
+    required: true
+  name:
+    description:
+      - The name of the target LPAR.
+    type: str
+    required: true
+  begin:
+    description:
+      - "A message sequence number to limit returned messages. Messages with
+         a sequence number less than this are omitted from the results."
+      - "If null, no such filtering is performed."
+    type: int
+    required: false
+    default: null
+  end:
+    description:
+      - "A message sequence number to limit returned messages. Messages with
+         a sequence number greater than this are omitted from the results."
+      - "If null, no such filtering is performed."
+    type: int
+    required: false
+    default: null
+  max_messages:
+    description:
+      - "Limits the returned messages to the specified maximum number, starting
+         from the begin of the sequence numbers in the result that would
+         otherwise be returned."
+      - "If null or 0, no such filtering is performed."
+    type: int
+    required: false
+    default: null
+  is_held:
+    description:
+      - "Limit the returned messages to only held (if true) or only non-held
+         (if false) messages."
+      - "If null, no such filtering is performed."
+    type: bool
+    required: false
+    default: null
+  is_priority:
+    description:
+      - "Limit the returned messages to only priority (if true) or only
+         non-priority (if false) messages."
+      - "If null, no such filtering is performed."
+    type: bool
+    required: false
+    default: null
+  log_file:
+    description:
+      - "File path of a log file to which the logic flow of this module as well
+         as interactions with the HMC are logged. If null, logging will be
+         propagated to the Python root logger."
+    type: str
+    required: false
+    default: null
+  _faked_session:
+    description:
+      - "An internal parameter used for testing the module."
+    type: raw
+    required: false
+    default: null
+"""
+
+EXAMPLES = """
+---
+# Note: The following examples assume that some variables named 'my_*' are set.
+
+- name: Get OS console messages for the OS in the LPAR
+  zhmc_lpar_messages:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    cpc_name: "{{ my_cpc_name }}"
+    name: "{{ my_lpar_name }}"
+  register: lpar_messages
+
+"""
+
+RETURN = """
+changed:
+  description: Indicates if any change has been made by the module.
+    This will always be false.
+  returned: always
+  type: bool
+msg:
+  description: An error message that describes the failure.
+  returned: failure
+  type: str
+messages:
+  description:
+    - "The list of operating system console messages."
+  returned: success
+  type: list
+  elements: dict
+  contains:
+    sequence_number:
+      description:
+      - "The sequence number assigned to this message by the HMC."
+      - "Although sequence numbers may wrap over time, this number can be
+         considered a unique identifier for the message."
+      type: int
+    message_text:
+      description: "The text of the message"
+      type: str
+    message_id:
+      description:
+        - "The message identifier assigned to this message by the operating
+           system."
+      type: str
+    timestamp:
+      description:
+        - "The point in time (as an ISO 8601 date and time value) when the
+           message was created, or null if this information is not available
+           from the operating system."
+      type: str
+    sound_alarm:
+      description:
+        - "Indicates whether the message should cause the alarm to be sounded."
+      type: bool
+    is_priority:
+      description:
+        - "Indicates whether the message is a priority message."
+        - "A priority message indicates a critical condition that requires
+           immediate attention."
+      type: bool
+    is_held:
+      description:
+        - "Indicates whether the message is a held message."
+        - "A held message is one that requires a response."
+      type: bool
+    prompt_text:
+      description:
+        - "The prompt text that is associated with this message, or null
+           indicating that there is no prompt text for this message."
+        - "The prompt text is used when responding to a message. The response
+           is to be sent as an operating system command where the command is
+           prefixed with the prompt text and followed by the response to the
+           message."
+      type: str
+    os_name:
+      description:
+        - "The name of the operating system that generated this omessage, or
+           null indicating there is no operating system name  associated with
+           this message."
+        - "This name is determined by the operating system and may be unrelated
+           to the name of the LPAR in which the operating system is running."
+      type: str
+  sample:
+    [
+        {
+            "is_held": false,
+            "is_priority": false,
+            "message_id": 2328551,
+            "message_text": "Uncompressing Linux... \n",
+            "os_name": null,
+            "prompt_text": "",
+            "sequence_number": 0,
+            "sound_alarm": false,
+            "timestamp": null
+        },
+        {
+            "is_held": false,
+            "is_priority": false,
+            "message_id": 2328552,
+            "message_text": "Ok, booting the kernel.\n",
+            "os_name": null,
+            "prompt_text": "",
+            "sequence_number": 1,
+            "sound_alarm": false,
+            "timestamp": null
+        }
+    ]
+"""
+
+import logging  # noqa: E402
+import traceback  # noqa: E402
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+
+from ..module_utils.common import log_init, open_session, close_session, \
+    hmc_auth_parameter, Error, missing_required_lib, \
+    common_fail_on_import_errors  # noqa: E402
+
+try:
+    import requests.packages.urllib3
+    IMP_URLLIB3_ERR = None
+except ImportError:
+    IMP_URLLIB3_ERR = traceback.format_exc()
+
+try:
+    import zhmcclient
+    IMP_ZHMCCLIENT_ERR = None
+except ImportError:
+    IMP_ZHMCCLIENT_ERR = traceback.format_exc()
+
+try:
+    import pytz
+    IMP_PYTZ_ERR = None
+except ImportError:
+    IMP_PYTZ_ERR = traceback.format_exc()
+
+# Python logger name for this module
+LOGGER_NAME = 'zhmc_lpar'
+
+LOGGER = logging.getLogger(LOGGER_NAME)
+
+
+def find_lpar(client, cpc_name, lpar_name):
+    """
+    Find the specified LPAR in the specified CPC.
+
+    The "List Permitted Logical Partitions" operation is used when available.
+
+    Returns:
+      zhmcclient.Lpar
+
+    Raises:
+      zhmcclient.NotFound: LPAR does not exist.
+    """
+    # The "List Permitted Logical Partitions" operation was added in HMC
+    # version 2.14.0. The operation depends only on the HMC version and not
+    # on the SE/CPC version, so it is supported e.g. for a 2.14 HMC managing
+    # a z13 CPC.
+    hmc_version = client.query_api_version()['hmc-version']
+    hmc_version_info = [int(x) for x in hmc_version.split('.')]
+    if hmc_version_info < [2, 14, 0]:
+        # Find the LPAR in the traditional way
+        cpc = client.cpcs.find(name=cpc_name)
+        lpar = cpc.lpars.find(name=lpar_name)
+    else:
+        # Find the LPAR using the new operation
+        filter_args = {'cpc-name': cpc_name, 'name': lpar_name}
+        lpars = client.consoles.console.list_permitted_lpars(
+            filter_args=filter_args)
+        try:
+            lpar = lpars[0]
+        except IndexError:
+            raise zhmcclient.NotFound(
+                message="Could not find LPAR {ln!r} in permitted LPARs of "
+                "CPC {c!r}".format(ln=lpar_name, c=cpc_name))
+    return lpar
+
+
+def perform_os_messages(params):
+    """
+    Get the OS console messages and return a list of them.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    cpc_name = params['cpc_name']
+    lpar_name = params['name']
+    begin = params['begin']
+    end = params['end']
+    is_held = params['is_held']
+    is_priority = params['is_priority']
+    max_messages = params['max_messages']
+    if max_messages is None:
+        max_messages = 0
+
+    session, logoff = open_session(params)
+    try:
+        client = zhmcclient.Client(session)
+
+        lpar = find_lpar(client, cpc_name, lpar_name)
+
+        result_dict = lpar.list_os_messages(
+            begin=begin, end=end, is_held=is_held, is_priority=is_priority,
+            max_messages=max_messages)
+
+        result = []
+        for os_message in result_dict['os-messages']:
+            hmc_ts = os_message.get('timestamp')
+            if hmc_ts == -1:
+                timestamp = None
+            else:
+                dt = zhmcclient.datetime_from_timestamp(hmc_ts, tzinfo=pytz.utc)
+                timestamp = dt.isoformat()
+            result_message = {
+                "sequence_number": os_message.get('sequence-number'),
+                "message_text": os_message.get('message-text'),
+                "message_id": os_message.get('message-id'),
+                "timestamp": timestamp,
+                "sound_alarm": os_message.get('sound-alarm'),
+                "is_priority": os_message.get('is-priority'),
+                "is_held": os_message.get('is-held'),
+                "prompt_text": os_message.get('prompt-text'),
+                "os_name": os_message.get('os-name'),
+            }
+            result.append(result_message)
+
+        return result
+
+    finally:
+        close_session(session, logoff)
+
+
+def main():
+
+    # The following definition of module input parameters must match the
+    # description of the options in the DOCUMENTATION string.
+    argument_spec = dict(
+        hmc_host=dict(required=True, type='str'),
+        hmc_auth=hmc_auth_parameter(),
+        cpc_name=dict(required=True, type='str'),
+        name=dict(required=True, type='str'),
+        begin=dict(required=False, type='int', default=None),
+        end=dict(required=False, type='int', default=None),
+        max_messages=dict(required=False, type='int', default=None),
+        is_held=dict(required=False, type='bool', default=None),
+        is_priority=dict(required=False, type='bool', default=None),
+        log_file=dict(required=False, type='str', default=None),
+        _faked_session=dict(required=False, type='raw'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True)
+
+    if IMP_URLLIB3_ERR is not None:
+        module.fail_json(msg=missing_required_lib("requests"),
+                         exception=IMP_URLLIB3_ERR)
+
+    requests.packages.urllib3.disable_warnings()
+
+    if IMP_ZHMCCLIENT_ERR is not None:
+        module.fail_json(msg=missing_required_lib("zhmcclient"),
+                         exception=IMP_ZHMCCLIENT_ERR)
+
+    if IMP_PYTZ_ERR is not None:
+        module.fail_json(msg=missing_required_lib("pytz"),
+                         exception=IMP_PYTZ_ERR)
+
+    common_fail_on_import_errors(module)
+
+    log_file = module.params['log_file']
+    log_init(LOGGER_NAME, log_file)
+
+    _params = dict(module.params)
+    del _params['hmc_auth']
+    LOGGER.debug("Module entry: params: %r", _params)
+
+    changed = False
+    try:
+
+        result = perform_os_messages(module.params)
+
+    except (Error, zhmcclient.Error) as exc:
+        # These exceptions are considered errors in the environment or in user
+        # input. They have a proper message that stands on its own, so we
+        # simply pass that message on and will not need a traceback.
+        msg = "{0}: {1}".format(exc.__class__.__name__, exc)
+        LOGGER.debug(
+            "Module exit (failure): msg: %s", msg)
+        module.fail_json(msg=msg)
+    # Other exceptions are considered module errors and are handled by Ansible
+    # by showing the traceback.
+
+    LOGGER.debug(
+        "Module exit (success): changed: %r, messages: %r", changed, result)
+    module.exit_json(changed=changed, messages=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/zhmc_partition_messages.py
+++ b/plugins/modules/zhmc_partition_messages.py
@@ -1,0 +1,434 @@
+#!/usr/bin/python
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# For information on the format of the ANSIBLE_METADATA, DOCUMENTATION,
+# EXAMPLES, and RETURN strings, see
+# http://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['stableinterface'],
+    'supported_by': 'community',
+    'shipped_by': 'other',
+    'other_repo_url': 'https://github.com/zhmcclient/zhmc-ansible-modules'
+}
+
+DOCUMENTATION = """
+---
+module: zhmc_partition_messages
+version_added: "2.9.0"
+short_description: Get console messages for OS in a partition
+description:
+  - Get the OS console messages for the OS running in an active partition.
+author:
+  - Andreas Maier (@andy-maier)
+requirements:
+  - The targeted CPC must be in the DPM operational mode.
+  - The targeted partition must be active (i.e. running an operating system).
+  - "The HMC userid must have these task permissions:
+    'Operating System Messages' (view-only is sufficient)"
+  - "The HMC userid must have object-access permissions to these objects:
+    Target CPC, target partition."
+options:
+  hmc_host:
+    description:
+      - The hostname or IP address of the HMC.
+    type: str
+    required: true
+  hmc_auth:
+    description:
+      - The authentication credentials for the HMC.
+    type: dict
+    required: true
+    suboptions:
+      userid:
+        description:
+          - The userid (username) for authenticating with the HMC.
+            This is mutually exclusive with providing C(session_id).
+        type: str
+        required: false
+        default: null
+      password:
+        description:
+          - The password for authenticating with the HMC.
+            This is mutually exclusive with providing C(session_id).
+        type: str
+        required: false
+        default: null
+      session_id:
+        description:
+          - HMC session ID to be used.
+            This is mutually exclusive with providing C(userid) and C(password)
+            and can be created as described in :ref:`zhmc_session_module`.
+        type: str
+        required: false
+        default: null
+      ca_certs:
+        description:
+          - Path name of certificate file or certificate directory to be used
+            for verifying the HMC certificate. If null (default), the path name
+            in the 'REQUESTS_CA_BUNDLE' environment variable or the path name
+            in the 'CURL_CA_BUNDLE' environment variable is used, or if neither
+            of these variables is set, the certificates in the Mozilla CA
+            Certificate List provided by the 'certifi' Python package are used
+            for verifying the HMC certificate.
+        type: str
+        required: false
+        default: null
+      verify:
+        description:
+          - If True (default), verify the HMC certificate as specified in the
+            C(ca_certs) parameter. If False, ignore what is specified in the
+            C(ca_certs) parameter and do not verify the HMC certificate.
+        type: bool
+        required: false
+        default: true
+  cpc_name:
+    description:
+      - The name of the CPC with the target partition.
+    type: str
+    required: true
+  name:
+    description:
+      - The name of the target partition.
+    type: str
+    required: true
+  begin:
+    description:
+      - "A message sequence number to limit returned messages. Messages with
+         a sequence number less than this are omitted from the results."
+      - "If null, no such filtering is performed."
+    type: int
+    required: false
+    default: null
+  end:
+    description:
+      - "A message sequence number to limit returned messages. Messages with
+         a sequence number greater than this are omitted from the results."
+      - "If null, no such filtering is performed."
+    type: int
+    required: false
+    default: null
+  log_file:
+    description:
+      - "File path of a log file to which the logic flow of this module as well
+         as interactions with the HMC are logged. If null, logging will be
+         propagated to the Python root logger."
+    type: str
+    required: false
+    default: null
+  _faked_session:
+    description:
+      - "An internal parameter used for testing the module."
+    type: raw
+    required: false
+    default: null
+"""
+
+EXAMPLES = """
+---
+# Note: The following examples assume that some variables named 'my_*' are set.
+
+- name: Get OS console messages for the OS in the partition
+  zhmc_partition_messages:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    cpc_name: "{{ my_cpc_name }}"
+    name: "{{ my_part_name }}"
+  register: part_messages
+
+"""
+
+RETURN = """
+changed:
+  description: Indicates if any change has been made by the module.
+    This will always be false.
+  returned: always
+  type: bool
+msg:
+  description: An error message that describes the failure.
+  returned: failure
+  type: str
+messages:
+  description:
+    - "The list of operating system console messages."
+  returned: success
+  type: list
+  elements: dict
+  contains:
+    sequence_number:
+      description:
+      - "The sequence number assigned to this message by the HMC."
+      - "Although sequence numbers may wrap over time, this number can be
+         considered a unique identifier for the message."
+      type: int
+    message_text:
+      description: "The text of the message"
+      type: str
+    message_id:
+      description:
+        - "The message identifier assigned to this message by the operating
+           system."
+      type: str
+    timestamp:
+      description:
+        - "The point in time (as an ISO 8601 date and time value) when the
+           message was created, or null if this information is not available
+           from the operating system."
+      type: str
+    sound_alarm:
+      description:
+        - "Indicates whether the message should cause the alarm to be sounded."
+      type: bool
+    is_priority:
+      description:
+        - "Indicates whether the message is a priority message."
+        - "A priority message indicates a critical condition that requires
+           immediate attention."
+      type: bool
+    is_held:
+      description:
+        - "Indicates whether the message is a held message."
+        - "A held message is one that requires a response."
+      type: bool
+    prompt_text:
+      description:
+        - "The prompt text that is associated with this message, or null
+           indicating that there is no prompt text for this message."
+        - "The prompt text is used when responding to a message. The response
+           is to be sent as an operating system command where the command is
+           prefixed with the prompt text and followed by the response to the
+           message."
+      type: str
+    os_name:
+      description:
+        - "The name of the operating system that generated this omessage, or
+           null indicating there is no operating system name  associated with
+           this message."
+        - "This name is determined by the operating system and may be unrelated
+           to the name of the partition in which the operating system is running."
+      type: str
+  sample:
+    [
+        {
+            "is_held": false,
+            "is_priority": false,
+            "message_id": 2328551,
+            "message_text": "Uncompressing Linux... \n",
+            "os_name": null,
+            "prompt_text": "",
+            "sequence_number": 0,
+            "sound_alarm": false,
+            "timestamp": null
+        },
+        {
+            "is_held": false,
+            "is_priority": false,
+            "message_id": 2328552,
+            "message_text": "Ok, booting the kernel.\n",
+            "os_name": null,
+            "prompt_text": "",
+            "sequence_number": 1,
+            "sound_alarm": false,
+            "timestamp": null
+        }
+    ]
+"""
+
+import logging  # noqa: E402
+import traceback  # noqa: E402
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+
+from ..module_utils.common import log_init, open_session, close_session, \
+    hmc_auth_parameter, Error, missing_required_lib, \
+    common_fail_on_import_errors  # noqa: E402
+
+try:
+    import requests.packages.urllib3
+    IMP_URLLIB3_ERR = None
+except ImportError:
+    IMP_URLLIB3_ERR = traceback.format_exc()
+
+try:
+    import zhmcclient
+    IMP_ZHMCCLIENT_ERR = None
+except ImportError:
+    IMP_ZHMCCLIENT_ERR = traceback.format_exc()
+
+try:
+    import pytz
+    IMP_PYTZ_ERR = None
+except ImportError:
+    IMP_PYTZ_ERR = traceback.format_exc()
+
+# Python logger name for this module
+LOGGER_NAME = 'zhmc_part'
+
+LOGGER = logging.getLogger(LOGGER_NAME)
+
+
+def find_partition(client, cpc_name, part_name):
+    """
+    Find the specified partition in the specified CPC.
+
+    The "List Permitted Partitions" operation is used when available.
+
+    Returns:
+      zhmcclient.Lpar
+
+    Raises:
+      zhmcclient.NotFound: partition does not exist.
+    """
+    # The "List Permitted Partitions" operation was added in HMC
+    # version 2.14.0. The operation depends only on the HMC version and not
+    # on the SE/CPC version, so it is supported e.g. for a 2.14 HMC managing
+    # a z13 CPC.
+    hmc_version = client.query_api_version()['hmc-version']
+    hmc_version_info = [int(x) for x in hmc_version.split('.')]
+    if hmc_version_info < [2, 14, 0]:
+        # Find the partition in the traditional way
+        cpc = client.cpcs.find(name=cpc_name)
+        part = cpc.partitions.find(name=part_name)
+    else:
+        # Find the partition using the new operation
+        filter_args = {'cpc-name': cpc_name, 'name': part_name}
+        parts = client.consoles.console.list_permitted_partitions(
+            filter_args=filter_args)
+        try:
+            part = parts[0]
+        except IndexError:
+            raise zhmcclient.NotFound(
+                message="Could not find partition {pn!r} in permitted "
+                "partitions of CPC {c!r}".format(pn=part_name, c=cpc_name))
+    return part
+
+
+def perform_os_messages(params):
+    """
+    Get the OS console messages and return a list of them.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    cpc_name = params['cpc_name']
+    part_name = params['name']
+    begin = params['begin']
+    end = params['end']
+
+    session, logoff = open_session(params)
+    try:
+        client = zhmcclient.Client(session)
+
+        part = find_partition(client, cpc_name, part_name)
+
+        result_dict = part.list_os_messages(begin=begin, end=end)
+
+        result = []
+        for os_message in result_dict['os-messages']:
+            hmc_ts = os_message.get('timestamp')
+            if hmc_ts == -1:
+                timestamp = None
+            else:
+                dt = zhmcclient.datetime_from_timestamp(hmc_ts, tzinfo=pytz.utc)
+                timestamp = dt.isoformat()
+            result_message = {
+                "sequence_number": os_message.get('sequence-number'),
+                "message_text": os_message.get('message-text'),
+                "message_id": os_message.get('message-id'),
+                "timestamp": timestamp,
+                "sound_alarm": os_message.get('sound-alarm'),
+                "is_priority": os_message.get('is-priority'),
+                "is_held": os_message.get('is-held'),
+                "prompt_text": os_message.get('prompt-text'),
+                "os_name": os_message.get('os-name'),
+            }
+            result.append(result_message)
+
+        return result
+
+    finally:
+        close_session(session, logoff)
+
+
+def main():
+
+    # The following definition of module input parameters must match the
+    # description of the options in the DOCUMENTATION string.
+    argument_spec = dict(
+        hmc_host=dict(required=True, type='str'),
+        hmc_auth=hmc_auth_parameter(),
+        cpc_name=dict(required=True, type='str'),
+        name=dict(required=True, type='str'),
+        begin=dict(required=False, type='int', default=None),
+        end=dict(required=False, type='int', default=None),
+        log_file=dict(required=False, type='str', default=None),
+        _faked_session=dict(required=False, type='raw'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True)
+
+    if IMP_URLLIB3_ERR is not None:
+        module.fail_json(msg=missing_required_lib("requests"),
+                         exception=IMP_URLLIB3_ERR)
+
+    requests.packages.urllib3.disable_warnings()
+
+    if IMP_ZHMCCLIENT_ERR is not None:
+        module.fail_json(msg=missing_required_lib("zhmcclient"),
+                         exception=IMP_ZHMCCLIENT_ERR)
+
+    if IMP_PYTZ_ERR is not None:
+        module.fail_json(msg=missing_required_lib("pytz"),
+                         exception=IMP_PYTZ_ERR)
+
+    common_fail_on_import_errors(module)
+
+    log_file = module.params['log_file']
+    log_init(LOGGER_NAME, log_file)
+
+    _params = dict(module.params)
+    del _params['hmc_auth']
+    LOGGER.debug("Module entry: params: %r", _params)
+
+    changed = False
+    try:
+
+        result = perform_os_messages(module.params)
+
+    except (Error, zhmcclient.Error) as exc:
+        # These exceptions are considered errors in the environment or in user
+        # input. They have a proper message that stands on its own, so we
+        # simply pass that message on and will not need a traceback.
+        msg = "{0}: {1}".format(exc.__class__.__name__, exc)
+        LOGGER.debug(
+            "Module exit (failure): msg: %s", msg)
+        module.fail_json(msg=msg)
+    # Other exceptions are considered module errors and are handled by Ansible
+    # by showing the traceback.
+
+    LOGGER.debug(
+        "Module exit (success): changed: %r, messages: %r", changed, result)
+    module.exit_json(changed=changed, messages=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,8 @@ ansible-core>=2.16.0; python_version >= '3.12'
 requests>=2.25.0; python_version <= '3.6'
 requests>=2.31.0; python_version >= '3.7'
 
+pytz>=2016.10
+
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
 zhmcclient>=1.12.0
 

--- a/tests/end2end/test_zhmc_lpar_messages.py
+++ b/tests/end2end/test_zhmc_lpar_messages.py
@@ -1,0 +1,213 @@
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for zhmc_lpar_messages module.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import random
+import pytest
+import mock
+import requests.packages.urllib3
+# pylint: disable=line-too-long,unused-import
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import classic_mode_cpcs  # noqa: F401, E501
+# pylint: enable=line-too-long,unused-import
+
+from plugins.modules import zhmc_lpar_messages
+from .utils import mock_ansible_module, get_failure_msg
+
+requests.packages.urllib3.disable_warnings()
+
+LOGGING = False
+LOG_FILE = 'zhmc_lpar_messages.log' if LOGGING else None
+
+
+def get_module_output(mod_obj):
+    """
+    Return the module output as a tuple (changed, messages) (i.e.
+    the arguments of the call to exit_json()).
+    If the module failed, return None.
+    """
+
+    def func(changed, messages):
+        return changed, messages
+
+    if not mod_obj.exit_json.called:
+        return None
+    call_args = mod_obj.exit_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])
+
+
+TESTCASES_ZHMC_LPAR_MESSAGES = [
+    # Testcases for test_zhmc_lpar_messages(), each with these items:
+    # * desc (str): Testcase description
+    # * in_params (dict): Input parameters passed to module, except for
+    #   hmc_host, hmc_auth, cpc, name, log_file.
+    # * exp_seqnos (dict): Expected message sequence numbers, if success,
+    #   or None for no checking
+
+    (
+        "Messages unfiltered",
+        {
+            'begin': None,
+            'end': None,
+            'max_messages': None,
+            'is_held': None,
+            'is_priority': None,
+        },
+        None
+    ),
+    (
+        "Messages 0-2 filtered by begin/end",
+        {
+            'begin': 0,
+            'end': 2,
+            'max_messages': None,
+            'is_held': None,
+            'is_priority': None,
+        },
+        [0, 1, 2]
+    ),
+    (
+        "Messages 0-2 filtered by max_messages",
+        {
+            'begin': None,
+            'end': None,
+            'max_messages': 3,
+            'is_held': None,
+            'is_priority': None,
+        },
+        [0, 1, 2]
+    ),
+    (
+        "Messages 1-2 filtered by begin and max_messages",
+        {
+            'begin': 1,
+            'end': None,
+            'max_messages': 2,
+            'is_held': None,
+            'is_priority': None,
+        },
+        [1, 2]
+    ),
+    (
+        "Messages 0-2 filtered by max_messages and is_held/is_priority false",
+        {
+            'begin': None,
+            'end': None,
+            'max_messages': 3,
+            'is_held': False,
+            'is_priority': False,
+        },
+        [0, 1, 2]
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, in_params, exp_seqnos",
+    TESTCASES_ZHMC_LPAR_MESSAGES
+)
+@pytest.mark.parametrize(
+    "check_mode", [
+        pytest.param(False, id="check_mode=False"),
+        pytest.param(True, id="check_mode=True"),
+    ]
+)
+@mock.patch("plugins.modules.zhmc_lpar_messages.AnsibleModule", autospec=True)
+def test_zhmc_lpar_messages(
+        ansible_mod_cls, check_mode,
+        desc, in_params, exp_seqnos,
+        classic_mode_cpcs):  # noqa: F811, E501
+    """
+    Test the zhmc_lpar_messages module with classic mode CPCs.
+    """
+    if not classic_mode_cpcs:
+        pytest.skip("HMC definition does not include any CPCs in classic mode")
+
+    for cpc in classic_mode_cpcs:
+        assert not cpc.dpm_enabled
+
+        session = cpc.manager.session
+        hd = session.hmc_definition
+        hmc_host = hd.host
+        hmc_auth = dict(userid=hd.userid, password=hd.password,
+                        ca_certs=hd.ca_certs, verify=hd.verify)
+        faked_session = session if hd.mock_file else None
+
+        lpars = cpc.lpars.list()
+        loaded_lpars = []
+        for lpar in lpars:
+            lpar_status = lpar.get_property('status')
+            if lpar_status in ('operating', 'exceptions'):
+                loaded_lpars.append(lpar)
+
+        if not loaded_lpars:
+            pytest.skip("CPC {c} does not have any LPARs in a loaded state".
+                        format(c=cpc.name))
+
+        lpar = random.choice(loaded_lpars)
+
+        # Prepare module input parameters (must be all required + optional)
+        params = {
+            'hmc_host': hmc_host,
+            'hmc_auth': hmc_auth,
+            'cpc_name': cpc.name,
+            'name': lpar.name,
+            'log_file': LOG_FILE,
+            '_faked_session': faked_session,
+        }
+        params.update(in_params)
+
+        # Prepare mocks for AnsibleModule object
+        mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+        # Exercise the code to be tested
+        with pytest.raises(SystemExit) as exc_info:
+            zhmc_lpar_messages.main()
+        exit_code = exc_info.value.args[0]
+
+        # Assert module exit code
+        assert exit_code == 0, \
+            "Module failed with exit code {e} and message:\n{m}". \
+            format(e=exit_code, m=get_failure_msg(mod_obj))
+
+        # Assert module output
+        changed, messages = get_module_output(mod_obj)
+        assert changed is False
+
+        if exp_seqnos is not None:
+            seqnos = [m['sequence_number'] for m in messages]
+            assert len(seqnos) == len(exp_seqnos), (
+                "Unexpected number of messages:\n"
+                "  Actual sequence numbers: {asn}\n"
+                "  Expected sequence numbers: {esn}\n".
+                format(asn=seqnos, esn=exp_seqnos)
+            )
+            for i, message in enumerate(messages):
+                exp_seqno = exp_seqnos[i]
+                seqno = message['sequence_number']
+                assert seqno == exp_seqno, (
+                    "Unexpected sequence number:\n"
+                    "  Actual sequence numbers: {asn}\n"
+                    "  Expected sequence numbers: {esn}\n".
+                    format(asn=seqnos, esn=exp_seqnos)
+                )

--- a/tests/end2end/test_zhmc_partition_messages.py
+++ b/tests/end2end/test_zhmc_partition_messages.py
@@ -1,0 +1,166 @@
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for zhmc_partition_messages module.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import random
+import pytest
+import mock
+import requests.packages.urllib3
+# pylint: disable=line-too-long,unused-import
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+from zhmcclient.testutils import dpm_mode_cpcs  # noqa: F401, E501
+# pylint: enable=line-too-long,unused-import
+
+from plugins.modules import zhmc_partition_messages
+from .utils import mock_ansible_module, get_failure_msg
+
+requests.packages.urllib3.disable_warnings()
+
+LOGGING = False
+LOG_FILE = 'zhmc_partition_messages.log' if LOGGING else None
+
+
+def get_module_output(mod_obj):
+    """
+    Return the module output as a tuple (changed, messages) (i.e.
+    the arguments of the call to exit_json()).
+    If the module failed, return None.
+    """
+
+    def func(changed, messages):
+        return changed, messages
+
+    if not mod_obj.exit_json.called:
+        return None
+    call_args = mod_obj.exit_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])
+
+
+TESTCASES_ZHMC_PARTITION_MESSAGES = [
+    # Testcases for test_zhmc_partition_messages(), each with these items:
+    # * desc (str): Testcase description
+    # * in_params (dict): Input parameters passed to module, except for
+    #   hmc_host, hmc_auth, cpc, name, log_file.
+    # * exp_seqnos (dict): Expected message sequence numbers, if success,
+    #   or None for no checking
+
+    (
+        "Messages unfiltered",
+        {
+            'begin': None,
+            'end': None,
+        },
+        None
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, in_params, exp_seqnos",
+    TESTCASES_ZHMC_PARTITION_MESSAGES
+)
+@pytest.mark.parametrize(
+    "check_mode", [
+        pytest.param(False, id="check_mode=False"),
+        pytest.param(True, id="check_mode=True"),
+    ]
+)
+@mock.patch("plugins.modules.zhmc_partition_messages.AnsibleModule", autospec=True)
+def test_zhmc_partition_messages(
+        ansible_mod_cls, check_mode,
+        desc, in_params, exp_seqnos,
+        dpm_mode_cpcs):  # noqa: F811, E501
+    """
+    Test the zhmc_partition_messages module with DPM mode CPCs.
+    """
+    if not dpm_mode_cpcs:
+        pytest.skip("HMC definition does not include any CPCs in DPM mode")
+
+    for cpc in dpm_mode_cpcs:
+        assert cpc.dpm_enabled
+
+        session = cpc.manager.session
+        hd = session.hmc_definition
+        hmc_host = hd.host
+        hmc_auth = dict(userid=hd.userid, password=hd.password,
+                        ca_certs=hd.ca_certs, verify=hd.verify)
+        faked_session = session if hd.mock_file else None
+
+        parts = cpc.partitions.list()
+        active_parts = []
+        for part in parts:
+            part_status = part.get_property('status')
+            if part_status in ('active', 'degraded'):
+                active_parts.append(part)
+
+        if not active_parts:
+            pytest.skip("CPC {c} does not have any partitions in an active "
+                        "state".format(c=cpc.name))
+
+        part = random.choice(active_parts)
+
+        # Prepare module input parameters (must be all required + optional)
+        params = {
+            'hmc_host': hmc_host,
+            'hmc_auth': hmc_auth,
+            'cpc_name': cpc.name,
+            'name': part.name,
+            'log_file': LOG_FILE,
+            '_faked_session': faked_session,
+        }
+        params.update(in_params)
+
+        # Prepare mocks for AnsibleModule object
+        mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+        # Exercise the code to be tested
+        with pytest.raises(SystemExit) as exc_info:
+            zhmc_partition_messages.main()
+        exit_code = exc_info.value.args[0]
+
+        # Assert module exit code
+        assert exit_code == 0, \
+            "Module failed with exit code {e} and message:\n{m}". \
+            format(e=exit_code, m=get_failure_msg(mod_obj))
+
+        # Assert module output
+        changed, messages = get_module_output(mod_obj)
+        assert changed is False
+
+        if exp_seqnos is not None:
+            seqnos = [m['sequence_number'] for m in messages]
+            assert len(seqnos) == len(exp_seqnos), (
+                "Unexpected number of messages:\n"
+                "  Actual sequence numbers: {asn}\n"
+                "  Expected sequence numbers: {esn}\n".
+                format(asn=seqnos, esn=exp_seqnos)
+            )
+            for i, message in enumerate(messages):
+                exp_seqno = exp_seqnos[i]
+                seqno = message['sequence_number']
+                assert seqno == exp_seqno, (
+                    "Unexpected sequence number:\n"
+                    "  Actual sequence numbers: {asn}\n"
+                    "  Expected sequence numbers: {esn}\n".
+                    format(asn=seqnos, esn=exp_seqnos)
+                )

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -13,6 +13,8 @@ plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-li
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_partition_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
@@ -27,6 +29,8 @@ plugins/modules/zhmc_virtual_function.py validate-modules:missing-gplv3-license 
 plugins/module_utils/common.py pylint:raise-missing-from
 plugins/modules/zhmc_crypto_attachment.py pylint:raise-missing-from
 plugins/modules/zhmc_hba.py pylint:raise-missing-from
+plugins/modules/zhmc_lpar_messages.py pylint:raise-missing-from
+plugins/modules/zhmc_partition_messages.py pylint:raise-missing-from
 plugins/modules/zhmc_nic.py pylint:raise-missing-from
 plugins/modules/zhmc_partition.py pylint:raise-missing-from
 tests/end2end/test_zhmc_partition.py pylint:raise-missing-from

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -13,6 +13,8 @@ plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-li
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_partition_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -13,6 +13,8 @@ plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-li
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_partition_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -13,6 +13,8 @@ plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-li
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_partition_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -13,6 +13,8 @@ plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-li
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_partition_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -13,6 +13,8 @@ plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-li
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_partition_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -13,6 +13,8 @@ plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-li
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_partition_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -13,6 +13,8 @@ plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-li
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_lpar_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zhmc_partition_messages.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_password_rule_list.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
@@ -26,6 +28,8 @@ plugins/modules/zhmc_user_list.py validate-modules:missing-gplv3-license # Licen
 plugins/modules/zhmc_virtual_function.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py pylint:raise-missing-from
 plugins/module_utils/common.py pylint:raise-missing-from
+plugins/modules/zhmc_lpar_messages.py pylint:raise-missing-from
+plugins/modules/zhmc_partition_messages.py pylint:raise-missing-from
 plugins/modules/zhmc_adapter.py pylint!skip # Unreliable duplicate-code issues
 plugins/modules/zhmc_cpc.py pylint!skip # Unreliable duplicate-code issues
 plugins/modules/zhmc_crypto_attachment.py pylint!skip # Unreliable duplicate-code issues
@@ -57,10 +61,12 @@ docs/source/modules/zhmc_ldap_server_definition.rst rstcheck!skip # (json) Expec
 docs/source/modules/zhmc_ldap_server_definition_list.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
 docs/source/modules/zhmc_lpar.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
 docs/source/modules/zhmc_lpar_list.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
+docs/source/modules/zhmc_lpar_messages.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
 docs/source/modules/zhmc_nic.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
 docs/source/modules/zhmc_nic_list.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
 docs/source/modules/zhmc_partition.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
 docs/source/modules/zhmc_partition_list.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
+docs/source/modules/zhmc_partition_messages.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
 docs/source/modules/zhmc_password_rule.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
 docs/source/modules/zhmc_password_rule_list.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes
 docs/source/modules/zhmc_session.rst rstcheck!skip # (json) Expecting property name enclosed in double quotes


### PR DESCRIPTION
Ready for review.
For details, see the commit message.
I ran the end2end tests for the new Ansible modules successfully on M96 (for LPAR) and on T224 (for DPM partitions).