### PR TITLE
Adjusted README to new AutomationHub requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2017,2020 IBM Corp. All Rights Reserved.
+Copyright 2017,2020,2024 IBM Corp. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -60,59 +60,213 @@ For details, see the discussion at https://github.com/ansible-collections/overvi
 [![Docs status (master)](https://github.com/zhmcclient/zhmc-ansible-modules/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/zhmcclient/zhmc-ansible-modules/actions/workflows/pages/pages-build-deployment "Docs status (master)")
 [![Test coverage (master)](https://img.shields.io/coveralls/zhmcclient/zhmc-ansible-modules.svg)](https://coveralls.io/github/zhmcclient/zhmc-ansible-modules "Test coverage (master)")
 
-IBM Z HMC collection
-====================
+# IBM® Z HMC collection
 
-The **IBM Z HMC collection** is part of the broader initiative to bring Ansible
-Automation to IBM Z® through the offering
-**Red Hat® Ansible Certified Content for IBM Z®**. The
-**IBM Z HMC collection** supports automation tasks such as creating, updating or
-deleting partitions and other resources that can be managed with the
-IBM Z Hardware Management Console (HMC).
+The **IBM Z HMC** collection enables automation with the IBM Z Hardware
+Management Console (HMC) to manage platform resources on
+[IBM Z](https://www.ibm.com/it-infrastructure/z) and
+[IBM LinuxONE](https://www.ibm.com/it-infrastructure/linuxone/) machines.
 
-Red Hat Ansible Certified Content for IBM Z
-===========================================
+## Description
 
-**Red Hat® Ansible Certified Content for IBM Z** provides the ability to
-connect IBM Z® to clients' wider enterprise automation strategy through the
-Ansible Automation Platform ecosystem. This enables development and operations
-automation on Z through a seamless, unified workflow orchestration with
-configuration management, provisioning, and application deployment in
-one easy-to-use platform.
+The **IBM Z HMC** collection is part of the
+**Red Hat® Ansible Certified Content for IBM Z®** offering that brings Ansible
+automation to IBM Z®.
 
-The **IBM Z HMC collection** is following the
-**Red Hat® Ansible Certified Content for IBM Z®** method of distributing
-content. Collections will be developed in the open, and when content is ready
-for use it is released to
-[Ansible Galaxy](https://galaxy.ansible.com/search?keywords=ibm_z&order_by=-relevance&deprecated=false&type=collection&page=1)
-for community adoption. Once contributors review community usage, feedback,
-and are satisfied with the content published, the collection will then be
-released to [Ansible Automation Hub](https://www.ansible.com/products/automation-hub)
-as **certified** and **IBM supported** for
-**Red Hat® Ansible Automation Platform subscribers**.
+This collection supports automation tasks on the IBM Z HMC such as creating,
+updating or deleting partitions, accesssing operating system messages,
+configuring adapters, managing HMC users, upgrading the SE and HMC firmware,
+and many more. It supports CPCs in classic mode and in DPM mode.
+
+The IBM Z HMC collection uses the Web Services API of the HMC and therefore its
+modules run on the Ansible control node (there is no separate Ansible managed
+node in this case).
 
 For guides and reference, please review the
 [documentation](https://zhmcclient.github.io/zhmc-ansible-modules/)
 or the Z HMC section in the
 [unified documentation](https://ibm.github.io/z_ansible_collections_doc/).
 
-Features
-========
+## Requirements
 
-The **IBM Z HMC collection** provides Ansible modules and
-[sample_playbooks](https://github.com/IBM/z_ansible_collections_samples/tree/master/z_systems_administration/zhmc)
-for automating management tasks on the Hardware Management Console (HMC) of
-[IBM Z](https://www.ibm.com/it-infrastructure/z/) and
-[LinuxONE](https://www.ibm.com/it-infrastructure/linuxone/) machines, such as
-creating, updating or deleting partitions and other resources.
+Before you install the IBM Z HMC collection, you must have a minimum Python
+version and Ansible version on the Ansible control node. The documentation section
+[Support matrix](https://zhmcclient.github.io/zhmc-ansible-modules/installation.html#support-matrix)
+details the specific version requirements.
 
-Copyright
-=========
+## Installation
 
-© Copyright IBM Corporation 2016,2020.
+Before using this collection, you need to install it with the Ansible Galaxy
+command-line tool:
 
-License
-=======
+```sh
+ansible-galaxy collection install ibm.ibm_zhmc
+```
+
+You can also include it in a requirements.yml file and install it with
+`ansible-galaxy collection install -r requirements.yml`, using the format:
+
+```sh
+collections:
+  - name: ibm.ibm_zhmc
+```
+
+The installation of the collection will not cause any required Python packages
+to be installed. They need to be installed separately, either as OS-level
+packages or as Python packages, depending on how you manage the Python packages
+on your system. A `requirements.txt` file is provided in the installation
+directory of the ibm.ibm_zhmc collection for that purpose, either for direct use
+with `pip install -r requirements.txt`, or for manually checking and installing
+the corresponding OS-level packages.
+
+Note that if you install the collection from Ansible Galaxy, it will not be
+upgraded automatically when you upgrade the Ansible (OS-level or Python) package.
+
+To upgrade the collection to the latest available version, run the following
+command:
+
+```sh
+ansible-galaxy collection install ibm.ibm_zhmc --upgrade
+```
+
+You can also install a specific version of the collection, for example, if you
+need to downgrade for some reason. For example, the following command installs
+version 1.0.0:
+
+```sh
+ansible-galaxy collection install ibm.ibm_zhmc:1.0.0
+```
+
+## Use Cases
+
+* Use Case Name: Create partition (DPM mode)
+  * Actors:
+    * System Programmer
+  * Description:
+    * The system programmer can automate the creation of a partition on a Z
+      system (that is in DPM mode).
+  * Flow:
+    * If the partition does not exist, create it.
+    * Update properties of the partition, including boot mode.
+    * Bring the partition into the specified status (active, stopped).
+
+* Use Case Name: Adjust workload related LPAR properties (classic mode)
+  * Actors:
+    * System Programmer
+  * Description:
+    * The system programmer can automate the adjustment of workload related
+      LPAR properties in order to optimize the performance of applications
+      running in the LPAR.
+  * Flow:
+    * Verify LPAR exists on the HMC
+    * Update the specified LPAR properties.
+
+* Use Case Name: Update password of HMC user
+  * Actors:
+    * System Programmer
+  * Description:
+    * The system programmer can automate the password update for their userid on
+      the HMC.
+  * Flow:
+    * Verify user exists on the HMC
+    * Update password of the user
+
+## Testing
+
+All releases will meet the following test criteria:
+
+* 100% success for [Unit](https://github.com/zhmcclient/zhmc-ansible-modules/tree/master/tests/unit) tests.
+* 100% success for [Function](https://github.com/zhmcclient/zhmc-ansible-modules/tree/master/tests/function) tests.
+* 100% success for [End2end](https://github.com/zhmcclient/zhmc-ansible-modules/tree/master/tests/end2end) tests.
+* 100% success for [Sanity](https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/index.html#all-sanity-tests) tests as part of [ansible-test](https://docs.ansible.com/ansible/latest/dev_guide/testing.html#run-sanity-tests).
+* 100% success for [flake8](https://flake8.pycqa.org).
+* 100% success for [ansible-lint](https://ansible.readthedocs.io/projects/lint/) allowing only false positives.
+
+For more details on testing the IBM Z HMC collection, including the specific version
+combinations that were tested, refer to documentation section
+[Testing](https://zhmcclient.github.io/zhmc-ansible-modules/development.html#testing).
+
+## Contributing
+
+This community is not currently accepting contributions. However, we encourage
+you to open [git issues](https://github.com/zhmcclient/zhmc-ansible-modules/issues)
+for bugs, comments or feature requests and check back periodically for when
+community contributions will be accepted in the near future.
+
+Review the [development docs](https://zhmcclient.github.io/zhmc-ansible-modules/development.html)
+to learn how you can create an environment and test the collections modules.
+
+## Communication
+
+If you would like to communicate with this community, you can do so through the
+following options:
+
+* GitHub [IBM Z HMC issues](https://github.com/zhmcclient/zhmc-ansible-modules/issues).
+* Discord [ansible in System Z Enthusiasts](https://discord.com/channels/880322471608344597/1195381184360894595)
+  - Invitation link for server [System Z Enthusiasts](https://discord.gg/Kmy5QaUGbB)
+  - Invitation link for channel [ansible](https://discord.gg/nHrDdRTC)
+
+## Support
+
+As Red Hat Ansible
+[Certified Content](https://catalog.redhat.com/software/search?target_platforms=Red%20Hat%20Ansible%20Automation%20Platform),
+this collection is entitled to [support](https://access.redhat.com/support/) through
+[Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible)
+(AAP). After creating a Red Hat support case, if it is determined the issue
+belongs to IBM, Red Hat will instruct you to create an
+[IBM support case](https://www.ibm.com/mysupport/s/createrecord/NewCase) and
+share the case number with Red Hat so that a collaboration can begin between
+Red Hat and IBM.
+
+If a support case cannot be opened with Red Hat and the collection has been
+obtained either from [Galaxy](https://galaxy.ansible.com/ui/) or its
+[GitHub repo](https://github.com/zhmcclient/zhmc-ansible-modules), there is
+community support available at no charge. Community support is limited to the
+collection; community support does not include any of the Ansible Automation
+Platform components or Ansible.
+
+The current supported versions of this collection can be found listed in the
+following section.
+
+## Release Notes and Roadmap
+
+The collection's cumulative release notes can be reviewed
+[here](https://zhmcclient.github.io/zhmc-ansible-modules/release_notes.html).
+Note, some collection versions release before an ansible-core version reaches
+End of Life (EOL), thus the version of ansible-core that is supported must be a
+version that is currently supported.
+
+For AAP users, to see the supported ansible-core versions, review the
+[AAP Life Cycle](https://access.redhat.com/support/policy/updates/ansible-automation-platform).
+
+For Galaxy and GitHub users, to see the supported ansible-core versions, review the
+[ansible-core support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix).
+
+The collection's changelogs can be reviewed in the following table:
+
+| Version  | Status         | Release notes & change log |
+|----------|----------------|----------------------------|
+| 1.9.0    | In development | unreleased                 |
+| 1.8.3    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.8.3/release_notes.html) |
+| 1.7.4    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.7.4/release_notes.html) |
+| 1.6.1    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.6.1/release_notes.html) |
+| 1.5.0    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.5.0/release_notes.html) |
+| 1.4.1    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.4.1/release_notes.html) |
+| 1.3.1    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.3.1/release_notes.html) |
+| 1.2.1    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.2.1/release_notes.html) |
+| 1.1.1    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.1.1/release_notes.html) |
+| 1.0.3    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.0.3/release_notes.html) |
+
+## Related Information
+
+Example playbooks and use cases can be be found in the
+[IBM Z HMC sample playbooks](https://github.com/IBM/z_ansible_collections_samples/tree/master/z_systems_administration/zhmc)
+repo.
+
+Supplemental content on getting started with Ansible, architecture and use cases
+is available [here](https://ibm.github.io/z_ansible_collections_doc/reference/helpful_links.html).
+
+## License Information
 
 This collection is licensed under
-[Apache License, Version 2.0](https://opensource.org/licenses/Apache-2.0).
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -293,13 +293,38 @@ local clone of the zhmc-ansible-modules Git repo.
       add text for any known issues you want users to know about.
     * Remove all empty list items.
 
-5.  Update the authors:
+5.  When releasing a new major or minor version, edit the support matrix:
+
+    .. code-block:: sh
+
+        vi docs/source/installation.rst
+
+    and make the following changes in section "Support matrix":
+
+    * Set the End of Life date of the previous minor version (M.N-1.x) to
+      today's date.
+    * Add a new row in the table for the current release (M.N.U), that has
+      today's date as the GA date and an empty End of Life cell.
+
+6.  Edit the change log table:
+
+    .. code-block:: sh
+
+        vi README.md
+
+    and make the following changes in section "Release Notes and Roadmap":
+
+    * When releasing a fix version, update the fix version in the table.
+    * When releasing a major or minor version, add a row with the released
+      version to the table, and increase the version in development.
+
+7.  Update the authors:
 
     .. code-block:: sh
 
         make authors
 
-6.  Run the Safety tool:
+8.  Run the Safety tool:
 
     .. code-block:: sh
 
@@ -312,24 +337,24 @@ local clone of the zhmc-ansible-modules Git repo.
     If the safety run fails, you need to fix the safety issues that are
     reported.
 
-7.  Review the result of the latest Mend scan in
+9.  Review the result of the latest Mend scan in
     `this Box folder <https://ibm.ent.box.com/folder/190964336381?s=070khx70ijj3ime3k4yfx7r7cjb2xx0k>`_.
 
     If the Mend scan shows any issues, fix them.
 
-8.  Check for any
+10. Check for any
     `dependabot issues <https://github.com/zhmcclient/zhmc-ansible-modules/security/dependabot>`_.
 
     If there are any dependebot issues, fix them.
 
-9.  Commit your changes and push the topic branch to the remote repo:
+11. Commit your changes and push the topic branch to the remote repo:
 
     .. code-block:: sh
 
         git commit -asm "Release ${MNU}"
         git push --set-upstream origin release_${MNU}
 
-10. On GitHub, create a Pull Request for branch ``release_M.N.U``.
+12. On GitHub, create a Pull Request for branch ``release_M.N.U``.
 
     Important: When creating Pull Requests, GitHub by default targets the
     ``master`` branch. When releasing based on a stable branch, you need to
@@ -339,18 +364,18 @@ local clone of the zhmc-ansible-modules Git repo.
     tests for all defined environments, since it discovers by the branch name
     that this is a PR for a release.
 
-11. On GitHub, once the checks for that Pull Request have succeeded, merge the
+13. On GitHub, once the checks for that Pull Request have succeeded, merge the
     Pull Request (no review is needed). This automatically deletes the branch
     on GitHub.
 
     If the PR did not succeed, fix the issues.
 
-12. On GitHub, close milestone ``M.N.U``.
+14. On GitHub, close milestone ``M.N.U``.
 
     Verify that the milestone has no open items anymore. If it does have open
     items, investigate why and fix.
 
-13. Publish the collection to Ansible Galaxy
+15. Publish the collection to Ansible Galaxy
 
     .. code-block:: sh
 
@@ -366,7 +391,7 @@ local clone of the zhmc-ansible-modules Git repo.
     it on Github, and finally creates a new stable branch on Github if the master
     branch was released.
 
-14. Verify the publishing
+16. Verify the publishing
 
     * Verify that the new version is available on Ansible Galaxy at
       https://galaxy.ansible.com/ibm/ibm_zhmc/
@@ -381,7 +406,7 @@ local clone of the zhmc-ansible-modules Git repo.
     * Verify that the new version has documentation on Github pages at
       https://zhmcclient.github.io/zhmc-ansible-modules/release_notes.html
 
-15. Publish the collection to Ansible AutomationHub
+17. Publish the collection to Ansible AutomationHub
 
     This needs to be done in addition to the prior publish step, and it
     has not successfully been automated as of today.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -254,7 +254,8 @@ For details, see sections "Connecting to the API HTTP server" and
 Supported environments
 ----------------------
 
-The following Z and LinuxONE machine generations are supported:
+The following Z and LinuxONE machine generations are supported by the IBM Z HMC
+collection:
 
 - z196 / z114
 - zEC12 / zBC12
@@ -263,57 +264,46 @@ The following Z and LinuxONE machine generations are supported:
 - z15 / LinuxONE III
 - z16 / LinuxONE 4
 
-The following environments are supported for running the Ansible modules of the
-ibm.ibm_zhmc collection.
 
-Operating systems:
+.. _`Support matrix`:
 
-- Linux
-- macOS (OS-X)
-- Windows
+Support matrix
+--------------
 
-Python versions:
+The following table shows for each released version of the IBM Z HMC collection
+the Ansible and ansible-core versions supported on the control node, the
+supported Z HMC versions and the support timeframe.
 
-- Python 2.7 to Python 3.8 are supported on a best-can-do basis
-- Python 3.9 and higher are officially supported (depends on the Ansible version used)
+The general strategy is to support the latest released minor version until the
+next minor version is released. See :ref:`Compatibility` for the rules this
+collection applies regarding compatibility.
 
-Ansible versions:
++------------+-----------+--------------+------------+-------------+-------------+
+| Collection | Ansible   | ansible-core | Z HMC      | GA          | End of Life |
++============+===========+==============+============+=============+=============+
+| 1.8.x      | >= 8.0.x  | >= 2.15.x    | >= 2.11    | 2024-01-15  |             |
++------------+-----------+--------------+------------+-------------+-------------+
+| 1.7.x      | >= 7.0.x  | >= 2.14.x    | >= 2.11    | 2023-10-09  | 2024-01-15  |
++------------+-----------+--------------+------------+-------------+-------------+
+| 1.6.x      | >= 2.9.x  | >= 2.9.x     | >= 2.11    | 2023-08-04  | 2023-10-09  |
++------------+-----------+--------------+------------+-------------+-------------+
+| 1.5.x      | >= 2.9.x  | >= 2.9.x     | >= 2.11    | 2023-07-18  | 2023-08-04  |
++------------+-----------+--------------+------------+-------------+-------------+
+| 1.4.x      | >= 2.9.x  | >= 2.9.x     | >= 2.11    | 2023-06-22  | 2023-07-18  |
++------------+-----------+--------------+------------+-------------+-------------+
+| 1.3.x      | >= 2.9.x  | >= 2.9.x     | >= 2.11    | 2023-03-03  | 2023-06-22  |
++------------+-----------+--------------+------------+-------------+-------------+
+| 1.2.x      | >= 2.9.x  | >= 2.9.x     | >= 2.11    | 2022-12-06  | 2023-03-03  |
++------------+-----------+--------------+------------+-------------+-------------+
+| 1.1.x      | >= 2.9.x  | >= 2.9.x     | >= 2.11    | 2022-06-01  | 2022-12-06  |
++------------+-----------+--------------+------------+-------------+-------------+
+| 1.0.x      | >= 2.9.x  | >= 2.9.x     | >= 2.11    | 2022-04-08  | 2022-06-01  |
++------------+-----------+--------------+------------+-------------+-------------+
 
-- Ansible 2.9 to 6 (ansible-core 2.13) are supported on a best-can-do basis
-- Ansible 7 (ansible-core 2.14) and higher are officially supported
+The `Ansible-core Support Matrix <https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix>`_
+shows for each ansible-core version the supported Python versions and the
+support timeframe.
 
-See `Ansible-core Support Matrix <https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix>`_
-for the officially supported Ansible / ansible-core versions and their Python versions.
-
-See `Red Hat Ansible Automation Platform Life Cycle <https://access.redhat.com/support/policy/updates/ansible-automation-platform>`_
-for the officially supported Ansible Automation Platform versions and their ansible-core
-versions.
-
-The general strategy for the ibm.ibm_zhmc collection is that all Python versions
-supported by the sanity test tool of a particular Ansible version are supported,
-as shown in the following tables:
-
-=======  =================  =========================  ===========
-Ansible  Ansible core       Supported Python versions  Support
--------  -----------------  -------------------------  -----------
-2.9      ansible 2.9        3.8                        best-can-do
-2.10     ansible 2.10       3.8                        best-can-do
-3        ansible-base 2.10  3.8                        best-can-do
-4        ansible-core 2.11  3.8 - 3.9                  best-can-do
-5        ansible-core 2.12  3.8 - 3.10                 best-can-do
-6        ansible-core 2.13  3.8 - 3.10                 best-can-do
-7        ansible-core 2.14  3.9 - 3.11                 best-can-do
-8        ansible-core 2.15  3.9 - 3.11                 official
-9        ansible-core 2.16  3.10 - 3.12                official
-10       ansible-core 2.17  3.10 - 3.12                official
-=======  =================  =========================  ===========
-
-======  ==========================
-Python  Supported Ansible versions
-------  --------------------------
-3.8     2.9 - 2.10, 3 - 6
-3.9     4 - 8
-3.10    5 - 9
-3.11    7 - 9
-3.12    9 and higher
-======  ==========================
+The `AAP included packages and versions <https://access.redhat.com/support/policy/updates/ansible-automation-platform#packages-and-versions>`_
+shows for each AAP version the ansible-core version it includes and the
+support timeframe.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -137,6 +137,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
   but the Makefile sets variables that depend on ansible being installed.
   That situation was handled correctly, but the error messages were confusing.
 
+* Docs: Adjusted README file to new Ansible Automation Hub requirements.
+  (issue #993)
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
The layout follows the [README.md file from the z/OS core collection](https://github.com/ansible-collections/ibm_zos_core/blob/staging-v1.10.0-release-tasks/README.md)

Link to the rendered versions
* README.md: https://github.com/zhmcclient/zhmc-ansible-modules/blob/andy/new-readme-content/README.md
* Support matrix: https://github.com/zhmcclient/zhmc-ansible-modules/blob/andy/new-readme-content/docs/source/installation.rst#support-matrix