### PR TITLE
Fixed 'missing required arguments' in console/cpc upgrade

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -61,6 +61,10 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Dev: Pinned voluptuous package to <0.14 on Python < 3.6.
 
+* Fixed "missing required arguments: b, u, n, d, l, e, _, l, e, v, e, l"
+  error when using the 'zhmc_console' or 'zhmc_cpc' modules with 'state=upgrade'.
+  (issue #834)
+
 **Enhancements:**
 
 * Added support for Python 3.12. (issue #796)

--- a/plugins/modules/zhmc_console.py
+++ b/plugins/modules/zhmc_console.py
@@ -290,7 +290,7 @@ def upgrade(module):
       zhmcclient.Error: Any zhmcclient exception can happen.
     """
 
-    module.fail_on_missing_params('bundle_level')
+    module.fail_on_missing_params(['bundle_level'])
     bundle_level = module.params['bundle_level']
     accept_firmware = module.params['accept_firmware']
     backup_location_type = module.params['backup_location_type']

--- a/plugins/modules/zhmc_cpc.py
+++ b/plugins/modules/zhmc_cpc.py
@@ -731,7 +731,7 @@ def upgrade(module):
       zhmcclient.Error: Any zhmcclient exception can happen.
     """
 
-    module.fail_on_missing_params('bundle_level')
+    module.fail_on_missing_params(['bundle_level'])
     bundle_level = module.params['bundle_level']
     accept_firmware = module.params['accept_firmware']
     cpc_name = module.params['name']


### PR DESCRIPTION
For details, see the commit message.