### PR TITLE
1.7: Fixed AutomationHub import warnings where possible; Added 'make lint'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,6 +281,11 @@ jobs:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
       run: |
         make sanity
+    - name: Run ansible-lint
+      env:
+        PACKAGE_LEVEL: ${{ matrix.package_level }}
+      run: |
+        make lint
     - name: Run unit/function test
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ help:
 	@echo '  dist       - Build the collection distribution archive in: $(dist_dir)'
 	@echo '  check      - Run flake8'
 	@echo '  sanity     - Run Ansible sanity tests (includes pep8, pylint, validate-modules)'
+	@echo '  lint       - dist + run ansible-lint on distribution archive'
 	@echo '  safety     - Run safety on sources'
 	@echo '  check_reqs - Perform missing dependency checks'
 	@echo '  docs       - Build the documentation for all enabled (docs/source/conf.py) versions in: $(doc_build_dir) using remote repo'
@@ -226,7 +227,7 @@ help:
 	@echo '  ansible-playbook playbooks/....'
 
 .PHONY: all
-all: install develop dist safety check sanity check_reqs docs docslocal linkcheck test end2end_mocked
+all: install develop dist safety check sanity lint check_reqs docs docslocal linkcheck test end2end_mocked
 	@echo '$@ done.'
 
 .PHONY: install
@@ -288,6 +289,15 @@ ifeq ($(run_sanity_virtual),true)
 else
 	echo "Skipping ansible sanity test with its own virtual Python env"
 endif
+	@echo '$@ done.'
+
+.PHONY:	lint
+lint: _check_version develop_$(pymn).done $(dist_file)
+	echo 'Running ansible-lint on distribution archive'
+	rm -rf $(dist_dir)/tmp
+	mkdir -p $(dist_dir)/tmp
+	tar -xf $(dist_file) --directory $(dist_dir)/tmp
+	-sh -c "cd $(dist_dir)/tmp; ansible-lint --profile production -f pep8"
 	@echo '$@ done.'
 
 .PHONY: check_reqs

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -54,12 +54,22 @@ coveralls>=3.3.0; python_version >= '3.5'
 # PyYAML is specified in requirements.txt
 
 # ansible-test
-yamllint>=1.25.0
-pathspec>=0.8.0
+yamllint>=1.25.0; python_version == '2.7'
+yamllint>=1.26.3; python_version >= '3.5'
+pathspec>=0.9.0
 # rstcheck 3.5.0 introduced a FutureWarning about Python 3.7 causing ansible sanity check "rstcheck" to fail.
 # ansible sanity check "rstcheck" is used only in ansible <= 2.10.
 rstcheck>=3.3.1,<3.5; python_version >= '3.5' and python_version <= '3.6'  # ansible <= 2.10 (on minimum package levels)
 rstcheck>=3.3.1,<4.0; python_version >= '3.7' and python_version <= '3.9'  # ansible >= 4
+
+# ansible-lint
+# ansible-lint requires yamllint, black
+# ansible-lint 6.14.0 depends on ansible-core>=2.12.0
+ansible-lint>=4.2.0; python_version == '2.7'
+ansible-lint>=4.2.0; python_version == '3.5'
+ansible-lint>=5.4.0; python_version >= '3.6' and python_version <= '3.9'
+ansible-lint>=6.14.0; python_version >= '3.10'
+black>=22.8.0; python_version >= '3.6'
 
 # Safety CI by pyup.io
 # Safety is run only on Python >=3.6
@@ -132,7 +142,7 @@ pylint>=2.6.0,<2.16; python_version >= '3.10'  # pylint 2.15
 astroid>=2.4.0,<2.5; python_version >= '3.5' and python_version <= '3.7'  # astroid 2.4
 astroid>=2.4.0,<2.7; python_version >= '3.8' and python_version <= '3.9'  # astroid 2.6
 astroid>=2.4.0,<2.13; python_version >= '3.10'  # astroid 2.12
-typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
+typed-ast>=1.4.2,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 # used by pylint 2.14 which requires python_version >= '3.7' and is used by us only on py>=3.10
 dill>=0.2; python_version >= '3.10'
 platformdirs>=2.2.0; python_version >= '3.10'

--- a/docs/source/modules/zhmc_cpc.rst
+++ b/docs/source/modules/zhmc_cpc.rst
@@ -202,7 +202,7 @@ Examples
        state: set
        properties:
          acceptable_status:
-          - active
+           - active
          description: "This is CPC {{ my_cpc_name }}"
      register: cpc1
 

