### PR TITLE
Fixed misspelling 'preferrable'

### DIFF
--- a/docs/source/modules/zhmc_adapter_list.rst
+++ b/docs/source/modules/zhmc_adapter_list.rst
@@ -150,7 +150,7 @@ full_properties
 
   Mutually exclusive with \ :literal:`additional\_properties`\ .
 
-  Note: Setting this to True causes a loop of 'Get Adapter Properties' operations to be executed. It is preferrable from a performance perspective to use the \ :literal:`additional\_properties`\  parameter instead.
+  Note: Setting this to True causes a loop of 'Get Adapter Properties' operations to be executed. It is preferable from a performance perspective to use the \ :literal:`additional\_properties`\  parameter instead.
 
   | **required**: False
   | **type**: bool

--- a/docs/source/modules/zhmc_lpar_list.rst
+++ b/docs/source/modules/zhmc_lpar_list.rst
@@ -115,7 +115,7 @@ full_properties
 
   Mutually exclusive with \ :literal:`additional\_properties`\ .
 
-  Note: Setting this to True causes a loop of 'Get Logical Partition Properties' operations to be executed. It is preferrable from a performance perspective to use the \ :literal:`additional\_properties`\  parameter instead.
+  Note: Setting this to True causes a loop of 'Get Logical Partition Properties' operations to be executed. It is preferable from a performance perspective to use the \ :literal:`additional\_properties`\  parameter instead.
 
   | **required**: False
   | **type**: bool

--- a/docs/source/modules/zhmc_partition_list.rst
+++ b/docs/source/modules/zhmc_partition_list.rst
@@ -115,7 +115,7 @@ full_properties
 
   Mutually exclusive with \ :literal:`additional\_properties`\ .
 
-  Note: Setting this to True causes a loop of 'Get Partition Properties' operations to be executed. It is preferrable from a performance perspective to use the \ :literal:`additional\_properties`\  parameter instead.
+  Note: Setting this to True causes a loop of 'Get Partition Properties' operations to be executed. It is preferable from a performance perspective to use the \ :literal:`additional\_properties`\  parameter instead.
 
   | **required**: False
   | **type**: bool

--- a/plugins/modules/zhmc_adapter_list.py
+++ b/plugins/modules/zhmc_adapter_list.py
@@ -171,7 +171,7 @@ options:
         Default: False."
       - Mutually exclusive with C(additional_properties).
       - "Note: Setting this to True causes a loop of 'Get Adapter Properties'
-        operations to be executed. It is preferrable from a performance
+        operations to be executed. It is preferable from a performance
         perspective to use the C(additional_properties) parameter instead."
     type: bool
     required: false

--- a/plugins/modules/zhmc_lpar_list.py
+++ b/plugins/modules/zhmc_lpar_list.py
@@ -133,7 +133,7 @@ options:
         Default: False."
       - Mutually exclusive with C(additional_properties).
       - "Note: Setting this to True causes a loop of 'Get Logical Partition
-        Properties' operations to be executed. It is preferrable from a
+        Properties' operations to be executed. It is preferable from a
         performance perspective to use the C(additional_properties) parameter
         instead."
     type: bool

--- a/plugins/modules/zhmc_partition_list.py
+++ b/plugins/modules/zhmc_partition_list.py
@@ -136,7 +136,7 @@ options:
         Default: False."
       - Mutually exclusive with C(additional_properties).
       - "Note: Setting this to True causes a loop of 'Get Partition Properties'
-        operations to be executed. It is preferrable from a performance
+        operations to be executed. It is preferable from a performance
         perspective to use the C(additional_properties) parameter instead."
     type: bool
     required: false


### PR DESCRIPTION
No review needed.
Came up during review of PR #853 