### PR TITLE
Pinned voluptuous to <0.14 on Python<3.6

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,8 +16,10 @@
 # Ansible validate-modules (no imports, invoked via validate-modules script)
 mock>=2.0.0
 # voluptous 0.13.0 uses 'enum' module which is not available on py27 (it also does not use enum34 for backport). This has been fixed in 0.13.1.
-voluptuous>=0.11.7,!=0.13.0; python_version == '2.7'
-voluptuous>=0.11.7; python_version >= '3.5'
+# voluptuous 0.14.0 requires Python >=3.6 without properly declaring that in the package metadata.
+voluptuous>=0.11.7,!=0.13.0,<0.14; python_version == '2.7'
+voluptuous>=0.11.7,<0.14; python_version == '3.5'
+voluptuous>=0.11.7; python_version >= '3.6'
 
 # Unit test (imports into testcases):
 # packaging is specified in requirements.txt

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -59,6 +59,8 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Fixed and improved the description of the 'zhmc_lpar' module for
   state=active/loaded; cleaned up the code without functional changes.
 
+* Dev: Pinned voluptuous package to <0.14 on Python < 3.6.
+
 **Enhancements:**
 
 * Added support for Python 3.12. (issue #796)


### PR DESCRIPTION
No review needed.