--- a/docs/source/modules/zhmc_lpar.rst
+++ b/docs/source/modules/zhmc_lpar.rst
@@ -255,7 +255,8 @@ Examples
        state: inactive
      register: lpar1
 
-   - name: Ensure the LPAR is active (using the default image profile when it needs to be activated), and then set the CP sharing weight to 20
+   - name: "Ensure the LPAR is active (using the default image profile when it needs to be activated),
+            and then set the CP sharing weight to 20"
      zhmc_lpar:
        hmc_host: "{{ my_hmc_host }}"
        hmc_auth: "{{ my_hmc_auth }}"

--- a/docs/source/modules/zhmc_user_role.rst
+++ b/docs/source/modules/zhmc_user_role.rst
@@ -282,13 +282,18 @@ Examples
        properties:
          description: "Example user role 1"
          permissions:
-           - task: "configure-storage-storageadmin"  # Task permission to "configure-storage-storageadmin"
-           - task: "hardware-messages"  # Task permission to the view-only version of "hardware-messages"
+           # Task permission to "configure-storage-storageadmin":
+           - task: "configure-storage-storageadmin"
+           # Task permission to the view-only version of "hardware-messages":
+           - task: "hardware-messages"
              view_only: true
-           - class: cpc        # Object permission to all CPCs
-           - partition: part1  # Object permission to part1 in cpc1
+           # Object permission to all CPCs:
+           - class: cpc
+           # Object permission to part1 in cpc1:
+           - partition: part1
              cpc: cpc1
-           - partition: part2  # Object permission to part2 in cpc2
+           # Object permission to part2 in cpc2:
+           - partition: part2
              cpc: cpc2
      register: rule1
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -79,6 +79,8 @@ build_ignore:
   - .coveragerc
   - .flake8  # only in older branches
   - .travis.yml
+  - .whitesource
+  - .safety-policy.yml
   - CODE_OF_CONDUCT.md
   - CONTRIBUTING.rst  # only in older branches
   - DCO1.1.txt  # only in older branches
@@ -86,6 +88,7 @@ build_ignore:
   - Makefile
   # requirements.txt is intentionally included for dependent install
   - dev-requirements.txt
+  - ansible-constraints.txt
   - minimum-constraints.txt
   - tools
   - docs_local

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 # Keep in sync with lowest ansible version in requirements.txt and minimum-constraints.txt
-requires_ansible: ">=2.9"
+requires_ansible: ">=2.9.27"

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -148,11 +148,13 @@ cryptography==41.0.4; python_version >= '3.7'
 importlib-metadata==0.12; python_version <= '3.7'
 importlib-metadata==1.1.0; python_version >= '3.8'
 packaging==20.5; python_version <= '3.5'
-packaging==21.0; python_version >= '3.6'
-PyYAML==5.3.1
+packaging==21.3; python_version >= '3.6'
+PyYAML==5.3.1; python_version <= '3.5'
+PyYAML==6.0.1; python_version >= '3.6'
 
 python-dateutil==2.8.2
-jsonschema==3.0.1
+jsonschema==3.0.1; python_version <= '3.6'
+jsonschema==4.10.0; python_version >= '3.7'
 urllib3==1.26.18; python_version == '2.7'
 urllib3==1.26.9; python_version == '3.5'
 urllib3==1.26.18; python_version >= '3.6'
@@ -201,9 +203,17 @@ pytest-cov==2.7.0
 coveralls==3.3.0; python_version >= '3.5'
 
 # ansible-test
-yamllint==1.25.0
-pathspec==0.8.0
+yamllint==1.25.0; python_version == '2.7'
+yamllint==1.26.3; python_version >= '3.5'
+pathspec==0.9.0
 rstcheck==3.3.1; python_version <= '3.9'  # ansible <= 2.10 (on minimum package levels)
+
+# ansible-lint
+ansible-lint==4.2.0; python_version == '2.7'
+ansible-lint==4.2.0; python_version == '3.5'
+ansible-lint==5.4.0; python_version >= '3.6' and python_version <= '3.9'
+ansible-lint==6.14.0; python_version >= '3.10'
+black==22.8.0; python_version >= '3.6'
 
 # Safety CI by pyup.io
 # Safety is run only on Python >=3.6
@@ -240,7 +250,7 @@ sphinx-rtd-theme==1.0.0; python_version >= '3.6'
 # Pylint is run in ansible sanity test which is run only on Python>=3.7
 pylint==2.6.0; python_version >= '3.5'
 astroid==2.4.0; python_version >= '3.5'
-typed-ast==1.4.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
+typed-ast==1.4.2; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 # used by pylint 2.14 which requires python_version >= '3.7' and is used by us only on py>=3.10
 dill==0.2; python_version >= '3.10'
 platformdirs==2.2.0; python_version >= '3.10'
