### PR TITLE
1.8: Bump cryptography minimum version to 42.0.2

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -35,7 +35,7 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Fixed safety issues up to 2024-02-18.
 
-* Fixed dependabot issues up to 2024-02-12.
+* Fixed dependabot issues up to 2024-02-18.
 
 **Enhancements:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -87,7 +87,7 @@ MarkupSafe==2.0.0; python_version >= '3.8'
 cryptography==3.3.2; python_version == '2.7'
 cryptography==3.0; python_version == '3.5'
 cryptography==3.4.7; python_version == '3.6'
-cryptography==42.0.0; python_version >= '3.7'
+cryptography==42.0.2; python_version >= '3.7'
 
 importlib-metadata==0.12; python_version <= '3.7'
 importlib-metadata==4.8.3; python_version >= '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ MarkupSafe>=2.0.0; python_version >= '3.8'
 cryptography>=3.3.2; python_version == '2.7'
 cryptography>=3.0,<3.1; python_version == '3.5'
 cryptography>=3.4.7,<37.0.0; python_version == '3.6'
-cryptography>=42.0.0; python_version >= '3.7'
+cryptography>=42.0.2; python_version >= '3.7'
 
 # importlib-metadata is used for install by jsonschema which is used by zhmcclient.
 # importlib-metadata is used for development by flake8 (and others).


### PR DESCRIPTION
Rolls back PR #925 into 1.8.3.