### PR TITLE
Added common functions for hyphen-underscore property name conversions

### DIFF
--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -19,6 +19,7 @@ colorama==0.4.6
 # packaging is covered in requirements.txt
 # requests is covered in requirements.txt
 requests-mock==1.6.0
+immutable-views==0.6.0
 
 # Unit test (indirect dependencies):
 pluggy==1.3.0

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -15,6 +15,7 @@ colorama>=0.4.6
 # packaging is covered in requirements.txt
 # requests is covered in requirements.txt
 requests-mock>=1.6.0
+immutable-views>=0.6.0
 
 # Unit test (indirect dependencies):
 pluggy>=1.3.0


### PR DESCRIPTION
For details, see the commit message.

This is intended to be used for consolidating all the conversions between hyphenized and underscored property names in the modules.