### PR TITLE
1.7: Added upgrade_timeout parameter to zhmc_console and zhmc_cpc modules …

### DIFF
--- a/docs/source/modules/zhmc_console.rst
+++ b/docs/source/modules/zhmc_console.rst
@@ -105,6 +105,14 @@ bundle_level
   | **type**: str
 
 
+upgrade_timeout
+  Timeout in seconds for waiting for completion of upgrade (e.g. 3600)
+
+  | **required**: False
+  | **type**: int
+  | **default**: 3600
+
+
 backup_location_type
   Type of backup location for the HMC backup that is performed:
 
@@ -161,6 +169,7 @@ Examples
        hmc_auth: "{{ my_hmc_auth }}"
        state: upgrade
        bundle_level: "H71"
+       upgrade_timeout: 3600
      register: hmc1
 
 

--- a/docs/source/modules/zhmc_cpc.rst
+++ b/docs/source/modules/zhmc_cpc.rst
@@ -143,6 +143,14 @@ bundle_level
   | **type**: str
 
 
+upgrade_timeout
+  Timeout in seconds for waiting for completion of upgrade (e.g. 10800)
+
+  | **required**: False
+  | **type**: int
+  | **default**: 10800
+
+
 accept_firmware
   Accept the previous bundle level before installing the new level.
 
@@ -213,6 +221,7 @@ Examples
        name: "{{ my_cpc_name }}"
        state: upgrade
        bundle_level: "S71"
+       upgrade_timeout: 10800
      register: cpc1
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -35,6 +35,8 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Enhancements:**
 
+* Added upgrade_timeout parameter to zhmc_console and zhmc_cpc modules.
+
 **Cleanup:**
 
 **Known issues:**

--- a/plugins/modules/zhmc_console.py
+++ b/plugins/modules/zhmc_console.py
@@ -114,6 +114,12 @@ options:
     type: str
     required: false
     default: null
+  upgrade_timeout:
+    description:
+      - "Timeout in seconds for waiting for completion of upgrade (e.g. 3600)"
+    type: int
+    required: false
+    default: 3600
   backup_location_type:
     description:
       - "Type of backup location for the HMC backup that is performed:"
@@ -166,6 +172,7 @@ EXAMPLES = """
     hmc_auth: "{{ my_hmc_auth }}"
     state: upgrade
     bundle_level: "H71"
+    upgrade_timeout: 3600
   register: hmc1
 """
 
@@ -292,6 +299,7 @@ def upgrade(module):
 
     module.fail_on_missing_params(['bundle_level'])
     bundle_level = module.params['bundle_level']
+    upgrade_timeout = module.params['upgrade_timeout']
     accept_firmware = module.params['accept_firmware']
     backup_location_type = module.params['backup_location_type']
 
@@ -320,7 +328,7 @@ def upgrade(module):
                     accept_firmware=accept_firmware,
                     backup_location_type=backup_location_type,
                     wait_for_completion=True,
-                    operation_timeout=None)
+                    operation_timeout=upgrade_timeout)
                 changed = True
             except zhmcclient.HTTPError as exc:
                 if exc.http_status == 400 and exc.reason == 356:
@@ -367,6 +375,7 @@ def main():
         hmc_auth=hmc_auth_parameter(),
         state=dict(required=True, type='str', choices=['facts', 'upgrade']),
         bundle_level=dict(required=False, type='str', default=None),
+        upgrade_timeout=dict(required=False, type='int', default=3600),
         backup_location_type=dict(
             required=False, type='str', choices=['ftp', 'usb'], default='usb'),
         accept_firmware=dict(required=False, type='bool', default=True),

--- a/plugins/modules/zhmc_cpc.py
+++ b/plugins/modules/zhmc_cpc.py
@@ -161,6 +161,12 @@ options:
     type: str
     required: false
     default: null
+  upgrade_timeout:
+    description:
+      - "Timeout in seconds for waiting for completion of upgrade (e.g. 10800)"
+    type: int
+    required: false
+    default: 10800
   accept_firmware:
     description:
       - "Accept the previous bundle level before installing the new level."
@@ -230,6 +236,7 @@ EXAMPLES = """
     name: "{{ my_cpc_name }}"
     state: upgrade
     bundle_level: "S71"
+    upgrade_timeout: 10800
   register: cpc1
 
 """
@@ -733,6 +740,7 @@ def upgrade(module):
 
     module.fail_on_missing_params(['bundle_level'])
     bundle_level = module.params['bundle_level']
+    upgrade_timeout = module.params['upgrade_timeout']
     accept_firmware = module.params['accept_firmware']
     cpc_name = module.params['name']
 
@@ -759,7 +767,7 @@ def upgrade(module):
                     bundle_level=bundle_level,
                     accept_firmware=accept_firmware,
                     wait_for_completion=True,
-                    operation_timeout=None)
+                    operation_timeout=upgrade_timeout)
                 changed = True
             except zhmcclient.HTTPError as exc:
                 if exc.http_status == 400 and exc.reason == 356:
@@ -813,6 +821,7 @@ def main():
         activation_profile_name=dict(required=False, type='str', default=None),
         properties=dict(required=False, type='dict', default=None),
         bundle_level=dict(required=False, type='str', default=None),
+        upgrade_timeout=dict(required=False, type='int', default=10800),
         accept_firmware=dict(required=False, type='bool', default=True),
         log_file=dict(required=False, type='str', default=None),
         _faked_session=dict(required=False, type='raw'),


### PR DESCRIPTION
Rolls back PR #843 into 1.7.3.