### PR TITLE
Support for redundant HMCs

### DIFF
--- a/docs/source/modules/zhmc_adapter.rst
+++ b/docs/source/modules/zhmc_adapter.rst
@@ -36,10 +36,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_adapter_list.rst
+++ b/docs/source/modules/zhmc_adapter_list.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_console.rst
+++ b/docs/source/modules/zhmc_console.rst
@@ -34,10 +34,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_cpc.rst
+++ b/docs/source/modules/zhmc_cpc.rst
@@ -37,10 +37,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_cpc_list.rst
+++ b/docs/source/modules/zhmc_cpc_list.rst
@@ -32,10 +32,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_crypto_attachment.rst
+++ b/docs/source/modules/zhmc_crypto_attachment.rst
@@ -36,10 +36,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_hba.rst
+++ b/docs/source/modules/zhmc_hba.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_ldap_server_definition.rst
+++ b/docs/source/modules/zhmc_ldap_server_definition.rst
@@ -33,10 +33,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_ldap_server_definition_list.rst
+++ b/docs/source/modules/zhmc_ldap_server_definition_list.rst
@@ -32,10 +32,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_lpar.rst
+++ b/docs/source/modules/zhmc_lpar.rst
@@ -39,10 +39,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_lpar_list.rst
+++ b/docs/source/modules/zhmc_lpar_list.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_lpar_messages.rst
+++ b/docs/source/modules/zhmc_lpar_messages.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_nic.rst
+++ b/docs/source/modules/zhmc_nic.rst
@@ -36,10 +36,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_nic_list.rst
+++ b/docs/source/modules/zhmc_nic_list.rst
@@ -32,10 +32,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_partition.rst
+++ b/docs/source/modules/zhmc_partition.rst
@@ -36,10 +36,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_partition_list.rst
+++ b/docs/source/modules/zhmc_partition_list.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_partition_messages.rst
+++ b/docs/source/modules/zhmc_partition_messages.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_password_rule.rst
+++ b/docs/source/modules/zhmc_password_rule.rst
@@ -33,10 +33,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_password_rule_list.rst
+++ b/docs/source/modules/zhmc_password_rule_list.rst
@@ -32,10 +32,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_session.rst
+++ b/docs/source/modules/zhmc_session.rst
@@ -30,10 +30,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth
@@ -124,7 +126,7 @@ Examples
 
    - name: Create an HMC session
      zhmc_session:
-       hmc_host: "{{ my_hmc_host }}"
+       hmc_host: "{{ my_hmc_host }}"  # Single HMC or list of redundant HMCs
        hmc_auth:
          userid: "{{ my_hmc_userid }}"
          password: "{{ my_hmc_password }}"
@@ -136,13 +138,13 @@ Examples
 
    - name: Example task using the previously created HMC session
      zhmc_cpc_list:
-       hmc_host: "{{ my_hmc_host }}"
+       hmc_host: "{{ session.hmc_host }}"  # The actually used HMC
        hmc_auth: "{{ session.hmc_auth }}"
      register: cpc_list
 
    - name: Delete the HMC session
      zhmc_session:
-       hmc_host: "{{ my_hmc_host }}"
+       hmc_host: "{{ session.hmc_host }}"  # The actually used HMC
        hmc_auth: "{{ session.hmc_auth }}"
        action: delete
      register: session    # Just for safety in case it is used after that
@@ -170,6 +172,14 @@ msg
   An error message that describes the failure.
 
   | **returned**: failure
+  | **type**: str
+
+hmc_host
+  The hostname or IP address of the HMC that was actually used for the session creation, for \ :literal:`action=create`\ . This value must be specified as 'hmc\_host' for \ :literal:`action=delete`\ .
+
+  For \ :literal:`action=delete`\ , returns the null value.
+
+  | **returned**: success
   | **type**: str
 
 hmc_auth

--- a/docs/source/modules/zhmc_storage_group.rst
+++ b/docs/source/modules/zhmc_storage_group.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_storage_group_attachment.rst
+++ b/docs/source/modules/zhmc_storage_group_attachment.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_storage_volume.rst
+++ b/docs/source/modules/zhmc_storage_volume.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_user.rst
+++ b/docs/source/modules/zhmc_user.rst
@@ -34,10 +34,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_user_list.rst
+++ b/docs/source/modules/zhmc_user_list.rst
@@ -32,10 +32,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_user_role.rst
+++ b/docs/source/modules/zhmc_user_role.rst
@@ -33,10 +33,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_user_role_list.rst
+++ b/docs/source/modules/zhmc_user_role_list.rst
@@ -32,10 +32,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/modules/zhmc_virtual_function.rst
+++ b/docs/source/modules/zhmc_virtual_function.rst
@@ -35,10 +35,12 @@ Parameters
 
 
 hmc_host
