### PR TITLE
Dropped test runs on Python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,26 +35,11 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\" ], \
-            \"python-version\": [ \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
+            \"python-version\": [ \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
             \"package_level\": [ \"minimum\", \"latest\", \"ansible\" ], \
             \"exclude\": [ \
               { \
                 \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"ansible\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -66,21 +51,6 @@ jobs:
               { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.6\", \
-                \"package_level\": \"ansible\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.5\", \
                 \"package_level\": \"ansible\" \
               }, \
               { \
@@ -135,21 +105,6 @@ jobs:
               }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"ansible\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -161,21 +116,6 @@ jobs:
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
-                \"package_level\": \"ansible\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.5\", \
                 \"package_level\": \"ansible\" \
               }, \
               { \
@@ -230,16 +170,6 @@ jobs:
               }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -275,7 +205,7 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-12\", \
-                \"python-version\": \"3.5\", \
+                \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
               }, \
               { \

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -274,7 +274,8 @@ Operating systems:
 
 Python versions:
 
-- Python 2.7 to Python 3.8 are supported on a best-can-do basis
+- Python 2.7 to Python 3.8 are supported on a best-can-do basis. The collection
+  is no longer tested on Python 3.5.
 - Python 3.9 and higher are officially supported (depends on the Ansible version used)
 
 Ansible versions:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -33,6 +33,10 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Deprecations:**
 
+* This collection is no longer tested on Python 3.5, and its use on Python 3.5
+  is at your own risk. The reason is that the setup of Python 3.5 on Github
+  Actions currently fails.
+
 **Bug fixes:**
 
 * Fixed safety issues up to 2024-05-14.


### PR DESCRIPTION
For details, see the commit message.

I have opened https://github.com/actions/setup-python/issues/866 for that. This change allows us to have successful test runs without a fix for that. Once we get a fix, we can revert this PR.

Note that this change does not drop the support for Python 3.5. It is still "best can do".