### PR TITLE
Fixed AttributeError in ensure_iso_mount function of zhmc_partition 

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -46,6 +46,8 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Increased the minimum version of zhmcclient to 1.13.3 to pick up fixes and
   performance improvements. (related to issue #904)
 
+* Fixed readable attribute error when ensuring ISO mounted onto the partition. (related to issue #932)
+
 **Enhancements:**
 
 * Added a new make target 'end2end_show' to show the HMCs defined for end2end

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -2059,7 +2059,7 @@ def ensure_iso_mount(params, check_mode):
             try:
                 with open(image_file, 'rb') as fp:
                     if not check_mode:
-                        image = fp.readall()
+                        image = fp.read()
             except IOError as exc:
                 raise ImageError(
                     "Cannot open ISO image file {fn!r} for reading: {exc}".


### PR DESCRIPTION
When running playbook partition_nodb_create.yml with linux partition input - playbook is failing when mounting iso to the partition
During investigation - we have checked BufferedReader class - it supports read() but it didn’t support readall()
https://docs.python.org/3/library/io.html#io.BufferedReader
Later we modified ensure_iso_mount to use BufferedReader.read() instead of BufferedReader.readall()

Created jira [IAUT-1151](https://jsw.ibm.com/browse/IAUT-1151) for the same - Please do review once & merge the code

![Screenshot 2024-02-20 at 5 27 19 PM](https://github.com/zhmcclient/zhmc-ansible-modules/assets/161458016/f2674d04-2dfc-4679-91b4-ea837a0cfb27)
