### PR TITLE
1.7: Fixed zhmc_adapter_list and zhmc_partition_list on HMC 2.14 and 2.15

### DIFF
--- a/docs/source/modules/zhmc_adapter_list.rst
+++ b/docs/source/modules/zhmc_adapter_list.rst
@@ -19,12 +19,13 @@ Synopsis
 - List adapters on a specific CPC (Z system) or on all managed CPCs.
 - CPCs in classic mode are ignored (i.e. do not lead to a failure).
 - Adapters for which the user has no object access permission are ignored (i.e. do not lead to a failure).
+- On HMCs with version 2.16.0 or higher, the "List Permitted Adapters" operation is used by this module. Otherwise, the managed CPCs are listed and then the adapters on each desired CPC or CPCs are listed. This improves the execution time of the module on newer HMCs but does not affect the module result data.
 
 
 Requirements
 ------------
 
-- The HMC userid must have object-access permissions to these objects: Target adapters, CPCs of target adapters (only for z13 and older).
+- The HMC userid must have object-access permissions to these objects: Target adapters, CPCs of target adapters (CPC access is only needed for HMC version 2.15 and older).
 
 
 
@@ -135,7 +136,7 @@ additional_properties
 
   The property names are specified with underscores instead of hyphens.
 
-  Note: The additional properties are passed to the 'List Adapters of a CPC' HMC operation, and do not cause a loop of 'Get Adapter Properties' operations to be executed.
+  On HMCs with an API version below 4.10 (= HMC version 2.16.0 with some post-GA updates), all properties of each adapter will be returned if this parameter is specified, but you should not rely on that.
 
   | **required**: False
   | **type**: list

--- a/docs/source/modules/zhmc_lpar_list.rst
+++ b/docs/source/modules/zhmc_lpar_list.rst
@@ -19,7 +19,7 @@ Synopsis
 - List LPARs on a specific CPC (Z system) or on all managed CPCs.
 - CPCs in DPM mode are ignored (i.e. do not lead to a failure).
 - LPARs for which the user has no object access permission are ignored (i.e. do not lead to a failure).
-- The module works for any HMC version. On HMCs with version 2.14.0 or higher, the "List Permitted Logical Partitions" opration is used. On older HMCs, the managed CPCs are listed and the LPARs on each CPC.
+- On HMCs with version 2.14.0 or higher, the "List Permitted Logical Partitions" operation is used by this module. Otherwise, the managed CPCs are listed and then the LPARs on each desired CPC or CPCs are listed. This improves the execution time of the module on newer HMCs but does not affect the module result data.
 
 
 Requirements

--- a/docs/source/modules/zhmc_partition_list.rst
+++ b/docs/source/modules/zhmc_partition_list.rst
@@ -19,7 +19,7 @@ Synopsis
 - List partitions on a specific CPC (Z system) or on all managed CPCs.
 - CPCs in classic mode are ignored (i.e. do not lead to a failure).
 - Partitions for which the user has no object access permission are ignored (i.e. do not lead to a failure).
-- The module works for any HMC version. On HMCs with version 2.14.0 or higher, the "List Permitted Partitions" opration is used. On older HMCs, the managed CPCs are listed and the partitions on each CPC.
+- On HMCs with version 2.14.0 or higher and when the \ :literal:`additional\_properties`\  module parameter is not used, the "List Permitted Partitions" operation is used by this module. Otherwise, the managed CPCs are listed and then the partitions on each desired CPC or CPCs are listed. This improves the execution time of the module on newer HMCs but does not affect the module result data.
 
 
 Requirements
@@ -101,7 +101,7 @@ additional_properties
 
   The property names are specified with underscores instead of hyphens.
 
-  Note: The additional properties are passed to the 'List Partitions of a CPC' HMC operation, and do not cause a loop of 'Get Partition Properties' operations to be executed.
+  On HMCs with an HMC version below 2.14.0, all properties of each partition will be returned if this parameter is specified, but you should not rely on that.
 
   | **required**: False
   | **type**: list

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -43,11 +43,34 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
   and 'virtual-storage-resources' returned by the module will be empty arrays
   for non-FCP storage groups. (e.g. NVMe). (issue #864)
 
+* Fixed that on HMC versions 2.14 and 2.15, the zhmc_adapter_list module
+  failed because it tried to use the "List Permitted Adapters" operation
+  that was added in HMC version 2.16 (actually API version 4.10).
+  (issue #850)
+
+* Fixed that on HMC versions 2.14 and 2.15, the zhmc_partition_list module
+  failed because it tried to use the 'additional-properties' query parameter
+  that was added in HMC version 2.16 (actually API version 4.10).
+  (issue #850)
+
 **Enhancements:**
 
 * Added a new make target 'make ansible_lint' which invokes ansible-lint.
   Fixed some of the warnings reported by ansible-lint.
   (related to issue #784)
+
+* In the 'zhmc_adapter_list' module, improved the use of the "Permitted
+  Adapters" operation so that it is now also used when the 'additional_properties'
+  module parameter is used and the HMC API version is 4.10 or higher.
+  (related to issue #850)
+
+* Docs: In the 'zhmc_lpar_list' module, clarified that the use of the "List
+  Permitted Logical Partitions" operation does not affect the module result
+  data. (related to issue #850)
+
+* Docs: In the 'zhmc_partition_list' module, clarified that the use of the "List
+  Permitted Partitions" operation does not affect the module result data.
+  (related to issue #850)
 
 **Cleanup:**
 

--- a/tests/end2end/test_zhmc_partition_list.py
+++ b/tests/end2end/test_zhmc_partition_list.py
@@ -170,17 +170,26 @@ def test_zhmc_partition_list(
         hmc_version_info = [int(x) for x in hmc_version.split('.')]
         if hmc_version_info < [2, 14, 0] or additional_properties:
             # List the LPARs in the traditional way
+            if hmc_version_info < [2, 16, 0] and additional_properties:
+                # Get full properties instead of specific additional properties
+                # since "List Partitions of a CPC" does not support
+                # additional-properties on these HMC versions.
+                _additional_properties = None
+                _full_properties = True
+            else:
+                _additional_properties = additional_properties
+                _full_properties = full_properties
             if with_cpc:
                 exp_partitions = cpc.partitions.list(
-                    additional_properties=additional_properties,
-                    full_properties=full_properties)
+                    additional_properties=_additional_properties,
+                    full_properties=_full_properties)
             else:
                 cpcs_ = client.cpcs.list()
                 exp_partitions = []
                 for cpc_ in cpcs_:
                     _partitions = cpc_.partitions.list(
-                        additional_properties=additional_properties,
-                        full_properties=full_properties)
+                        additional_properties=_additional_properties,
+                        full_properties=_full_properties)
                     exp_partitions.extend(_partitions)
         else:
             # List the LPARs using the new operation


### PR DESCRIPTION
Rolls back PR #854 into 1.7.4.