### PR TITLE
Added zhmc_versions module

### DIFF
--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -39,6 +39,7 @@ Modules targeting the HMC (i.e. not a specific CPC):
    :maxdepth: 1
    :glob:
 
+   modules/zhmc_versions
    modules/zhmc_console
    modules/zhmc_user
    modules/zhmc_user_list

--- a/docs/source/modules/zhmc_versions.rst
+++ b/docs/source/modules/zhmc_versions.rst
@@ -1,0 +1,276 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_core/blob/dev/plugins/modules/zhmc_versions.py
+
+.. _zhmc_versions_module:
+
+
+zhmc_versions -- Retrieve HMC/CPC version and feature facts
+===========================================================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Retrieve version and feature facts for the targeted HMC and its managed CPCs.
+
+
+Requirements
+------------
+
+- No specific task or object-access permissions are required.
+
+
+
+
+Parameters
+----------
+
+
+hmc_host
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
+
+  | **required**: True
+  | **type**: raw
+
+
+hmc_auth
+  The authentication credentials for the HMC.
+
+  | **required**: True
+  | **type**: dict
+
+
+  userid
+    The userid (username) for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  password
+    The password for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  session_id
+    HMC session ID to be used. This is mutually exclusive with providing \ :literal:`userid`\  and \ :literal:`password`\  and can be created as described in :ref:\`zhmc\_session\_module\`.
+
+    | **required**: False
+    | **type**: str
+
+
+  ca_certs
+    Path name of certificate file or certificate directory to be used for verifying the HMC certificate. If null (default), the path name in the 'REQUESTS\_CA\_BUNDLE' environment variable or the path name in the 'CURL\_CA\_BUNDLE' environment variable is used, or if neither of these variables is set, the certificates in the Mozilla CA Certificate List provided by the 'certifi' Python package are used for verifying the HMC certificate.
+
+    | **required**: False
+    | **type**: str
+
+
+  verify
+    If True (default), verify the HMC certificate as specified in the \ :literal:`ca\_certs`\  parameter. If False, ignore what is specified in the \ :literal:`ca\_certs`\  parameter and do not verify the HMC certificate.
+
+    | **required**: False
+    | **type**: bool
+    | **default**: True
+
+
+
+cpc_names
+  List of CPC names for which facts are to be included in the result.
+
+  Default: All managed CPCs.
+
+  | **required**: False
+  | **type**: list
+  | **elements**: str
+
+
+log_file
+  File path of a log file to which the logic flow of this module as well as interactions with the HMC are logged. If null, logging will be propagated to the Python root logger.
+
+  | **required**: False
+  | **type**: str
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   ---
+   # Note: The following examples assume that some variables named 'my_*' are set.
+
+   - name: Retrieve version and feature information for HMC and all managed CPCs
+     zhmc_versions:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+     register: hmc1
+
+   - name: Retrieve version and feature information for HMC only
+     zhmc_versions:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       cpc_names: []
+     register: hmc1
+
+
+
+
+
+
+
+
+
+
+Return Values
+-------------
+
+
+changed
+  Indicates if any change has been made by the module. This will always be false.
+
+  | **returned**: always
+  | **type**: bool
+
+msg
+  An error message that describes the failure.
+
+  | **returned**: failure
+  | **type**: str
+
+versions
+  The version information.
+
+  | **returned**: success
+  | **type**: dict
+  | **sample**:
+
+    .. code-block:: json
+
+        {
+            "cpcs": [
+                {
+                    "cpc_api_features": [
+                        "adapter-network-information",
+                        "..."
+                    ],
+                    "dpm_enabled": true,
+                    "has_unacceptable_status": false,
+                    "name": "CPC1",
+                    "se_version": "2.16.0",
+                    "se_version_info": [
+                        2,
+                        16,
+                        0
+                    ],
+                    "status": "active"
+                }
+            ],
+            "hmc_api_features": [
+                "adapter-network-information",
+                "..."
+            ],
+            "hmc_api_version": "4.10",
+            "hmc_api_version_info": [
+                4,
+                10
+            ],
+            "hmc_name": "HMC1",
+            "hmc_version": "2.16.0",
+            "hmc_version_info": [
+                2,
+                16,
+                0
+            ]
+        }
+
+  hmc_name
+    HMC name
+
+    | **type**: str
+
+  hmc_version
+    HMC version, as a string.
+
+    | **type**: str
+
+  hmc_version_info
+    HMC version, as a list of integers.
+
+    | **type**: list
+    | **elements**: int
+
+  hmc_api_version
+    HMC API version, as a string.
+
+    | **type**: str
+
+  hmc_api_version_info
+    HMC API version, as a list of integers.
+
+    | **type**: list
+    | **elements**: int
+
+  hmc_api_features
+    The available HMC API features.
+
+    | **type**: list
+    | **elements**: str
+
+  cpcs
+    Version data for the requested CPCs of the HMC.
+
+    | **type**: list
+    | **elements**: dict
+
+    name
+      CPC name.
+
+      | **type**: str
+
+    status
+      The current status of the CPC. For details, see the description of the 'status' property in the data model of the 'CPC' resource (see :term:\`HMC API\`).
+
+      | **type**: str
+
+    has_unacceptable_status
+      Indicates whether the current status of the CPC is unacceptable, based on its 'acceptable-status' property.
+
+      | **type**: bool
+
+    dpm_enabled
+      Indicates wehether the CPC is in DPM mode (true) or in classic mode (false).
+
+      | **type**: bool
+
+    se_version
+      SE version of the CPC, as a string.
+
+      | **type**: str
+
+    se_version_info
+      SE version of the CPC, as a list of integers.
+
+      | **type**: list
+      | **elements**: int
+
+    cpc_api_features
+      The available CPC API features.
+
+      | **type**: list
+      | **elements**: str
+
+
+

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -94,6 +94,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Docs: Improved the short descriptions of the modules. (issue #998)
 
+* Added a new module zhmc_versions that retrieves facts for HMC/CPC versions
+  and features.
+
 **Cleanup:**
 
 * Modernized the code to match the minimum Python version 3.8 (use of f-strings,

--- a/plugins/modules/zhmc_versions.py
+++ b/plugins/modules/zhmc_versions.py
@@ -1,0 +1,394 @@
+#!/usr/bin/python
+# Copyright 2024 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# For information on the format of the ANSIBLE_METADATA, DOCUMENTATION,
+# EXAMPLES, and RETURN strings, see
+# http://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['stableinterface'],
+    'supported_by': 'community',
+    'shipped_by': 'other',
+    'other_repo_url': 'https://github.com/zhmcclient/zhmc-ansible-modules'
+}
+
+DOCUMENTATION = """
+---
+module: zhmc_versions
+version_added: "2.15.0"
+short_description: Retrieve HMC/CPC version and feature facts
+description:
+  - Retrieve version and feature facts for the targeted HMC and its managed
+    CPCs.
+author:
+  - Andreas Maier (@andy-maier)
+requirements:
+  - "No specific task or object-access permissions are required."
+options:
+  hmc_host:
+    description:
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
+    required: true
+  hmc_auth:
+    description:
+      - The authentication credentials for the HMC.
+    type: dict
+    required: true
+    suboptions:
+      userid:
+        description:
+          - The userid (username) for authenticating with the HMC.
+            This is mutually exclusive with providing C(session_id).
+        type: str
+        required: false
+        default: null
+      password:
+        description:
+          - The password for authenticating with the HMC.
+            This is mutually exclusive with providing C(session_id).
+        type: str
+        required: false
+        default: null
+      session_id:
+        description:
+          - HMC session ID to be used.
+            This is mutually exclusive with providing C(userid) and C(password)
+            and can be created as described in :ref:`zhmc_session_module`.
+        type: str
+        required: false
+        default: null
+      ca_certs:
+        description:
+          - Path name of certificate file or certificate directory to be used
+            for verifying the HMC certificate. If null (default), the path name
+            in the 'REQUESTS_CA_BUNDLE' environment variable or the path name
+            in the 'CURL_CA_BUNDLE' environment variable is used, or if neither
+            of these variables is set, the certificates in the Mozilla CA
+            Certificate List provided by the 'certifi' Python package are used
+            for verifying the HMC certificate.
+        type: str
+        required: false
+        default: null
+      verify:
+        description:
+          - If True (default), verify the HMC certificate as specified in the
+            C(ca_certs) parameter. If False, ignore what is specified in the
+            C(ca_certs) parameter and do not verify the HMC certificate.
+        type: bool
+        required: false
+        default: true
+  cpc_names:
+    description:
+      - "List of CPC names for which facts are to be included in the result."
+      - "Default: All managed CPCs."
+    type: list
+    elements: str
+    required: false
+    default: null
+  log_file:
+    description:
+      - "File path of a log file to which the logic flow of this module as well
+         as interactions with the HMC are logged. If null, logging will be
+         propagated to the Python root logger."
+    type: str
+    required: false
+    default: null
+  _faked_session:
+    description:
+      - "An internal parameter used for testing the module."
+    type: raw
+    required: false
+    default: null
+"""
+
+EXAMPLES = """
+---
+# Note: The following examples assume that some variables named 'my_*' are set.
+
+- name: Retrieve version and feature information for HMC and all managed CPCs
+  zhmc_versions:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+  register: hmc1
+
+- name: Retrieve version and feature information for HMC only
+  zhmc_versions:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    cpc_names: []
+  register: hmc1
+"""
+
+RETURN = """
+changed:
+  description: Indicates if any change has been made by the module.
+    This will always be false.
+  returned: always
+  type: bool
+msg:
+  description: An error message that describes the failure.
+  returned: failure
+  type: str
+versions:
+  description: "The version information."
+  returned: success
+  type: dict
+  contains:
+    hmc_name:
+      description: "HMC name"
+      type: str
+    hmc_version:
+      description: "HMC version, as a string."
+      type: str
+    hmc_version_info:
+      description: "HMC version, as a list of integers."
+      type: list
+      elements: int
+    hmc_api_version:
+      description: "HMC API version, as a string."
+      type: str
+    hmc_api_version_info:
+      description: "HMC API version, as a list of integers."
+      type: list
+      elements: int
+    hmc_api_features:
+      description: "The available HMC API features."
+      type: list
+      elements: str
+    cpcs:
+      description: "Version data for the requested CPCs of the HMC."
+      type: list
+      elements: dict
+      contains:
+        name:
+          description: "CPC name."
+          type: str
+        status:
+          description: "The current status of the CPC. For details, see the
+            description of the 'status' property in the data model of the 'CPC'
+            resource (see :term:`HMC API`)."
+          type: str
+        has_unacceptable_status:
+          description: "Indicates whether the current status of the CPC is
+            unacceptable, based on its 'acceptable-status' property."
+          type: bool
+        dpm_enabled:
+          description: "Indicates wehether the CPC is in DPM mode (true) or in
+            classic mode (false)."
+          type: bool
+        se_version:
+          description: "SE version of the CPC, as a string."
+          type: str
+        se_version_info:
+          description: "SE version of the CPC, as a list of integers."
+          type: list
+          elements: int
+        cpc_api_features:
+          description: "The available CPC API features."
+          type: list
+          elements: str
+
+  sample:
+    {
+        "hmc_name": "HMC1",
+        "hmc_version": "2.16.0",
+        "hmc_version_info": [2, 16, 0],
+        "hmc_api_version": "4.10",
+        "hmc_api_version_info": [4, 10],
+        "hmc_api_features": [
+            "adapter-network-information",
+            "..."
+        ],
+        "cpcs": [
+            {
+                "name": "CPC1",
+                "status": "active",
+                "has_unacceptable_status": false,
+                "dpm_enabled": true,
+                "se_version": "2.16.0",
+                "se_version_info": [2, 16, 0],
+                "cpc_api_features": [
+                    "adapter-network-information",
+                    "..."
+                ]
+            }
+        ]
+    }
+"""
+
+import logging  # noqa: E402
+import traceback  # noqa: E402
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+
+from ..module_utils.common import log_init, open_session, close_session, \
+    hmc_auth_parameter, Error, missing_required_lib, \
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+
+try:
+    import requests.packages.urllib3
+    IMP_URLLIB3_ERR = None
+except ImportError:
+    IMP_URLLIB3_ERR = traceback.format_exc()
+
+try:
+    import zhmcclient
+    IMP_ZHMCCLIENT_ERR = None
+except ImportError:
+    IMP_ZHMCCLIENT_ERR = traceback.format_exc()
+
+# Python logger name for this module
+LOGGER_NAME = 'zhmc_versions'
+
+LOGGER = logging.getLogger(LOGGER_NAME)
+
+
+def get_versions(module):
+    """
+    Retrieve the data and return a dict with the results of this module.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    cpc_names = module.params['cpc_names']
+
+    versions = {}
+    session, logoff = open_session(module.params)
+    try:
+
+        client = zhmcclient.Client(session)
+        console = client.consoles.console
+
+        # Get HMC version info
+        vers = client.query_api_version()
+        versions['hmc_name'] = vers['hmc-name']
+        hmc_version_str = vers['hmc-version']
+        hmc_version_info = list(map(int, hmc_version_str.split('.')))
+        versions['hmc_version'] = hmc_version_str
+        versions['hmc_version_info'] = hmc_version_info
+        api_version_info = [
+            vers['api-major-version'],
+            vers['api-minor-version']]
+        api_version_str = '{}.{}'.format(*api_version_info)
+        versions['hmc_api_version'] = api_version_str
+        versions['hmc_api_version_info'] = api_version_info
+
+        # Get HMC API features
+        versions['hmc_api_features'] = console.list_api_features()
+
+        # List managed CPCs
+        cpcs = client.cpcs.list()
+        versions['cpcs'] = []
+        for cpc in cpcs:
+
+            # Filter on the requested CPCs
+            if cpc_names is not None and cpc.name not in cpc_names:
+                continue
+
+            cpc_vers = {}
+
+            # Get CPC data from list result
+            cpc_vers['name'] = cpc.prop('name')
+            cpc_vers['status'] = cpc.prop('status')
+            cpc_vers['has_unacceptable_status'] = \
+                cpc.prop('has-unacceptable-status')
+            cpc_vers['dpm_enabled'] = cpc.prop('dpm-enabled')
+            se_version_str = cpc.prop('se-version')
+            se_version_info = list(map(int, se_version_str.split('.')))
+            cpc_vers['se_version'] = se_version_str
+            cpc_vers['se_version_info'] = se_version_info
+
+            # Get CPC API features
+            cpc_vers['cpc_api_features'] = cpc.list_api_features()
+
+            versions['cpcs'].append(cpc_vers)
+
+        return False, versions
+
+    finally:
+        close_session(session, logoff)
+
+
+def main():
+
+    # The following definition of module input parameters must match the
+    # description of the options in the DOCUMENTATION string.
+    argument_spec = dict(
+        hmc_host=dict(required=True, type='raw'),
+        hmc_auth=hmc_auth_parameter(),
+        cpc_names=dict(required=False, type='list', elements='str',
+                       default=None),
+        log_file=dict(required=False, type='str', default=None),
+        _faked_session=dict(required=False, type='raw'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True)
+
+    if IMP_URLLIB3_ERR is not None:
+        module.fail_json(msg=missing_required_lib("requests"),
+                         exception=IMP_URLLIB3_ERR)
+
+    requests.packages.urllib3.disable_warnings()
+
+    if IMP_ZHMCCLIENT_ERR is not None:
+        module.fail_json(msg=missing_required_lib("zhmcclient"),
+                         exception=IMP_ZHMCCLIENT_ERR)
+
+    common_fail_on_import_errors(module)
+
+    log_file = module.params['log_file']
+    log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
+
+    _params = dict(module.params)
+    del _params['hmc_auth']
+    LOGGER.debug("Module entry: params: %r", _params)
+
+    try:
+
+        changed, versions = get_versions(module)
+
+    except (Error, zhmcclient.Error) as exc:
+        # These exceptions are considered errors in the environment or in user
+        # input. They have a proper message that stands on its own, so we
+        # simply pass that message on and will not need a traceback.
+        msg = f"{exc.__class__.__name__}: {exc}"
+        LOGGER.debug("Module exit (failure): msg: %r", msg)
+        module.fail_json(msg=msg)
+    # Other exceptions are considered module errors and are handled by Ansible
+    # by showing the traceback.
+
+    LOGGER.debug("Module exit (success): changed: %s, versions: %r",
+                 changed, versions)
+    module.exit_json(
+        changed=changed, versions=versions)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/end2end/test_zhmc_versions.py
+++ b/tests/end2end/test_zhmc_versions.py
@@ -1,0 +1,208 @@
+# Copyright 2024 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for zhmc_versions module.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+from unittest import mock
+import requests.packages.urllib3
+import zhmcclient
+# pylint: disable=line-too-long,unused-import
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+# pylint: enable=line-too-long,unused-import
+
+from plugins.modules import zhmc_versions
+from .utils import mock_ansible_module, get_failure_msg
+
+requests.packages.urllib3.disable_warnings()
+
+# Print debug messages
+DEBUG = False
+
+LOG_FILE = 'zhmc_versions.log' if DEBUG else None
+
+
+def get_module_output(mod_obj):
+    """
+    Return the module output as a tuple (changed, versions) (i.e.
+    the arguments of the call to exit_json()).
+    If the module failed, return None.
+    """
+
+    def func(changed, versions):
+        return changed, versions
+
+    if not mod_obj.exit_json.called:
+        return None
+    call_args = mod_obj.exit_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])
+
+
+def assert_versions(
+        versions, exp_hmc_api_version, exp_hmc_api_features,
+        exp_cpc_props_dict, exp_cpc_api_features_dict):
+    """
+    Assert the output of the zhmc_versions module.
+
+    Parameters:
+
+      exp_hmc_api_version(dict): Expected HMC APi version info, as the result
+        of Client.query_api_version().
+
+      exp_hmc_api_features(list): List of expected HMC API features.
+
+      exp_cpc_props_dict(dict): Expected CPCs and their properties.
+        Key: CPC name.
+        Value: Dict of expected CPC properties (with hyphens in their names)
+
+      exp_cpc_api_features_dict(dict): Expected CPCs and their API features.
+        Key: CPC name.
+        Value: List of expected CPC API features.
+    """
+
+    # Check against exp_hmc_api_version
+    assert versions['hmc_name'] == exp_hmc_api_version['hmc-name']
+    hmc_version_str = exp_hmc_api_version['hmc-version']
+    hmc_version_info = list(map(int, hmc_version_str.split('.')))
+    assert versions['hmc_version'] == hmc_version_str
+    assert versions['hmc_version_info'] == hmc_version_info
+    api_version_info = [
+        exp_hmc_api_version['api-major-version'],
+        exp_hmc_api_version['api-minor-version']]
+    api_version_str = '{}.{}'.format(*api_version_info)
+    assert versions['hmc_api_version'] == api_version_str
+    assert versions['hmc_api_version_info'] == api_version_info
+
+    # Check against exp_hmc_api_features
+    assert isinstance(versions['hmc_api_features'], list)
+    assert set(versions['hmc_api_features']) == set(exp_hmc_api_features)
+
+    # Check against exp_cpc_props_dict and exp_cpc_api_features_dict
+    assert len(versions['cpcs']) == len(exp_cpc_props_dict)
+    assert len(versions['cpcs']) == len(exp_cpc_api_features_dict)
+    for cpc_item in versions['cpcs']:
+
+        assert 'name' in cpc_item
+        cpc_name = cpc_item['name']
+        assert cpc_name in exp_cpc_props_dict
+        exp_cpc_props = exp_cpc_props_dict[cpc_name]
+        assert cpc_name in exp_cpc_api_features_dict
+        exp_cpc_api_features = exp_cpc_api_features_dict[cpc_name]
+        assert cpc_item['name'] == exp_cpc_props['name']
+        assert cpc_item['status'] == exp_cpc_props['status']
+        assert cpc_item['has_unacceptable_status'] == \
+            exp_cpc_props['has-unacceptable-status']
+        assert cpc_item['dpm_enabled'] == exp_cpc_props['dpm-enabled']
+        se_version_str = exp_cpc_props['se-version']
+        se_version_info = list(map(int, se_version_str.split('.')))
+        assert cpc_item['se_version'] == se_version_str
+        assert cpc_item['se_version_info'] == se_version_info
+
+        assert set(cpc_item['cpc_api_features']) == set(exp_cpc_api_features)
+
+
+@pytest.mark.parametrize(
+    "check_mode", [
+        pytest.param(False, id="check_mode=False"),
+        pytest.param(True, id="check_mode=True"),
+    ]
+)
+@pytest.mark.parametrize(
+    "cpc_filter", [
+        pytest.param('all', id="cpc_filter=all"),
+        pytest.param('first', id="cpc_filter=first"),
+        pytest.param('none', id="cpc_filter=none"),
+    ]
+)
+@mock.patch("plugins.modules.zhmc_versions.AnsibleModule", autospec=True)
+def test_zhmc_versions(
+        ansible_mod_cls, cpc_filter, check_mode,
+        hmc_session):  # noqa: F811, E501
+    """
+    Test the zhmc_versions module.
+    """
+
+    hd = hmc_session.hmc_definition
+    hmc_host = hd.host
+    hmc_auth = dict(userid=hd.userid, password=hd.password,
+                    ca_certs=hd.ca_certs, verify=hd.verify)
+
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+
+    faked_session = hmc_session if hd.mock_file else None
+
+    # Determine the expected results
+    exp_hmc_api_version = client.query_api_version()
+    exp_hmc_api_features = console.list_api_features()
+    exp_cpc_props_dict = {}  # key: CPC name, value: dict of CPC properties
+    exp_cpc_api_features_dict = {}  # key: CPC name, value: list of CPC API feat
+    if cpc_filter != 'none':
+        first_cpc = None
+        for cpc in client.cpcs.list():
+            exp_cpc_props_dict[cpc.name] = dict(cpc.properties)
+            exp_cpc_api_features_dict[cpc.name] = cpc.list_api_features()
+            if cpc_filter == 'first':
+                first_cpc = cpc
+                break
+
+    if cpc_filter == 'all':
+        # Note: All optional params need to be provided, so here we set
+        # the default explicitly.
+        cpc_names = None
+    elif cpc_filter == 'none':
+        cpc_names = []
+    else:
+        assert cpc_filter == 'first'
+        if first_cpc is None:
+            pytest.skip("HMC does not manage any CPCs")
+        cpc_names = [first_cpc.name]
+
+    # Prepare module input parameters (must be all required + optional)
+    params = {
+        'hmc_host': hmc_host,
+        'hmc_auth': hmc_auth,
+        'cpc_names': cpc_names,
+        'log_file': LOG_FILE,
+        '_faked_session': faked_session,
+    }
+
+    # Prepare mocks for AnsibleModule object
+    mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+    # Exercise the code to be tested
+    with pytest.raises(SystemExit) as exc_info:
+        zhmc_versions.main()
+    exit_code = exc_info.value.args[0]
+
+    # Assert module exit code
+    assert exit_code == 0, \
+        f"Module failed with exit code {exit_code} and message:\n" \
+        f"{get_failure_msg(mod_obj)}"
+
+    # Assert module output
+    changed, versions = get_module_output(mod_obj)
+    assert changed is False
+
+    assert_versions(
+        versions, exp_hmc_api_version, exp_hmc_api_features,
+        exp_cpc_props_dict, exp_cpc_api_features_dict)

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -25,4 +25,5 @@ plugins/modules/zhmc_user_list.py validate-modules:missing-gplv3-license  # Lice
 plugins/modules/zhmc_user_role_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_versions.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_virtual_function.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -25,4 +25,5 @@ plugins/modules/zhmc_user_list.py validate-modules:missing-gplv3-license  # Lice
 plugins/modules/zhmc_user_role_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_versions.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_virtual_function.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -25,4 +25,5 @@ plugins/modules/zhmc_user_list.py validate-modules:missing-gplv3-license  # Lice
 plugins/modules/zhmc_user_role_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_versions.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_virtual_function.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -25,4 +25,5 @@ plugins/modules/zhmc_user_list.py validate-modules:missing-gplv3-license  # Lice
 plugins/modules/zhmc_user_role_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_versions.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_virtual_function.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0


### PR DESCRIPTION
For details, see the commit message.

Link to RST source of docs page for new module: https://github.com/zhmcclient/zhmc-ansible-modules/blob/andy/versions-module/docs/source/modules/zhmc_versions.rst

Particular review points:
* Should the CPCs be filtered, as currently implemented
* Should the CPC Firmware Features not be returned, as currently implemented (that would require "Get CPC Properties")