### PR TITLE
Obscure password in log messages

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -31,6 +31,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Incompatible changes:**
 
+* Value of 'password' property will be replaced with '********' in log messages and
+  'result' dictionary returned by zhmc_user.ensure_present().
+
 **Deprecations:**
 
 **Bug fixes:**

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -39,6 +39,8 @@ try:
 except ImportError:
     IMP_ZHMCCLIENT_MOCK_ERR = traceback.format_exc()
 
+BLANKED_OUT = '********'  # Replacement for blanked out sensitive values
+
 
 class Error(Exception):
     """


### PR DESCRIPTION
Changes:
- Obscure 'password' property in log messages.

Fixes https://github.com/zhmcclient/zhmc-ansible-modules/issues/967