### PR TITLE
Removed Python 3.13-beta1 again from tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\" ], \
-            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\", \"3.13.0-beta.1\" ], \
+            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
             \"package_level\": [ \"minimum\", \"latest\", \"ansible\" ] \
           }" >> $GITHUB_OUTPUT; \
         else \
@@ -83,11 +83,6 @@ jobs:
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.11\", \
                 \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.13.0-beta.1\", \
-                \"package_level\": \"latest\" \
               }, \
               { \
                 \"os\": \"macos-latest\", \

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -72,9 +72,6 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
   because we can test only one Ansible version on each Python version and
   we ran out of Python versions.
 
-* Test: Added tests for Python 3.13 (beta.1). Ansible sanity tests are skipped
-  because Ansible up to version 10 does not support sanity tests on Python 3.13.
-
 * Added a new make target 'end2end_show' to show the HMCs defined for end2end
   tests. (issue #888)
 


### PR DESCRIPTION
No review needed.