### PR TITLE
Fixed recently introduced errors in zhmc_user module

### DIFF
--- a/plugins/modules/zhmc_user.py
+++ b/plugins/modules/zhmc_user.py
@@ -374,7 +374,6 @@ user:
 import uuid  # noqa: E402
 import logging  # noqa: E402
 import traceback  # noqa: E402
-from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
@@ -1165,9 +1164,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = deepcopy(module.params)
+    _params = dict(module.params)
     del _params['hmc_auth']
-    if 'properties' in _params and 'password' in _params['properties']:
+    if _params['properties'] and 'password' in _params['properties']:
         # This is not a hard-coded password. Added # nosec to avoid
         # generating false positive in bandit
         _params['properties']['password'] = BLANKED_OUT    # nosec


### PR DESCRIPTION
For details, see the commit message.

PR that introduced the errors: #970

Example of the prior error in the end2end_mocked tests for that PR: https://github.com/zhmcclient/zhmc-ansible-modules/actions/runs/9535584752/job/26281487052#step:19:2482

I did not find them in the review, and I did not look at the end2end_mocked test results which clearly showed the error. Because of other errors currently in these tests, a non-zero exit code of that test is currently tolerated in the test workflow.