### PR TITLE
1.8: Re-established test runs on Python 3.5 and circumvented pip cert issue 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -305,8 +305,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      if: ${{ ! ( matrix.python-version == '2.7' ) }}
+    - name: Set up Python ${{ matrix.python-version }} (if py==3.5)
+      if: ${{ matrix.python-version == '3.5' }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+      env:
+        # Workaround for cert issue on Python 3.5, see https://github.com/actions/setup-python/issues/866
+        PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
+    - name: Set up Python ${{ matrix.python-version }} (if py>=3.6)
+      if: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,24 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\" ], \
-            \"python-version\": [ \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
+            \"python-version\": [ \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
             \"package_level\": [ \"minimum\", \"latest\", \"ansible\" ], \
             \"exclude\": [ \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"ansible\" \
+              }, \
               { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.6\", \
@@ -51,6 +66,21 @@ jobs:
               { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.6\", \
+                \"package_level\": \"ansible\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.5\", \
                 \"package_level\": \"ansible\" \
               }, \
               { \
@@ -105,6 +135,21 @@ jobs:
               }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"ansible\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -116,6 +161,21 @@ jobs:
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
+                \"package_level\": \"ansible\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.5\", \
                 \"package_level\": \"ansible\" \
               }, \
               { \
@@ -170,6 +230,16 @@ jobs:
               }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -205,7 +275,7 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-12\", \
-                \"python-version\": \"3.6\", \
+                \"python-version\": \"3.5\", \
                 \"package_level\": \"latest\" \
               }, \
               { \

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -274,8 +274,7 @@ Operating systems:
 
 Python versions:
 
-- Python 2.7 to Python 3.8 are supported on a best-can-do basis. The collection
-  is no longer tested on Python 3.5.
+- Python 2.7 to Python 3.8 are supported on a best-can-do basis
 - Python 3.9 and higher are officially supported (depends on the Ansible version used)
 
 Ansible versions:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -66,6 +66,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Fixed readable attribute error when ensuring ISO mounted onto the partition.
   (related to issue #932)
 
+* In the Github Actions test workflow for Python 3.5, added a circumvention
+  for the Pip certificate issue.
+
 **Cleanup:**
 
 * Resolved the 'no-log-needed' issue raised by the sanity test and ansible-lint

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -31,10 +31,6 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Deprecations:**
 
-* This collection is no longer tested on Python 3.5, and its use on Python 3.5
-  is at your own risk. The reason is that the setup of Python 3.5 on Github
-  Actions currently fails.
-
 **Bug fixes:**
 
 * Fixed safety issues up to 2024-05-14.


### PR DESCRIPTION
Rolls back PR #963 into 1.8.4.