-  The hostname or IP address of the HMC.
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
 
   | **required**: True
-  | **type**: str
+  | **type**: raw
 
 
 hmc_auth

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -151,6 +151,20 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
   the description of how to release a version in the development
   documentation. (issue #631)
 
+* Added support for redundant HMC hosts. The 'hmc_host' module input parameter
+  can now be specified as a single HMC as before, or as a list of redundant
+  HMCs. The HMC list can be specified as a list type or as a Python string
+  representation of a list in order to accomodate Ansible expressions.
+  (issue #849)
+
+* The 'zhmc_session' module now has an additional module return parameter
+  'hmc_host' which for 'action=create' contains the actually used HMC.
+  If you use that module and now start specifying redundant HMCs for
+  'action=create', you need to also change the 'hmc_host' parameter of all
+  ibm_zhmc modules that use that session including the 'zhmc_session' module
+  with 'action=delete', to specify the so returned HMC. If you use that
+  module with a single HMC, no change is needed. (related to issue #849)
+
 **Cleanup:**
 
 * Removed documentation and test files (except sanity test ignore files) from

--- a/plugins/modules/zhmc_adapter.py
+++ b/plugins/modules/zhmc_adapter.py
@@ -53,8 +53,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -342,7 +347,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, eq_hex, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -921,7 +926,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         name=dict(required=True, type='str'),
@@ -951,6 +956,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_adapter_list.py
+++ b/plugins/modules/zhmc_adapter_list.py
@@ -54,8 +54,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -272,7 +277,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, \
-    missing_required_lib  # noqa: E402
+    missing_required_lib, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -432,7 +437,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=False, type='str', default=None),
         name=dict(required=False, type='str', default=None),
@@ -463,6 +468,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_console.py
+++ b/plugins/modules/zhmc_console.py
@@ -46,8 +46,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -229,7 +234,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -371,7 +376,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         state=dict(required=True, type='str', choices=['facts', 'upgrade']),
         bundle_level=dict(required=False, type='str', default=None),
@@ -401,6 +406,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_cpc.py
+++ b/plugins/modules/zhmc_cpc.py
@@ -54,8 +54,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -409,7 +414,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, StatusError, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, pull_properties  # noqa: E402
+    common_fail_on_import_errors, pull_properties, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -853,7 +858,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         name=dict(required=True, type='str'),
         state=dict(required=True, type='str',
@@ -887,6 +892,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_cpc_list.py
+++ b/plugins/modules/zhmc_cpc_list.py
@@ -44,8 +44,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -215,7 +220,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -293,7 +298,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         include_unmanaged_cpcs=dict(required=False, type='bool', default=False),
         full_properties=dict(required=False, type='bool', default=False),
@@ -319,6 +324,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_crypto_attachment.py
+++ b/plugins/modules/zhmc_crypto_attachment.py
@@ -53,8 +53,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -367,7 +372,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 
 try:
@@ -1052,7 +1057,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         partition_name=dict(required=True, type='str'),
@@ -1089,6 +1094,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_ldap_server_definition.py
+++ b/plugins/modules/zhmc_ldap_server_definition.py
@@ -44,8 +44,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -236,7 +241,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -628,7 +633,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         name=dict(required=True, type='str'),
         state=dict(required=True, type='str',
@@ -656,6 +661,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_ldap_server_definition_list.py
+++ b/plugins/modules/zhmc_ldap_server_definition_list.py
@@ -42,8 +42,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -156,7 +161,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -212,7 +217,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         log_file=dict(required=False, type='str', default=None),
         _faked_session=dict(required=False, type='raw'),
@@ -236,6 +241,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_lpar.py
+++ b/plugins/modules/zhmc_lpar.py
@@ -54,8 +54,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -592,7 +597,7 @@ from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, StatusError, \
     ensure_lpar_inactive, ensure_lpar_active, ensure_lpar_loaded, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, pull_properties  # noqa: E402
+    common_fail_on_import_errors, pull_properties, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -1228,7 +1233,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         name=dict(required=True, type='str'),
@@ -1273,6 +1278,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_lpar_list.py
+++ b/plugins/modules/zhmc_lpar_list.py
@@ -51,8 +51,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -213,7 +218,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -332,7 +337,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=False, type='str', default=None),
         full_properties=dict(required=False, type='bool', default=False),
@@ -358,6 +363,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_lpar_messages.py
+++ b/plugins/modules/zhmc_lpar_messages.py
@@ -47,8 +47,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -280,7 +285,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -403,7 +408,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         name=dict(required=True, type='str'),
@@ -438,6 +443,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_nic.py
+++ b/plugins/modules/zhmc_nic.py
@@ -54,8 +54,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -272,7 +277,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, wait_for_transition_completion, \
     eq_hex, eq_mac, to_unicode, process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -712,7 +717,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         partition_name=dict(required=True, type='str'),
@@ -742,6 +747,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_nic_list.py
+++ b/plugins/modules/zhmc_nic_list.py
@@ -45,8 +45,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -189,7 +194,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -264,7 +269,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         partition_name=dict(required=True, type='str'),
@@ -291,6 +296,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -61,8 +61,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -602,7 +607,7 @@ from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, StatusError, stop_partition, \
     start_partition, wait_for_transition_completion, eq_hex, to_unicode, \
     process_normal_property, missing_required_lib, ImageError, \
-    common_fail_on_import_errors, pull_properties  # noqa: E402
+    common_fail_on_import_errors, pull_properties, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -2172,7 +2177,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         name=dict(required=True, type='str'),
@@ -2210,6 +2215,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_partition_list.py
+++ b/plugins/modules/zhmc_partition_list.py
@@ -54,8 +54,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -227,7 +232,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -376,7 +381,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=False, type='str', default=None),
         additional_properties=dict(
@@ -404,6 +409,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_partition_messages.py
+++ b/plugins/modules/zhmc_partition_messages.py
@@ -47,8 +47,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -255,7 +260,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -371,7 +376,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         name=dict(required=True, type='str'),
@@ -403,6 +408,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_password_rule.py
+++ b/plugins/modules/zhmc_password_rule.py
@@ -44,8 +44,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -256,7 +261,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -632,7 +637,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         name=dict(required=True, type='str'),
         state=dict(required=True, type='str',
@@ -660,6 +665,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_password_rule_list.py
+++ b/plugins/modules/zhmc_password_rule_list.py
@@ -43,8 +43,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -169,7 +174,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -230,7 +235,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         full_properties=dict(required=False, type='bool', default=False),
         log_file=dict(required=False, type='str', default=None),
@@ -255,6 +260,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_storage_group.py
+++ b/plugins/modules/zhmc_storage_group.py
@@ -58,8 +58,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -568,7 +573,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -1092,7 +1097,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         name=dict(required=True, type='str'),
@@ -1124,6 +1129,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_storage_group_attachment.py
+++ b/plugins/modules/zhmc_storage_group_attachment.py
@@ -56,8 +56,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -220,7 +225,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -414,7 +419,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         storage_group_name=dict(required=True, type='str'),
@@ -443,6 +448,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_storage_volume.py
+++ b/plugins/modules/zhmc_storage_volume.py
@@ -57,8 +57,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -271,7 +276,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, eq_hex, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -668,7 +673,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         storage_group_name=dict(required=True, type='str'),
@@ -698,6 +703,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_user.py
+++ b/plugins/modules/zhmc_user.py
@@ -48,8 +48,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -369,7 +374,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -1116,7 +1121,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         name=dict(required=True, type='str'),
         state=dict(required=True, type='str',
@@ -1145,6 +1150,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_user_list.py
+++ b/plugins/modules/zhmc_user_list.py
@@ -42,8 +42,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -174,7 +179,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -235,7 +240,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         full_properties=dict(required=False, type='bool', default=False),
         log_file=dict(required=False, type='str', default=None),
@@ -260,6 +265,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_user_role.py
+++ b/plugins/modules/zhmc_user_role.py
@@ -44,8 +44,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -444,7 +449,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -1283,7 +1288,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         name=dict(required=True, type='str'),
         state=dict(required=True, type='str',
@@ -1311,6 +1316,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_user_role_list.py
+++ b/plugins/modules/zhmc_user_role_list.py
@@ -43,8 +43,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -174,7 +179,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -235,7 +240,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         full_properties=dict(required=False, type='bool', default=False),
         log_file=dict(required=False, type='str', default=None),
@@ -260,6 +265,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/plugins/modules/zhmc_virtual_function.py
+++ b/plugins/modules/zhmc_virtual_function.py
@@ -53,8 +53,13 @@ requirements:
 options:
   hmc_host:
     description:
-      - The hostname or IP address of the HMC.
-    type: str
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
     required: true
   hmc_auth:
     description:
@@ -234,7 +239,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, wait_for_transition_completion, \
     eq_hex, to_unicode, process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
 
 try:
     import requests.packages.urllib3
@@ -564,7 +569,7 @@ def main():
     # The following definition of module input parameters must match the
     # description of the options in the DOCUMENTATION string.
     argument_spec = dict(
-        hmc_host=dict(required=True, type='str'),
+        hmc_host=dict(required=True, type='raw'),
         hmc_auth=hmc_auth_parameter(),
         cpc_name=dict(required=True, type='str'),
         partition_name=dict(required=True, type='str'),
@@ -594,6 +599,8 @@ def main():
 
     log_file = module.params['log_file']
     log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
     _params = dict(module.params)
     del _params['hmc_auth']

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the 'module_utils.common' Python module.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import pytest
+
+from plugins.module_utils import common
+
+
+COMMON_PARSE_HMC_HOST_TESTCASES = [
+    # Testcases for test_partition_create_check_mode_partition()
+    # The list items are tuples with the following items:
+    # - desc (string): description of the testcase.
+    # - in_hmc_host (str or list of str): Input hmc_host
+    # - exp_hmc_host (str): Expected hmc_host
+    # - exp_exc_type: Expected exception type, or None for no exc. expected.
+    # - exp_exc_pattern: Expected exception message pattern, or None for no
+    #   exception expected.
+
+    (
+        "hmc_host parameter as IP address string",
+        '10.11.12.13',
+        '10.11.12.13',
+        None,
+        None,
+    ),
+    (
+        "hmc_host parameter as hostname string",
+        'myhmc',
+        'myhmc',
+        None,
+        None,
+    ),
+
+    (
+        "hmc_host parameter as list with one IP address string",
+        ['10.11.12.13'],
+        ['10.11.12.13'],
+        None,
+        None,
+    ),
+    (
+        "hmc_host parameter as list with one hostname string",
+        ['myhmc'],
+        ['myhmc'],
+        None,
+        None,
+    ),
+    (
+        "hmc_host parameter as list with two items",
+        ['10.11.12.13', 'myhmc'],
+        ['10.11.12.13', 'myhmc'],
+        None,
+        None,
+    ),
+
+    (
+        "hmc_host parameter as stringified list with one IP address string",
+        "['10.11.12.13']",
+        ['10.11.12.13'],
+        None,
+        None,
+    ),
+    (
+        "hmc_host parameter as stringified list with one hostname string",
+        "['myhmc']",
+        ['myhmc'],
+        None,
+        None,
+    ),
+    (
+        "hmc_host parameter as stringified list with two items",
+        "['10.11.12.13', 'myhmc']",
+        ['10.11.12.13', 'myhmc'],
+        None,
+        None,
+    ),
+    (
+        "hmc_host parameter as stringified list with two items - no space",
+        "['10.11.12.13','myhmc']",
+        ['10.11.12.13', 'myhmc'],
+        None,
+        None,
+    ),
+    (
+        "hmc_host parameter as stringified list with two items - more spaces",
+        "[ '10.11.12.13',  'myhmc' ]",
+        ['10.11.12.13', 'myhmc'],
+        None,
+        None,
+    ),
+    (
+        "hmc_host parameter as stringified list with two items - diff. quotes",
+        '["10.11.12.13", \'myhmc\']',
+        ['10.11.12.13', 'myhmc'],
+        None,
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, in_hmc_host, exp_hmc_host, exp_exc_type, exp_exc_pattern",
+    COMMON_PARSE_HMC_HOST_TESTCASES)
+def test_common_parse_hmc_host(
+        desc, in_hmc_host, exp_hmc_host, exp_exc_type, exp_exc_pattern):
+    """
+    Test the parse_hmc_host() function.
+    """
+
+    if exp_exc_type:
+        with pytest.raises(exp_exc_type) as exc_info:
+
+            # The code to be tested
+            common.parse_hmc_host(in_hmc_host)
+
+        exc_msg = str(exc_info.value)
+        if exp_exc_pattern:
+            assert re.match(exp_exc_pattern, exc_msg)
+
+    else:
+
+        # The code to be tested
+        hmc_host = common.parse_hmc_host(in_hmc_host)
+
+        assert hmc_host == exp_hmc_host

--- a/tests/unit/test_hba.py
+++ b/tests/unit/test_hba.py
@@ -79,7 +79,7 @@ class TestZhmcHbaMain(object):
 
         # Assert call to AnsibleModule()
         expected_argument_spec = dict(
-            hmc_host=dict(required=True, type='str'),
+            hmc_host=dict(required=True, type='raw'),
             hmc_auth=dict(
                 required=True,
                 type='dict',
@@ -87,10 +87,10 @@ class TestZhmcHbaMain(object):
                     userid=dict(required=False, type='str', default=None),
                     password=dict(required=False, type='str', default=None,
                                   no_log=True),
-                    ca_certs=dict(required=False, type='str', default=None),
-                    verify=dict(required=False, type='bool', default=True),
                     session_id=dict(required=False, type='str', default=None,
                                     no_log=True),
+                    ca_certs=dict(required=False, type='str', default=None),
+                    verify=dict(required=False, type='bool', default=True),
                 ),
             ),
             cpc_name=dict(required=True, type='str'),

--- a/tests/unit/test_nic.py
+++ b/tests/unit/test_nic.py
@@ -79,7 +79,7 @@ class TestZhmcNicMain(object):
 
         # Assert call to AnsibleModule()
         expected_argument_spec = dict(
-            hmc_host=dict(required=True, type='str'),
+            hmc_host=dict(required=True, type='raw'),
             hmc_auth=dict(
                 required=True,
                 type='dict',
@@ -87,10 +87,10 @@ class TestZhmcNicMain(object):
                     userid=dict(required=False, type='str', default=None),
                     password=dict(required=False, type='str', default=None,
                                   no_log=True),
-                    ca_certs=dict(required=False, type='str', default=None),
-                    verify=dict(required=False, type='bool', default=True),
                     session_id=dict(required=False, type='str', default=None,
                                     no_log=True),
+                    ca_certs=dict(required=False, type='str', default=None),
+                    verify=dict(required=False, type='bool', default=True),
                 ),
             ),
             cpc_name=dict(required=True, type='str'),

--- a/tests/unit/test_partition.py
+++ b/tests/unit/test_partition.py
@@ -88,7 +88,7 @@ class TestZhmcPartitionMain(unittest.TestCase):
 
         # Assert call to AnsibleModule()
         expected_argument_spec = dict(
-            hmc_host=dict(required=True, type='str'),
+            hmc_host=dict(required=True, type='raw'),
             hmc_auth=dict(
                 required=True,
                 type='dict',

--- a/tests/unit/test_virtual_function.py
+++ b/tests/unit/test_virtual_function.py
@@ -79,7 +79,7 @@ class TestZhmcVirtualFunctionMain(object):
 
         # Assert call to AnsibleModule()
         expected_argument_spec = dict(
-            hmc_host=dict(required=True, type='str'),
+            hmc_host=dict(required=True, type='raw'),
             hmc_auth=dict(
                 required=True,
                 type='dict',
@@ -87,10 +87,10 @@ class TestZhmcVirtualFunctionMain(object):
                     userid=dict(required=False, type='str', default=None),
                     password=dict(required=False, type='str', default=None,
                                   no_log=True),
-                    ca_certs=dict(required=False, type='str', default=None),
-                    verify=dict(required=False, type='bool', default=True),
                     session_id=dict(required=False, type='str', default=None,
                                     no_log=True),
+                    ca_certs=dict(required=False, type='str', default=None),
+                    verify=dict(required=False, type='bool', default=True),
                 ),
             ),
             cpc_name=dict(required=True, type='str'),


### PR DESCRIPTION
For details, see the commit message.

Particular review points:
* Specification of a list of HMC hosts in the "hmc_host" module parameter.
* Requirement for specifying a single HMC in the "hmc_host" module parameter for any modules that use the session ID returned by the zhmc_session module with action=create.

End2end tests:
* Ran TESTCASES='test_zhmc_cpc_list' successfully against M12 with two redundant HMCs (of versions 2.14 and 2.15)