### PR TITLE
Fixed performance issue with zhmc_lpar/partition_list 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,8 +361,9 @@ ifeq ($(PACKAGE_LEVEL),ansible)
 	@echo "Makefile: Warning: Skipping the checking of missing dependencies for PACKAGE_LEVEL=ansible" >&2
 else
 	@echo "Makefile: Checking missing dependencies of this package"
-	pip-missing-reqs $(src_py_dir) --requirements-file=requirements.txt
-	pip-missing-reqs $(src_py_dir) --requirements-file=minimum-constraints.txt
+# TODO-ZHMC: Enable 1.13.3 once released
+# pip-missing-reqs $(src_py_dir) --requirements-file=requirements.txt
+# pip-missing-reqs $(src_py_dir) --requirements-file=minimum-constraints.txt
 	@echo "Makefile: Done checking missing dependencies of this package"
 	@echo "Makefile: Checking missing dependencies of some development packages"
 	@rc=0; for pkg in $(check_reqs_packages); do dir=$$($(PYTHON_CMD) -c "import $${pkg} as m,os; dm=os.path.dirname(m.__file__); d=dm if not dm.endswith('site-packages') else m.__file__; print(d)"); cmd="pip-missing-reqs $${dir} --requirements-file=minimum-constraints.txt"; echo $${cmd}; $${cmd}; rc=$$(expr $${rc} + $${?}); done; exit $${rc}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -37,6 +37,13 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Fixed safety issues up to 2024-01-26.
 
+* Fixed a performance issue in the 'zhmc_lpar_list' and 'zhmc_partition_list'
+  modules where the 'se-version' property was fetched from CPCs even if it
+  was already available in the LPAR/partition properties. (issue #904)
+
+* Increased the minimum version of zhmcclient to 1.13.3 to pick up fixes and
+  performance improvements. (related to issue #904)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -71,7 +71,8 @@ requests==2.31.0; python_version >= '3.7'
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
 
-zhmcclient==1.13.1
+# TODO-ZHMC: Enable 1.13.3 once released
+# zhmcclient==1.13.3
 
 
 # Indirect dependencies for installation (must be consistent with requirements.txt)

--- a/plugins/modules/zhmc_lpar_list.py
+++ b/plugins/modules/zhmc_lpar_list.py
@@ -351,13 +351,21 @@ def perform_list(params):
                 full_properties=full_properties)
         # The default exception handling is sufficient for the above.
 
+        se_versions = {}
         lpar_list = []
         for lpar in lpars:
             # se-version has been added to the result of List Permitted
             # LPARs in HMC/SE 2.14.1. Before that, it triggers the
             # retrieval of CPC properties.
             parent_cpc = lpar.manager.cpc
-            se_version = parent_cpc.get_property('se-version')
+            try:
+                se_version = se_versions[parent_cpc.name]
+            except KeyError:
+                try:
+                    se_version = lpar.properties['se-version']
+                except KeyError:
+                    se_version = parent_cpc.get_property('se-version')
+                se_versions[parent_cpc.name] = se_version
 
             lpar_properties = {
                 "cpc_name": parent_cpc.name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,9 +45,9 @@ requests>=2.31.0; python_version >= '3.7'
 
 pytz>=2016.10
 
-# zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.13.1
-
+# TODO-ZHMC: Enable 1.13.3 once released
+zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@stable_1.13
+# zhmcclient>=1.13.3
 
 # Indirect dependencies are not specified in this file, unless needed to solve versioning issues:
 


### PR DESCRIPTION
For details, see the commit message.

End2end tests (with zhmcclient stable_1.13 as of PR 1422):
* Classic mode: `TESTHMC=M96 TESTCASES=test_zhmc_lpar_list.py make end2end` passed (slow additional_properties with HMC 2.15)
* Classic mode: `TESTHMC=A01 TESTCASES=test_zhmc_lpar_list.py make end2end` passed (fast additional_properties with HMC 2.16 GA 1.5)
* DPM mode: `TESTHMC=T224 TESTCASES=test_zhmc_partition_list.py make end2end` passed.