### PR TITLE
Increased minimum Ansible version to Ansible 8 / ansible-core 2.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ collection_version := $(shell $(PYTHON_CMD) tools/version.py)
 
 # Minimum ansible-core version that is officially supported
 # If this version is changed, update the check_reqs_packages variable as well
-min_ansible_core_version := 2.14.0
+min_ansible_core_version := 2.15.0
 
 # Installed ansible-core version
 ansible_core_version := $(shell $(PYTHON_CMD) -c "import sys,ansible; sys.stdout.write(ansible.__version__)")

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -302,7 +302,7 @@ Ansible  Ansible core       Supported Python versions  Support
 4        ansible-core 2.11  3.8 - 3.9                  best-can-do
 5        ansible-core 2.12  3.8 - 3.10                 best-can-do
 6        ansible-core 2.13  3.8 - 3.10                 best-can-do
-7        ansible-core 2.14  3.9 - 3.11                 official
+7        ansible-core 2.14  3.9 - 3.11                 best-can-do
 8        ansible-core 2.15  3.9 - 3.11                 official
 9        ansible-core 2.16  3.10 - 3.12                official
 10       ansible-core 2.17  3.10 - 3.12                official

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -36,6 +36,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Dropped support for Python 2.7, 3.5, 3.6, and 3.7.
 
+* Increased minimum officially supported Ansible version to Ansible 8 /
+  ansible-core 2.15. (issue #988)
+
 **Deprecations:**
 
 **Bug fixes:**

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -10,4 +10,4 @@
 # Note: There are some lower ansible versions that are tested against, see the
 # Python requirements and constraint files.
 #
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"


### PR DESCRIPTION
This is needed to pass the ansible-lint test on Ansible Automation Hub.