### PR TITLE
1.7: Fixed KeyError in 'zhmc_storage_group' module for non-FCP groups

### DIFF
--- a/docs/source/modules/zhmc_storage_group.rst
+++ b/docs/source/modules/zhmc_storage_group.rst
@@ -481,7 +481,7 @@ storage_group
     | **elements**: str
 
   candidate-adapter-ports
-    Only present if \ :literal:`expand=true`\ : List of candidate storage adapter ports of the storage group.
+    Only present if \ :literal:`expand=true`\ : List of candidate storage adapter ports of the storage group. Will be empty for storage group types other than FCP.
 
     | **returned**: success+expand
     | **type**: list
@@ -535,7 +535,7 @@ storage_group
 
 
   virtual-storage-resources
-    Only present if \ :literal:`expand=true`\ : Virtual storage resources of the storage group.
+    Only present if \ :literal:`expand=true`\ : Virtual storage resources of the storage group. Will be empty for storage group types other than FCP.
 
     | **returned**: success+expand
     | **type**: list

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -38,6 +38,11 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Fixed end2end test for zhmc_cpc_list module that failed when the HMC had
   unmanaged CPCs or had HMC version 2.14.
 
+* Fixed KeyError in 'zhmc_storage_group' module when used with non-FCP storage
+  groups, and clarified that the artificial properties 'candidate-adapter-ports'
+  and 'virtual-storage-resources' returned by the module will be empty arrays
+  for non-FCP storage groups. (e.g. NVMe). (issue #864)
+
 **Enhancements:**
 
 * Added a new make target 'make ansible_lint' which invokes ansible-lint.


### PR DESCRIPTION
Rolls back PR #864 into 1.7.4.