@@ -284,7 +294,11 @@ contextlib2==0.6.0
 custom-inherit==2.2.2
 docopt==0.6.2
 enum34==1.1.6; python_version < "3.4"
-filelock==3.0.0
+filelock==3.2.0; python_version == '2.7'
+filelock==3.2.0; python_version == '3.4'
+filelock==3.2.0; python_version == '3.5'
+filelock==3.3.0; python_version >= '3.6' and python_version <= '3.11'
+filelock==3.11.0; python_version >= '3.12'
 future==0.18.3
 futures==3.3.0; python_version < "3.2"
 gitdb2==2.0.0; python_version == '3.6'
@@ -329,7 +343,7 @@ toml==0.10.0
 traceback2==1.4.0
 traitlets==4.3.1
 typing==3.6.1; python_version < '3.5'
-typing-extensions==3.7.4.3  # Used in some combinations of Python version and package level
+typing-extensions==3.10.0.0  # Used in some combinations of Python version and package level
 wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==1.2.6

--- a/plugins/modules/zhmc_cpc.py
+++ b/plugins/modules/zhmc_cpc.py
@@ -219,7 +219,7 @@ EXAMPLES = """
     state: set
     properties:
       acceptable_status:
-       - active
+        - active
       description: "This is CPC {{ my_cpc_name }}"
   register: cpc1
 

--- a/plugins/modules/zhmc_lpar.py
+++ b/plugins/modules/zhmc_lpar.py
@@ -310,7 +310,8 @@ EXAMPLES = """
     state: inactive
   register: lpar1
 
-- name: Ensure the LPAR is active (using the default image profile when it needs to be activated), and then set the CP sharing weight to 20
+- name: "Ensure the LPAR is active (using the default image profile when it needs to be activated),
+         and then set the CP sharing weight to 20"
   zhmc_lpar:
     hmc_host: "{{ my_hmc_host }}"
     hmc_auth: "{{ my_hmc_auth }}"

--- a/plugins/modules/zhmc_user_role.py
+++ b/plugins/modules/zhmc_user_role.py
@@ -273,13 +273,18 @@ EXAMPLES = """
     properties:
       description: "Example user role 1"
       permissions:
-        - task: "configure-storage-storageadmin"  # Task permission to "configure-storage-storageadmin"
-        - task: "hardware-messages"  # Task permission to the view-only version of "hardware-messages"
+        # Task permission to "configure-storage-storageadmin":
+        - task: "configure-storage-storageadmin"
+        # Task permission to the view-only version of "hardware-messages":
+        - task: "hardware-messages"
           view_only: true
-        - class: cpc        # Object permission to all CPCs
-        - partition: part1  # Object permission to part1 in cpc1
+        # Object permission to all CPCs:
+        - class: cpc
+        # Object permission to part1 in cpc1:
+        - partition: part1
           cpc: cpc1
-        - partition: part2  # Object permission to part2 in cpc2
+        # Object permission to part2 in cpc2:
+        - partition: part2
           cpc: cpc2
   register: rule1
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ importlib-metadata>=1.1.0; python_version >= '3.8'
 # packaging>=20.5 is needed by pip-check-reqs 2.4.3 but it requires only packaging>=16.0
 # packaging 21.0 removed support for Python <3.6
 packaging>=20.5; python_version <= '3.5'
-packaging>=21.0; python_version >= '3.6'
+packaging>=21.3; python_version >= '3.6'
 
 # PyYAML 5.3 fixed narrow build error on Python 2.7
 # PyYAML 5.3.1 addressed issue 38100 reported by safety
@@ -91,11 +91,11 @@ packaging>=21.0; python_version >= '3.6'
 # PyYAML 5.4 and 6.0.0 fails install since Cython 3 was released, see issue
 #   https://github.com/yaml/pyyaml/issues/724.
 PyYAML>=5.3.1; python_version <= '3.5'
-PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version >= '3.6' and python_version <= '3.11'
-PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
+PyYAML>=6.0.1; python_version >= '3.6'
 
 python-dateutil>=2.8.2
-jsonschema>=3.0.1,!=4.0.0,!=4.18.1
+jsonschema>=3.0.1,!=4.0.0,!=4.18.1; python_version <= '3.6'
+jsonschema>=4.10.0,!=4.18.1; python_version >= '3.7'
 # urllib3 1.26.10 removed support for py35
 urllib3>=1.26.18; python_version == '2.7'
 urllib3>=1.26.9; python_version == '3.5'


### PR DESCRIPTION
Rolls back PR #839 into 1.7.2.