### PR TITLE
Added user_pattern and user_pattern_list modules

### DIFF
--- a/docs/source/bibliography.rst
+++ b/docs/source/bibliography.rst
@@ -50,3 +50,6 @@ Resources
    HMC API 2.15.0
        `IBM SC27-2638, IBM Z Hardware Management Console Web Services API (Version 2.15.0) <https://www.ibm.com/support/pages/node/6019720>`_
        (covers both GA1 and GA2)
+
+   Java regular expressions
+       `Java class java.util.regex.Pattern <https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html>`_

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -47,6 +47,8 @@ Modules targeting the HMC (i.e. not a specific CPC):
    modules/zhmc_password_rule_list
    modules/zhmc_user_role
    modules/zhmc_user_role_list
+   modules/zhmc_user_pattern
+   modules/zhmc_user_pattern_list
    modules/zhmc_ldap_server_definition
    modules/zhmc_ldap_server_definition_list
 

--- a/docs/source/modules/zhmc_user_pattern.rst
+++ b/docs/source/modules/zhmc_user_pattern.rst
@@ -1,0 +1,288 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_core/blob/dev/plugins/modules/zhmc_user_pattern.py
+
+.. _zhmc_user_pattern_module:
+
+
+zhmc_user_pattern -- Manage an HMC user pattern
+===============================================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Gather facts about a user pattern on an HMC of a Z system.
+- Create, delete, or update a user pattern on an HMC.
+
+
+Requirements
+------------
+
+- The HMC userid must have these task permissions: 'Manage User Patterns'.
+
+
+
+
+Parameters
+----------
+
+
+hmc_host
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
+
+  | **required**: True
+  | **type**: raw
+
+
+hmc_auth
+  The authentication credentials for the HMC.
+
+  | **required**: True
+  | **type**: dict
+
+
+  userid
+    The userid (username) for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`hmc\_auth.session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  password
+    The password for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`hmc\_auth.session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  session_id
+    HMC session ID to be used. This is mutually exclusive with providing \ :literal:`hmc\_auth.userid`\  and \ :literal:`hmc\_auth.password`\  and can be created as described in the \ :ref:`zhmc\_session module <zhmc_session_module>`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  ca_certs
+    Path name of certificate file or certificate directory to be used for verifying the HMC certificate. If null (default), the path name in the \ :envvar:`REQUESTS\_CA\_BUNDLE`\  environment variable or the path name in the \ :envvar:`CURL\_CA\_BUNDLE`\  environment variable is used, or if neither of these variables is set, the certificates in the Mozilla CA Certificate List provided by the 'certifi' Python package are used for verifying the HMC certificate.
+
+    | **required**: False
+    | **type**: str
+
+
+  verify
+    If True (default), verify the HMC certificate as specified in the \ :literal:`hmc\_auth.ca\_certs`\  parameter. If False, ignore what is specified in the \ :literal:`hmc\_auth.ca\_certs`\  parameter and do not verify the HMC certificate.
+
+    | **required**: False
+    | **type**: bool
+    | **default**: True
+
+
+
+name
+  The name of the target user pattern.
+
+  | **required**: True
+  | **type**: str
+
+
+state
+  The desired state for the HMC user pattern. All states are fully idempotent within the limits of the properties that can be changed:
+
+  \* \ :literal:`absent`\ : Ensures that the user pattern does not exist.
+
+  \* \ :literal:`present`\ : Ensures that the user pattern exists and has the specified properties.
+
+  \* \ :literal:`facts`\ : Returns the user pattern properties.
+
+  | **required**: True
+  | **type**: str
+  | **choices**: absent, present, facts
+
+
+properties
+  Dictionary with desired properties for the user pattern. Used for \ :literal:`state=present`\ ; ignored for \ :literal:`state=absent|facts`\ . Dictionary key is the property name with underscores instead of hyphens, and dictionary value is the property value in YAML syntax. Integer properties may also be provided as decimal strings.
+
+  The possible input properties in this dictionary are the properties defined as writeable in the data model for User Pattern resources (where the property names contain underscores instead of hyphens), with the following exceptions:
+
+  \* \ :literal:`name`\ : Cannot be specified because the name has already been specified in the \ :literal:`name`\  module parameter.
+
+  \* \ :literal:`...\_uri`\ : Cannot be set directly, but indirectly via the corresponding artificial property \ :literal:`...\_name`\ . An empty string for the name will set the URI to null.
+
+  Properties omitted in this dictionary will remain unchanged when the user pattern already exists, and will get the default value defined in the data model for user patterns in the \ :ref:`HMC API <HMC API>`\  book when the user pattern is being created.
+
+  | **required**: False
+  | **type**: dict
+
+
+log_file
+  File path of a log file to which the logic flow of this module as well as interactions with the HMC are logged. If null, logging will be propagated to the Python root logger.
+
+  | **required**: False
+  | **type**: str
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   ---
+   # Note: The following examples assume that some variables named 'my_*' are set.
+
+   - name: Gather facts about a user pattern
+     zhmc_user_pattern:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       name: "{{ my_user_pattern_name }}"
+       state: facts
+     register: userpattern1
+
+   - name: Ensure the user pattern does not exist
+     zhmc_user_pattern:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       name: "{{ my_user_pattern_name }}"
+       state: absent
+
+   - name: Ensure the user pattern exists and has certain properties
+     zhmc_user_pattern:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+       name: "{{ my_user_pattern_name }}"
+       state: present
+       properties:
+         description: "Example user pattern 1"
+     register: userpattern1
+
+
+
+
+
+
+
+
+
+
+Return Values
+-------------
+
+
+changed
+  Indicates if any change has been made by the module. For \ :literal:`state=facts`\ , always will be false.
+
+  | **returned**: always
+  | **type**: bool
+
+msg
+  An error message that describes the failure.
+
+  | **returned**: failure
+  | **type**: str
+
+user_pattern
+  For \ :literal:`state=absent`\ , an empty dictionary.
+
+  For \ :literal:`state=present|facts`\ , a dictionary with the resource properties of the target user pattern and some additional artificial properties.
+
+  | **returned**: success
+  | **type**: dict
+  | **sample**:
+
+    .. code-block:: json
+
+        {
+            "class": "user-pattern",
+            "description": "A pattern that matches a bluepages email address.",
+            "domain_name_restrictions": null,
+            "domain_name_restrictions_ldap_server_definition_name": null,
+            "domain_name_restrictions_ldap_server_definition_uri": null,
+            "element_id": "cbcaf7a0-46cc-11e9-bfd3-f44a39cd42f9",
+            "element_uri": "/api/console/user-patterns/cbcaf7a0-46cc-11e9-bfd3-f44a39cd42f9",
+            "ldap_group_default_template_name": null,
+            "ldap_group_default_template_uri": null,
+            "ldap_group_ldap_server_definition_name": null,
+            "ldap_group_ldap_server_definition_uri": null,
+            "ldap_group_to_template_mappings": null,
+            "ldap_server_definition_name": null,
+            "ldap_server_definition_uri": null,
+            "name": "Bluepages email address",
+            "parent": "/api/console",
+            "pattern": "*@*ibm.com",
+            "replication_overwrite_possible": false,
+            "retention_time": 90,
+            "search_order_index": 0,
+            "specific_template_name": "Product Engineering and Access Administrator",
+            "specific_template_uri": "/api/users/97769500-4a81-11e9-aa1b-00106f23f636",
+            "template_name_override": null,
+            "template_name_override_default_template_name": null,
+            "template_name_override_default_template_uri": null,
+            "template_name_override_ldap_server_definition_name": null,
+            "template_name_override_ldap_server_definition_uri": null,
+            "type": "glob-like",
+            "user_template_name": "Product Engineering and Access Administrator",
+            "user_template_uri": "/api/users/97769500-4a81-11e9-aa1b-00106f23f636"
+        }
+
+  name
+    User Pattern name
+
+    | **type**: str
+
+  {property}
+    Additional properties of the user pattern, as described in the data model of the 'User Pattern' object in the \ :ref:`HMC API <HMC API>`\  book. The property names will have underscores instead of hyphens.
+
+    The items in the \ :literal:`ldap\_group\_to\_template\_mappings`\  property have an additional item \ :literal:`template-name`\  which is the name of the resource object referenced by \ :literal:`template-uri`\ .
+
+    | **type**: raw
+
+  domain_name_restrictions_ldap_server_definition_name
+    Name of the resource object referenced by the corresponding ...\_uri property.
+
+    | **type**: str
+
+  ldap_group_default_template_name
+    Name of the resource object referenced by the corresponding ...\_uri property.
+
+    | **type**: str
+
+  ldap_group_ldap_server_definition_name
+    Name of the resource object referenced by the corresponding ...\_uri property.
+
+    | **type**: str
+
+  ldap_server_definition_name
+    Name of the resource object referenced by the corresponding ...\_uri property.
+
+    | **type**: str
+
+  specific_template_name
+    Name of the resource object referenced by the corresponding ...\_uri property.
+
+    | **type**: str
+
+  template_name_override_default_template_name
+    Name of the resource object referenced by the corresponding ...\_uri property.
+
+    | **type**: str
+
+  template_name_override_ldap_server_definition_name
+    Name of the resource object referenced by the corresponding ...\_uri property.
+
+    | **type**: str
+
+  user_template_name
+    Name of the resource object referenced by the corresponding ...\_uri property.
+
+    | **type**: str
+
+

--- a/docs/source/modules/zhmc_user_pattern_list.rst
+++ b/docs/source/modules/zhmc_user_pattern_list.rst
@@ -1,0 +1,192 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_core/blob/dev/plugins/modules/zhmc_user_pattern_list.py
+
+.. _zhmc_user_pattern_list_module:
+
+
+zhmc_user_pattern_list -- List HMC user patterns
+================================================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- List User Patterns on the HMC.
+
+
+Requirements
+------------
+
+- The HMC userid must have object-access permission to the User Pattern objects included in the result, or task permission to the 'Manage User Patterns' task.
+
+
+
+
+Parameters
+----------
+
+
+hmc_host
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
+
+  | **required**: True
+  | **type**: raw
+
+
+hmc_auth
+  The authentication credentials for the HMC.
+
+  | **required**: True
+  | **type**: dict
+
+
+  userid
+    The userid (username) for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`hmc\_auth.session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  password
+    The password for authenticating with the HMC. This is mutually exclusive with providing \ :literal:`hmc\_auth.session\_id`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  session_id
+    HMC session ID to be used. This is mutually exclusive with providing \ :literal:`hmc\_auth.userid`\  and \ :literal:`hmc\_auth.password`\  and can be created as described in the \ :ref:`zhmc\_session module <zhmc_session_module>`\ .
+
+    | **required**: False
+    | **type**: str
+
+
+  ca_certs
+    Path name of certificate file or certificate directory to be used for verifying the HMC certificate. If null (default), the path name in the \ :envvar:`REQUESTS\_CA\_BUNDLE`\  environment variable or the path name in the \ :envvar:`CURL\_CA\_BUNDLE`\  environment variable is used, or if neither of these variables is set, the certificates in the Mozilla CA Certificate List provided by the 'certifi' Python package are used for verifying the HMC certificate.
+
+    | **required**: False
+    | **type**: str
+
+
+  verify
+    If True (default), verify the HMC certificate as specified in the \ :literal:`hmc\_auth.ca\_certs`\  parameter. If False, ignore what is specified in the \ :literal:`hmc\_auth.ca\_certs`\  parameter and do not verify the HMC certificate.
+
+    | **required**: False
+    | **type**: bool
+    | **default**: True
+
+
+
+full_properties
+  If True, all properties of each user pattern will be returned. Default: False.
+
+  Note: Setting this to True causes a loop of 'Get User Pattern Properties' operations to be executed.
+
+  | **required**: False
+  | **type**: bool
+
+
+log_file
+  File path of a log file to which the logic flow of this module as well as interactions with the HMC are logged. If null, logging will be propagated to the Python root logger.
+
+  | **required**: False
+  | **type**: str
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   ---
+   # Note: The following examples assume that some variables named 'my_*' are set.
+
+   - name: List User Patterns
+     zhmc_user_pattern_list:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth: "{{ my_hmc_auth }}"
+     register: upattern_list
+
+
+
+
+
+
+
+
+
+
+Return Values
+-------------
+
+
+changed
+  Indicates if any change has been made by the module. This will always be false.
+
+  | **returned**: always
+  | **type**: bool
+
+msg
+  An error message that describes the failure.
+
+  | **returned**: failure
+  | **type**: str
+
+user_patterns
+  The list of User Patterns, with a subset or all of their properties, dependent on \ :literal:`full\_properties`\ .
+
+  | **returned**: success
+  | **type**: list
+  | **elements**: dict
+  | **sample**:
+
+    .. code-block:: json
+
+        [
+            {
+                "element_uri": "/api/console/user-patterns/cbcaf7a0-46cc-11e9-bfd3-f44a39cd42f9",
+                "name": "Bluepages email address",
+                "type": "glob-like"
+            },
+            {
+                "element_uri": "/api/console/user-patterns/fb22d4a2-4e40-11e9-a8a8-00106f23f636",
+                "name": "regexp pattern 1",
+                "type": "regular-expression"
+            }
+        ]
+
+  name
+    User pattern name
+
+    | **type**: str
+
+  element_uri
+    Element URI of the User Pattern object
+
+    | **type**: str
+
+  type
+    The style in which the user pattern is expressed, as one of the following values:
+
+    \ :literal:`glob-like`\  - Glob-like pattern as used in file names, supporting the special characters \ :literal:`\*`\  and \ :literal:`?`\ .
+
+    \ :literal:`regular-expression`\  - Regular expression pattern using :term:\`Java regular expressions\`.
+
+    | **type**: str
+
+  {additional_property}
+    Additional properties requested via \ :literal:`full\_properties`\ , as described in the data model of the 'User Pattern' object in the \ :ref:`HMC API <HMC API>`\  book. The property names will have underscores instead of hyphens.
+
+    | **type**: raw
+
+

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -118,6 +118,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
   how to build and install a development version of the collection from
   the repo. (issue #1008)
 
+* Added new Ansible modules 'zhmc_user_pattern_list' and 'zhmc_user_pattern'
+  for listing and managing user patterns on the HMC. (issue #361)
+
 **Cleanup:**
 
 * Modernized the code to match the minimum Python version 3.8 (use of f-strings,

--- a/plugins/modules/zhmc_user_pattern.py
+++ b/plugins/modules/zhmc_user_pattern.py
@@ -1,0 +1,973 @@
+#!/usr/bin/python
+# Copyright 2024 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# For information on the format of the ANSIBLE_METADATA, DOCUMENTATION,
+# EXAMPLES, and RETURN strings, see
+# http://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['stableinterface'],
+    'supported_by': 'community',
+    'shipped_by': 'other',
+    'other_repo_url': 'https://github.com/zhmcclient/zhmc-ansible-modules'
+}
+
+DOCUMENTATION = """
+---
+module: zhmc_user_pattern
+version_added: "2.15.0"
+short_description: Manage an HMC user pattern
+description:
+  - Gather facts about a user pattern on an HMC of a Z system.
+  - Create, delete, or update a user pattern on an HMC.
+author:
+  - Andreas Maier (@andy-maier)
+requirements:
+  - "The HMC userid must have these task permissions:
+    'Manage User Patterns'."
+options:
+  hmc_host:
+    description:
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
+    required: true
+  hmc_auth:
+    description:
+      - The authentication credentials for the HMC.
+    type: dict
+    required: true
+    suboptions:
+      userid:
+        description:
+          - The userid (username) for authenticating with the HMC.
+            This is mutually exclusive with providing O(hmc_auth.session_id).
+        type: str
+        required: false
+        default: null
+      password:
+        description:
+          - The password for authenticating with the HMC.
+            This is mutually exclusive with providing O(hmc_auth.session_id).
+        type: str
+        required: false
+        default: null
+      session_id:
+        description:
+          - HMC session ID to be used.
+            This is mutually exclusive with providing O(hmc_auth.userid) and
+            O(hmc_auth.password) and can be created as described in the
+            R(zhmc_session module,zhmc_session_module).
+        type: str
+        required: false
+        default: null
+      ca_certs:
+        description:
+          - Path name of certificate file or certificate directory to be used
+            for verifying the HMC certificate. If null (default), the path name
+            in the E(REQUESTS_CA_BUNDLE) environment variable or the path name
+            in the E(CURL_CA_BUNDLE) environment variable is used, or if neither
+            of these variables is set, the certificates in the Mozilla CA
+            Certificate List provided by the 'certifi' Python package are used
+            for verifying the HMC certificate.
+        type: str
+        required: false
+        default: null
+      verify:
+        description:
+          - If True (default), verify the HMC certificate as specified in the
+            O(hmc_auth.ca_certs) parameter. If False, ignore what is specified in the
+            O(hmc_auth.ca_certs) parameter and do not verify the HMC certificate.
+        type: bool
+        required: false
+        default: true
+  name:
+    description:
+      - The name of the target user pattern.
+    type: str
+    required: true
+  state:
+    description:
+      - "The desired state for the HMC user pattern. All states are fully
+         idempotent within the limits of the properties that can be changed:"
+      - "* V(absent): Ensures that the user pattern does not exist."
+      - "* V(present): Ensures that the user pattern exists and has the
+         specified properties."
+      - "* V(facts): Returns the user pattern properties."
+    type: str
+    required: true
+    choices: ['absent', 'present', 'facts']
+  properties:
+    description:
+      - "Dictionary with desired properties for the user pattern.
+         Used for O(state=present); ignored for O(state=absent|facts).
+         Dictionary key is the property name with underscores instead
+         of hyphens, and dictionary value is the property value in YAML syntax.
+         Integer properties may also be provided as decimal strings."
+      - "The possible input properties in this dictionary are the properties
+         defined as writeable in the data model for User Pattern resources
+         (where the property names contain underscores instead of hyphens),
+         with the following exceptions:"
+      - "* C(name): Cannot be specified because the name has already been
+         specified in the O(name) module parameter."
+      - "* C(..._uri): Cannot be set directly, but indirectly via the
+         corresponding artificial property C(..._name). An empty string for
+         the name will set the URI to null."
+      - "Properties omitted in this dictionary will remain unchanged when the
+         user pattern already exists, and will get the default value defined
+         in the data model for user patterns in the R(HMC API,HMC API) book
+         when the user pattern is being created."
+    type: dict
+    required: false
+    default: null
+  log_file:
+    description:
+      - "File path of a log file to which the logic flow of this module as well
+         as interactions with the HMC are logged. If null, logging will be
+         propagated to the Python root logger."
+    type: str
+    required: false
+    default: null
+  _faked_session:
+    description:
+      - "An internal parameter used for testing the module."
+    type: raw
+    required: false
+    default: null
+"""
+
+EXAMPLES = """
+---
+# Note: The following examples assume that some variables named 'my_*' are set.
+
+- name: Gather facts about a user pattern
+  zhmc_user_pattern:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    name: "{{ my_user_pattern_name }}"
+    state: facts
+  register: userpattern1
+
+- name: Ensure the user pattern does not exist
+  zhmc_user_pattern:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    name: "{{ my_user_pattern_name }}"
+    state: absent
+
+- name: Ensure the user pattern exists and has certain properties
+  zhmc_user_pattern:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+    name: "{{ my_user_pattern_name }}"
+    state: present
+    properties:
+      description: "Example user pattern 1"
+  register: userpattern1
+"""
+
+RETURN = """
+changed:
+  description: Indicates if any change has been made by the module.
+    For O(state=facts), always will be false.
+  returned: always
+  type: bool
+msg:
+  description: An error message that describes the failure.
+  returned: failure
+  type: str
+user_pattern:
+  description:
+    - "For O(state=absent), an empty dictionary."
+    - "For O(state=present|facts), a dictionary with the resource properties of
+      the target user pattern and some additional artificial properties."
+  returned: success
+  type: dict
+  contains:
+    name:
+      description: "User Pattern name"
+      type: str
+    "{property}":
+      description:
+        - "Additional properties of the user pattern, as described in the
+          data model of the 'User Pattern' object in the R(HMC API,HMC API) book.
+          The property names will have underscores instead of hyphens."
+        - "The items in the C(ldap_group_to_template_mappings) property have
+          an additional item C(template-name) which is the name of the
+          resource object referenced by C(template-uri)."
+      type: raw
+    domain_name_restrictions_ldap_server_definition_name:
+      description: "Name of the resource object referenced by the corresponding
+        ..._uri property."
+      type: str
+    ldap_group_default_template_name:
+      description: "Name of the resource object referenced by the corresponding
+        ..._uri property."
+      type: str
+    ldap_group_ldap_server_definition_name:
+      description: "Name of the resource object referenced by the corresponding
+        ..._uri property."
+      type: str
+    ldap_server_definition_name:
+      description: "Name of the resource object referenced by the corresponding
+        ..._uri property."
+      type: str
+    specific_template_name:
+      description: "Name of the resource object referenced by the corresponding
+        ..._uri property."
+      type: str
+    template_name_override_default_template_name:
+      description: "Name of the resource object referenced by the corresponding
+        ..._uri property."
+      type: str
+    template_name_override_ldap_server_definition_name:
+      description: "Name of the resource object referenced by the corresponding
+        ..._uri property."
+      type: str
+    user_template_name:
+      description: "Name of the resource object referenced by the corresponding
+        ..._uri property."
+      type: str
+  sample:
+    {
+        "class": "user-pattern",
+        "description": "A pattern that matches a bluepages email address.",
+        "domain_name_restrictions": null,
+        "domain_name_restrictions_ldap_server_definition_name": null,
+        "domain_name_restrictions_ldap_server_definition_uri": null,
+        "element_id": "cbcaf7a0-46cc-11e9-bfd3-f44a39cd42f9",
+        "element_uri": "/api/console/user-patterns/cbcaf7a0-46cc-11e9-bfd3-f44a39cd42f9",
+        "ldap_group_default_template_name": null,
+        "ldap_group_default_template_uri": null,
+        "ldap_group_ldap_server_definition_name": null,
+        "ldap_group_ldap_server_definition_uri": null,
+        "ldap_group_to_template_mappings": null,
+        "ldap_server_definition_name": null,
+        "ldap_server_definition_uri": null,
+        "name": "Bluepages email address",
+        "parent": "/api/console",
+        "pattern": "*@*ibm.com",
+        "replication_overwrite_possible": false,
+        "retention_time": 90,
+        "search_order_index": 0,
+        "specific_template_name": "Product Engineering and Access Administrator",
+        "specific_template_uri": "/api/users/97769500-4a81-11e9-aa1b-00106f23f636",
+        "template_name_override": null,
+        "template_name_override_default_template_name": null,
+        "template_name_override_default_template_uri": null,
+        "template_name_override_ldap_server_definition_name": null,
+        "template_name_override_ldap_server_definition_uri": null,
+        "type": "glob-like",
+        "user_template_name": "Product Engineering and Access Administrator",
+        "user_template_uri": "/api/users/97769500-4a81-11e9-aa1b-00106f23f636"
+    }
+"""
+
+import uuid  # noqa: E402
+import logging  # noqa: E402
+import traceback  # noqa: E402
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+
+from ..module_utils.common import log_init, open_session, close_session, \
+    hmc_auth_parameter, Error, ParameterError, to_unicode, \
+    process_normal_property, missing_required_lib, underscore_properties, \
+    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+
+try:
+    import urllib3
+    IMP_URLLIB3_ERR = None
+except ImportError:
+    IMP_URLLIB3_ERR = traceback.format_exc()
+
+try:
+    import zhmcclient
+    IMP_ZHMCCLIENT_ERR = None
+except ImportError:
+    IMP_ZHMCCLIENT_ERR = traceback.format_exc()
+
+# Python logger name for this module
+LOGGER_NAME = 'zhmc_user_pattern'
+
+LOGGER = logging.getLogger(LOGGER_NAME)
+
+# Dictionary of properties of user pattern resources, in this format:
+#   name: (allowed, create, update, eq_func, type_cast)
+# where:
+#   name: Name of the property according to the data model, with hyphens
+#     replaced by underscores (this is how it is or would be specified in
+#     the 'properties' module parameter).
+#   allowed: Indicates whether it is allowed in the 'properties' module
+#     parameter.
+#   create: Indicates whether it can be specified for the "Create User Pattern"
+#    operation.
+#   update: Indicates whether it can be specified for the "Modify User Pattern
+#     Properties" operation (at all).
+#   update_while_active: Not used for this module, always True.
+#   eq_func: Equality test function for two values of the property; None means
+#     to use Python equality.
+#   type_cast: Type cast function for an input value of the property; None
+#     means to use it directly. This can be used for example to convert
+#     integers provided as strings by Ansible back into integers (that is a
+#     current deficiency of Ansible).
+ZHMC_USER_PATTERN_PROPERTIES = {
+
+    # create+update properties:
+    'name': (False, True, True, True, None, None),
+    # name: provided in 'name' module parm
+    'description': (True, True, True, True, None, to_unicode),
+    'type': (True, True, True, True, None, None),
+    'pattern': (True, True, True, True, None, to_unicode),
+    'retention_time': (True, True, True, True, None, int),
+    'user_template_uri': (False, False, True, True, None, None),
+    'user_template_name': (True, True, True, True, None, None),
+    # user_template_name: Artificial property, based on
+    # user_template_uri
+    'ldap_server_definition_uri': (False, False, True, True, None, None),
+    'ldap_server_definition_name': (True, True, True, True, None, None),
+    # ldap_server_definition_name: Artificial property, based on
+    # ldap_server_definition_uri
+    'template_name_override': (True, True, True, True, None, None),
+    'domain_name_restrictions': (True, True, True, True, None, None),
+    'specific_template_uri': (False, False, True, True, None, None),
+    'specific_template_name': (True, True, True, True, None, None),
+    # specific_template_name: Artificial property, based on
+    # specific_template_uri
+    'template_name_override_ldap_server_definition_uri':
+        (False, False, True, True, None, None),
+    'template_name_override_ldap_server_definition_name':
+        (True, True, True, True, None, None),
+    # template_name_override_ldap_server_definition_name: Artificial property,
+    # based on template_name_override_ldap_server_definition_uri
+    'template_name_override_default_template_uri':
+        (False, False, True, True, None, None),
+    'template_name_override_default_template_name':
+        (True, True, True, True, None, None),
+    # template_name_override_default_template_name: Artificial property,
+    # based on template_name_override_default_template_uri
+    'ldap_group_to_template_mappings':
+        (True, True, True, True, None, list),
+    # ldap_group_to_template_mappings is an array of group-to-template-mapping
+    # objects:
+    #   ldap_group_name: String
+    #   template_uri: String
+    #   template_name: String - Additional artificial property
+    'ldap_group_ldap_server_definition_uri':
+        (False, False, True, True, None, None),
+    'ldap_group_ldap_server_definition_name':
+        (True, True, True, True, None, None),
+    # ldap_group_ldap_server_definition_name: Artificial property,
+    # based on ldap_group_ldap_server_definition_uri
+    'ldap_group_default_template_uri':
+        (False, False, True, True, None, None),
+    'ldap_group_default_template_name':
+        (True, True, True, True, None, None),
+    # ldap_group_default_template_name: Artificial property,
+    # based on ldap_group_default_template_uri
+    'domain_name_restrictions_ldap_server_definition_uri':
+        (False, False, True, True, None, None),
+    'domain_name_restrictions_ldap_server_definition_name':
+        (True, True, True, True, None, None),
+    # domain_name_restrictions_ldap_server_definition_name: Artificial property,
+    # based on domain_name_restrictions_ldap_server_definition_uri
+
+    # read-only properties:
+    'element_uri': (False, False, False, None, None, None),
+    'element_id': (False, False, False, None, None, None),
+    'parent': (False, False, False, None, None, None),
+    'class': (False, False, False, None, None, None),
+    'search_order_index': (False, False, False, None, None, int),
+    'replication_overwrite_possible': (False, False, False, None, None, bool),
+}
+
+
+def process_properties(console, upattern, params):
+    """
+    Process the properties specified in the 'properties' module parameter,
+    and return two dictionaries (create_props, update_props) that contain
+    the properties that can be created, and the properties that can be updated,
+    respectively. If the resource exists, the input property values are
+    compared with the existing resource property values and the returned set
+    of properties is the minimal set of properties that need to be changed.
+
+    - Underscores in the property names are translated into hyphens.
+    - The presence of read-only properties, invalid properties (i.e. not
+      defined in the data model for user patterns), and properties that are
+      not allowed because of restrictions or because they are auto-created from
+      an artificial property is surfaced by raising ParameterError.
+
+    Parameters:
+
+      upattern (zhmcclient.UserPattern): User Pattern object to be updated with
+        the full set of current properties, or `None` if it did not previously
+        exist.
+
+      params (dict): Module input parameters.
+
+    Returns:
+      tuple of (create_props, update_props),
+      where:
+        * create_props: dict of properties for
+          zhmcclient.UserPatternManager.create()
+        * update_props: dict of properties for
+          zhmcclient.UserPattern.update_properties()
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+    """
+
+    def find_by_name(res_mgr, res_name, res_kind, specified):
+        try:
+            res = res_mgr.find_by_name(res_name)
+        except zhmcclient.NotFound:
+            raise ParameterError(
+                f"{res_kind} {res_name!r} specified in {specified} does not "
+                "exist.")
+        return res.uri
+
+    def set_uri_prop(res_mgr, res_name, uri_pname_hyphen, res_kind, specified):
+        """
+        Set a resource URI property in the create_props or update_props
+        dict.
+        """
+        if res_name:
+            res_uri = find_by_name(res_mgr, res_name, res_kind, specified)
+        else:
+            # An empty string for name should result in setting URI to null
+            res_uri = None
+        if upattern is None:
+            if res_uri is not None:
+                create_props[uri_pname_hyphen] = res_uri
+        else:
+            if upattern.prop(uri_pname_hyphen) != res_uri:
+                update_props[uri_pname_hyphen] = res_uri
+
+    create_props = {}
+    update_props = {}
+
+    # handle 'name' property
+    upattern_name = to_unicode(params['name'])
+    if upattern is None:
+        # User Pattern does not exist yet.
+        create_props['name'] = upattern_name
+    else:
+        # User Pattern does already exist.
+        # We looked up the user pattern by name, so we will never have to
+        # update the user pattern name.
+        pass
+
+    # handle the other properties
+    input_props = params['properties']
+    if input_props is None:
+        input_props = {}
+
+    for prop_name in input_props:
+
+        if prop_name not in ZHMC_USER_PATTERN_PROPERTIES:
+            raise ParameterError(
+                f"Property {prop_name!r} is not defined in the data model for "
+                "user patterns.")
+
+        # pylint: disable=unused-variable
+        allowed, create, update, update_while_active, eq_func, type_cast = \
+            ZHMC_USER_PATTERN_PROPERTIES[prop_name]
+
+        if not allowed:
+            raise ParameterError(
+                f"Property {prop_name!r} is not allowed in the 'properties' "
+                "module parameter.")
+
+        # Process artificial properties allowed in input parameters
+
+        if prop_name == 'user_template_name':
+            set_uri_prop(console.users,
+                         input_props[prop_name],
+                         'user-template-uri',
+                         "User", f"property {prop_name!r}")
+            continue
+
+        if prop_name == 'ldap_server_definition_name':
+            set_uri_prop(console.ldap_server_definitions,
+                         input_props[prop_name],
+                         'ldap-server-definition-uri',
+                         "LDAP Server Definition", f"property {prop_name!r}")
+            continue
+
+        if prop_name == 'specific_template_name':
+            set_uri_prop(console.users,
+                         input_props[prop_name],
+                         'specific-template-uri',
+                         "User", f"property {prop_name!r}")
+            continue
+
+        if prop_name == 'template_name_override_ldap_server_definition_name':
+            set_uri_prop(console.ldap_server_definitions,
+                         input_props[prop_name],
+                         'template-name-override-ldap-server-definition-uri',
+                         "LDAP Server Definition", f"property {prop_name!r}")
+            continue
+
+        if prop_name == 'template_name_override_default_template_name':
+            set_uri_prop(console.users,
+                         input_props[prop_name],
+                         'template-name-override-default-template-uri',
+                         "User", f"property {prop_name!r}")
+            continue
+
+        if prop_name == 'ldap_group_ldap_server_definition_name':
+            set_uri_prop(console.ldap_server_definitions,
+                         input_props[prop_name],
+                         'ldap-group-ldap-server-definition-uri',
+                         "LDAP Server Definition", f"property {prop_name!r}")
+            continue
+
+        if prop_name == 'ldap_group_default_template_name':
+            set_uri_prop(console.users,
+                         input_props[prop_name],
+                         'ldap-group-default-template-uri',
+                         "User", f"property {prop_name!r}")
+            continue
+
+        if prop_name == 'domain_name_restrictions_ldap_server_definition_name':
+            set_uri_prop(console.ldap_server_definitions,
+                         input_props[prop_name],
+                         'domain-name-restrictions-ldap-server-definition-uri',
+                         "LDAP Server Definition", f"property {prop_name!r}")
+            continue
+
+        if prop_name == 'ldap_group_to_template_mappings':
+            # Process normal and artificial properties
+            input_mappings = input_props['ldap_group_to_template_mappings']
+            mappings = []  # used for the HMC operation
+            if input_mappings is not None:
+                for item in input_mappings:
+                    mapping_item = {}
+                    for pname, pvalue in item.items():
+                        pname_hyphen = pname.replace('_', '-')
+                        if pname == 'template_uri':
+                            raise ParameterError(
+                                "Property 'template_uri' in an item of "
+                                "'ldap_group_to_template_mappings' is not "
+                                "allowed in the 'properties' module parameter.")
+                        if pname == 'template_name':
+                            mapping_item['template-uri'] = find_by_name(
+                                console.users, pvalue, "User",
+                                "property 'template_uri' in an item of "
+                                "'ldap_group_to_template_mappings'")
+                        else:
+                            mapping_item[pname_hyphen] = pvalue
+                    mappings.append(mapping_item)
+            if not mappings:
+                mappings = None
+            if upattern is None:
+                create_props['ldap-group-to-template-mappings'] = mappings
+            else:
+                update_props['ldap-group-to-template-mappings'] = mappings
+
+        # Process a normal (= non-artificial) property
+        _create_props, _update_props, _stop = process_normal_property(
+            prop_name, ZHMC_USER_PATTERN_PROPERTIES, input_props, upattern)
+        create_props.update(_create_props)
+        update_props.update(_update_props)
+        if _stop:
+            raise AssertionError(
+                f"Input property {prop_name!r} unexpectedly defined with stop")
+    return create_props, update_props
+
+
+def add_artificial_properties(upattern_props, upattern):
+    """
+    Add artificial properties to the user pattern result properties.
+
+    Upon return, the upattern_props dict has been extended by these
+    properties:
+
+    * The following properties with the name of corresponding '...-uri' object:
+      - 'user-template-name'
+      - 'ldap-server-definition-name'
+      - 'specific-template-name'
+      - 'template-name-override-ldap-server-definition-name'
+      - 'template-name-override-default-template-name'
+      - 'ldap-group-ldap-server-definition-name'
+      - 'ldap-group-default-template-name'
+      - 'domain-name-restrictions-ldap-server-definition-name'
+
+    * In each item of the 'ldap-group-to-template-mappings' list:
+      - 'template-name' with the name of corresponding '...-uri' object
+    """
+    console = upattern.manager.parent
+
+    def set_name(set_dict, name_prop_name, mgr, uri_prop_name):
+        """Set the name property in set_dict by looking up the resource URI."""
+        try:
+            uri = upattern.get_property(uri_prop_name)
+        except KeyError:
+            # If the property does not exist (e.g. in a mocked environment),
+            # we also don't set the name property.
+            return
+        if uri is not None:
+            # pylint: disable=protected-access
+            filter_args = {mgr._uri_prop: uri}
+            res = mgr.find(**filter_args)
+            res_name = res.name
+        else:
+            res_name = None
+
+        set_dict[name_prop_name] = res_name
+
+    set_name(upattern_props,
+             'user_template_name',
+             console.users,
+             'user-template-uri')
+
+    set_name(upattern_props,
+             'ldap_server_definition_name',
+             console.ldap_server_definitions,
+             'ldap-server-definition-uri')
+
+    set_name(upattern_props,
+             'specific_template_name',
+             console.users,
+             'specific-template-uri')
+
+    set_name(upattern_props,
+             'template_name_override_ldap_server_definition_name',
+             console.ldap_server_definitions,
+             'template-name-override-ldap-server-definition-uri')
+
+    set_name(upattern_props,
+             'template_name_override_default_template_name',
+             console.users,
+             'template-name-override-default-template-uri')
+
+    set_name(upattern_props,
+             'ldap_group_ldap_server_definition_name',
+             console.ldap_server_definitions,
+             'ldap-group-ldap-server-definition-uri')
+
+    set_name(upattern_props,
+             'ldap_group_default_template_name',
+             console.users,
+             'ldap-group-default-template-uri')
+
+    set_name(upattern_props,
+             'domain_name_restrictions_ldap_server_definition_name',
+             console.ldap_server_definitions,
+             'domain-name-restrictions-ldap-server-definition-uri')
+
+    mappings = upattern_props.get('ldap-group-to-template-mappings')
+    if mappings is not None:
+        for item in mappings:
+            set_name(item, 'template-name', console.users, 'template-uri')
+
+
+def create_check_mode_upattern(console, create_props, update_props):
+    """
+    Create and return a fake local User Pattern object.
+
+    This is used when a user pattern needs to be created in check mode.
+
+    This function must be consistent with the behavior of the "Create Password
+    Rule" operation on the HMC. HTTP errors the HMC would return are indicated
+    by raising zhmcclient.HTTPError.
+    """
+
+    input_props = {}
+    input_props.update(create_props)
+    input_props.update(update_props)
+
+    # Check required input properties
+    missing_props = []
+    for pname in ('name',):
+        if pname not in input_props:
+            missing_props.append(pname)
+    if missing_props:
+        raise zhmcclient.HTTPError({
+            'http-status': 400,
+            'reason': 4,
+            'message': "Required input properties missing for Create "
+            f"User Pattern: {missing_props}",
+        })
+
+    # Defaults for optional properties
+    props = {
+        # createable/updateable
+        'description': '',
+        'domain-name-restrictions': None,
+        'domain-name-restrictions-ldap-server-definition-uri': None,
+        'ldap-group-default-template-uri': None,
+        'ldap-group-ldap-server-definition-uri': None,
+        'ldap-group-to-template-mappings': None,
+        'ldap-server-definition-uri': None,
+        'specific-template-uri': None,
+        'template-name-override': None,
+        'template-name-override-default-template-uri': None,
+        'template-name-override-ldap-server-definition-uri': None,
+        'user-template-uri': None,
+        # read-only
+        'replication-overwrite-possible': False,
+        'search-order-index': 0,
+    }
+
+    # Apply specified input properties on top of the defaults
+    props.update(input_props)
+
+    upattern_oid = f'fake-{uuid.uuid4()}'
+    upattern = console.user_patterns.resource_object(upattern_oid, props=props)
+
+    return upattern
+
+
+def ensure_present(params, check_mode):
+    """
+    Ensure that the user pattern exists and has the specified properties.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    upattern_name = params['name']
+
+    changed = False
+    result = {}
+
+    session, logoff = open_session(params)
+    try:
+        client = zhmcclient.Client(session)
+        console = client.consoles.console
+        # The default exception handling is sufficient for the above.
+
+        try:
+            upattern = console.user_patterns.find(name=upattern_name)
+        except zhmcclient.NotFound:
+            upattern = None
+
+        if upattern is None:
+            # It does not exist. Create it and update it if there are
+            # update-only properties.
+            create_props, update_props = \
+                process_properties(console, upattern, params)
+            update2_props = {}
+            for name, value in update_props.items():
+                if name not in create_props:
+                    update2_props[name] = value
+            if not check_mode:
+                upattern = console.user_patterns.create(create_props)
+                if update2_props:
+                    upattern.update_properties(update2_props)
+                # We refresh the properties after the update, in case an
+                # input property value gets changed.
+                upattern.pull_full_properties()
+            else:
+                # Create a User Pattern object locally
+                upattern = create_check_mode_upattern(
+                    console, create_props, update2_props)
+            result = underscore_properties(upattern.properties)
+            changed = True
+        else:
+            # It exists. Update its properties.
+            upattern.pull_full_properties()
+            result = underscore_properties(upattern.properties)
+            create_props, update_props = \
+                process_properties(console, upattern, params)
+            if create_props:
+                raise AssertionError("Unexpected "
+                                     "create_props: %r" % create_props)
+            if update_props:
+                LOGGER.debug(
+                    "Existing user pattern %r needs to get properties "
+                    "updated: %r", upattern_name, update_props)
+                if not check_mode:
+                    upattern.update_properties(update_props)
+                    # We refresh the properties after the update, in case an
+                    # input property value gets changed.
+                    upattern.pull_full_properties()
+                    result = underscore_properties(upattern.properties)
+                else:
+                    # Update the local User Pattern object's properties
+                    result.update(update_props)
+                changed = True
+
+        if not upattern:
+            raise AssertionError()
+
+        add_artificial_properties(result, upattern)
+
+        return changed, result
+
+    finally:
+        close_session(session, logoff)
+
+
+def ensure_absent(params, check_mode):
+    """
+    Ensure that the user pattern does not exist.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    upattern_name = params['name']
+
+    changed = False
+    result = {}
+
+    session, logoff = open_session(params)
+    try:
+        client = zhmcclient.Client(session)
+        console = client.consoles.console
+        # The default exception handling is sufficient for the above.
+
+        try:
+            upattern = console.user_patterns.find(name=upattern_name)
+        except zhmcclient.NotFound:
+            return changed, result
+
+        if not check_mode:
+            upattern.delete()
+        changed = True
+
+        return changed, result
+
+    finally:
+        close_session(session, logoff)
+
+
+def facts(params, check_mode):
+    # pylint: disable=unused-argument
+    """
+    Return facts about a user pattern.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    upattern_name = params['name']
+
+    changed = False
+    result = {}
+
+    session, logoff = open_session(params)
+    try:
+        # The default exception handling is sufficient for this code
+        client = zhmcclient.Client(session)
+        console = client.consoles.console
+
+        upattern = console.user_patterns.find(name=upattern_name)
+        upattern.pull_full_properties()
+
+        result = underscore_properties(upattern.properties)
+        add_artificial_properties(result, upattern)
+
+        return changed, result
+
+    finally:
+        close_session(session, logoff)
+
+
+def perform_task(params, check_mode):
+    """
+    Perform the task for this module, dependent on the 'state' module
+    parameter.
+
+    If check_mode is True, check whether changes would occur, but don't
+    actually perform any changes.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+    actions = {
+        "absent": ensure_absent,
+        "present": ensure_present,
+        "facts": facts,
+    }
+    return actions[params['state']](params, check_mode)
+
+
+def main():
+    """Main function"""
+
+    # The following definition of module input parameters must match the
+    # description of the options in the DOCUMENTATION string.
+    argument_spec = dict(
+        hmc_host=dict(required=True, type='raw'),
+        hmc_auth=hmc_auth_parameter(),
+        name=dict(required=True, type='str'),
+        state=dict(required=True, type='str',
+                   choices=['absent', 'present', 'facts']),
+        properties=dict(required=False, type='dict', default=None),
+        log_file=dict(required=False, type='str', default=None),
+        _faked_session=dict(required=False, type='raw'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True)
+
+    if IMP_URLLIB3_ERR is not None:
+        module.fail_json(msg=missing_required_lib("requests"),
+                         exception=IMP_URLLIB3_ERR)
+
+    urllib3.disable_warnings()
+
+    if IMP_ZHMCCLIENT_ERR is not None:
+        module.fail_json(msg=missing_required_lib("zhmcclient"),
+                         exception=IMP_ZHMCCLIENT_ERR)
+
+    common_fail_on_import_errors(module)
+
+    log_file = module.params['log_file']
+    log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
+
+    _params = dict(module.params)
+    del _params['hmc_auth']
+    LOGGER.debug("Module entry: params: %r", _params)
+
+    try:
+
+        changed, result = perform_task(module.params, module.check_mode)
+
+    except (Error, zhmcclient.Error) as exc:
+        # These exceptions are considered errors in the environment or in user
+        # input. They have a proper message that stands on its own, so we
+        # simply pass that message on and will not need a traceback.
+        msg = f"{exc.__class__.__name__}: {exc}"
+        LOGGER.debug(
+            "Module exit (failure): msg: %s", msg)
+        module.fail_json(msg=msg)
+    # Other exceptions are considered module errors and are handled by Ansible
+    # by showing the traceback.
+
+    LOGGER.debug(
+        "Module exit (success): changed: %r, user_pattern: %r",
+        changed, result)
+    module.exit_json(changed=changed, user_pattern=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/zhmc_user_pattern_list.py
+++ b/plugins/modules/zhmc_user_pattern_list.py
@@ -1,0 +1,304 @@
+#!/usr/bin/python
+# Copyright 2024 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# For information on the format of the ANSIBLE_METADATA, DOCUMENTATION,
+# EXAMPLES, and RETURN strings, see
+# http://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['stableinterface'],
+    'supported_by': 'community',
+    'shipped_by': 'other',
+    'other_repo_url': 'https://github.com/zhmcclient/zhmc-ansible-modules'
+}
+
+DOCUMENTATION = """
+---
+module: zhmc_user_pattern_list
+version_added: "2.15.0"
+short_description: List HMC user patterns
+description:
+  - List User Patterns on the HMC.
+author:
+  - Andreas Maier (@andy-maier)
+requirements:
+  - "The HMC userid must have object-access permission to the User Pattern
+    objects included in the result, or task permission to the
+    'Manage User Patterns' task."
+options:
+  hmc_host:
+    description:
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
+    required: true
+  hmc_auth:
+    description:
+      - The authentication credentials for the HMC.
+    type: dict
+    required: true
+    suboptions:
+      userid:
+        description:
+          - The userid (username) for authenticating with the HMC.
+            This is mutually exclusive with providing O(hmc_auth.session_id).
+        type: str
+        required: false
+        default: null
+      password:
+        description:
+          - The password for authenticating with the HMC.
+            This is mutually exclusive with providing O(hmc_auth.session_id).
+        type: str
+        required: false
+        default: null
+      session_id:
+        description:
+          - HMC session ID to be used.
+            This is mutually exclusive with providing O(hmc_auth.userid) and
+            O(hmc_auth.password) and can be created as described in the
+            R(zhmc_session module,zhmc_session_module).
+        type: str
+        required: false
+        default: null
+      ca_certs:
+        description:
+          - Path name of certificate file or certificate directory to be used
+            for verifying the HMC certificate. If null (default), the path name
+            in the E(REQUESTS_CA_BUNDLE) environment variable or the path name
+            in the E(CURL_CA_BUNDLE) environment variable is used, or if neither
+            of these variables is set, the certificates in the Mozilla CA
+            Certificate List provided by the 'certifi' Python package are used
+            for verifying the HMC certificate.
+        type: str
+        required: false
+        default: null
+      verify:
+        description:
+          - If True (default), verify the HMC certificate as specified in the
+            O(hmc_auth.ca_certs) parameter. If False, ignore what is specified in the
+            O(hmc_auth.ca_certs) parameter and do not verify the HMC certificate.
+        type: bool
+        required: false
+        default: true
+  full_properties:
+    description:
+      - "If True, all properties of each user pattern will be returned.
+        Default: False."
+      - "Note: Setting this to True causes a loop of 'Get User Pattern
+        Properties' operations to be executed."
+    type: bool
+    required: false
+    default: false
+  log_file:
+    description:
+      - "File path of a log file to which the logic flow of this module as well
+         as interactions with the HMC are logged. If null, logging will be
+         propagated to the Python root logger."
+    type: str
+    required: false
+    default: null
+  _faked_session:
+    description:
+      - "An internal parameter used for testing the module."
+    type: raw
+    required: false
+    default: null
+"""
+
+EXAMPLES = """
+---
+# Note: The following examples assume that some variables named 'my_*' are set.
+
+- name: List User Patterns
+  zhmc_user_pattern_list:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth: "{{ my_hmc_auth }}"
+  register: upattern_list
+"""
+
+RETURN = """
+changed:
+  description: Indicates if any change has been made by the module.
+    This will always be false.
+  returned: always
+  type: bool
+msg:
+  description: An error message that describes the failure.
+  returned: failure
+  type: str
+user_patterns:
+  description: The list of User Patterns, with a subset or all of their
+    properties, dependent on O(full_properties).
+  returned: success
+  type: list
+  elements: dict
+  contains:
+    name:
+      description: "User pattern name"
+      type: str
+    element_uri:
+      description: "Element URI of the User Pattern object"
+      type: str
+    type:
+      description:
+        - "The style in which the user pattern is expressed, as one of the
+          following values:"
+        - "V(glob-like) - Glob-like pattern as used in file names, supporting
+          the special characters C(*) and C(?)."
+        - "V(regular-expression) - Regular expression pattern using
+          :term:`Java regular expressions`."
+      type: str
+    "{additional_property}":
+      description: "Additional properties requested via O(full_properties), as
+        described in the data model of the 'User Pattern' object in the
+        R(HMC API,HMC API) book.
+        The property names will have underscores instead of hyphens."
+      type: raw
+  sample:
+    [
+        {
+            "element_uri": "/api/console/user-patterns/cbcaf7a0-46cc-11e9-bfd3-f44a39cd42f9",
+            "name": "Bluepages email address",
+            "type": "glob-like"
+        },
+        {
+            "element_uri": "/api/console/user-patterns/fb22d4a2-4e40-11e9-a8a8-00106f23f636",
+            "name": "regexp pattern 1",
+            "type": "regular-expression"
+        }
+    ]
+"""
+
+import logging  # noqa: E402
+import traceback  # noqa: E402
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+
+from ..module_utils.common import log_init, open_session, close_session, \
+    hmc_auth_parameter, Error, missing_required_lib, \
+    underscore_properties_list, common_fail_on_import_errors, \
+    parse_hmc_host  # noqa: E402
+
+try:
+    import urllib3
+    IMP_URLLIB3_ERR = None
+except ImportError:
+    IMP_URLLIB3_ERR = traceback.format_exc()
+
+try:
+    import zhmcclient
+    IMP_ZHMCCLIENT_ERR = None
+except ImportError:
+    IMP_ZHMCCLIENT_ERR = traceback.format_exc()
+
+# Python logger name for this module
+LOGGER_NAME = 'zhmc_user_pattern_list'
+
+LOGGER = logging.getLogger(LOGGER_NAME)
+
+
+def perform_list(params):
+    """
+    List the managed User Patterns and return a subset of properties.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+
+    full_properties = params['full_properties']
+
+    session, logoff = open_session(params)
+    try:
+        client = zhmcclient.Client(session)
+        console = client.consoles.console
+
+        upattern_hmc_list = \
+            console.user_patterns.list(full_properties=full_properties)
+        upattern_list = underscore_properties_list(upattern_hmc_list)
+        return upattern_list
+
+    finally:
+        close_session(session, logoff)
+
+
+def main():
+    """Main function"""
+
+    # The following definition of module input parameters must match the
+    # description of the options in the DOCUMENTATION string.
+    argument_spec = dict(
+        hmc_host=dict(required=True, type='raw'),
+        hmc_auth=hmc_auth_parameter(),
+        full_properties=dict(required=False, type='bool', default=False),
+        log_file=dict(required=False, type='str', default=None),
+        _faked_session=dict(required=False, type='raw'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True)
+
+    if IMP_URLLIB3_ERR is not None:
+        module.fail_json(msg=missing_required_lib("requests"),
+                         exception=IMP_URLLIB3_ERR)
+
+    urllib3.disable_warnings()
+
+    if IMP_ZHMCCLIENT_ERR is not None:
+        module.fail_json(msg=missing_required_lib("zhmcclient"),
+                         exception=IMP_ZHMCCLIENT_ERR)
+
+    common_fail_on_import_errors(module)
+
+    log_file = module.params['log_file']
+    log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
+
+    _params = dict(module.params)
+    del _params['hmc_auth']
+    LOGGER.debug("Module entry: params: %r", _params)
+
+    changed = False
+    try:
+
+        result_list = perform_list(module.params)
+
+    except (Error, zhmcclient.Error) as exc:
+        # These exceptions are considered errors in the environment or in user
+        # input. They have a proper message that stands on its own, so we
+        # simply pass that message on and will not need a traceback.
+        msg = f"{exc.__class__.__name__}: {exc}"
+        LOGGER.debug("Module exit (failure): msg: %r", msg)
+        module.fail_json(msg=msg)
+    # Other exceptions are considered module errors and are handled by Ansible
+    # by showing the traceback.
+
+    LOGGER.debug("Module exit (success): changed: %s, user_patterns: %r",
+                 changed, result_list)
+    module.exit_json(changed=changed, user_patterns=result_list)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/end2end/mocked_hmc_z14.yaml
+++ b/tests/end2end/mocked_hmc_z14.yaml
@@ -158,6 +158,43 @@ hmc_definition:
             web-services-api-session-idle-timeout: 360
             user-roles:
               - /api/user-roles/hmc-all-system-managed-objects
+        - properties:
+            # class: created automatically
+            # parent: created automatically
+            # object-uri: created automatically
+            object-id: usertemplate1
+            name: USERTEMPLATE1
+            description: "User template 1"
+            allow-management-interfaces: true
+            allow-remote-access: true
+            authentication-type: local
+            default-group-uri: null
+            disable-delay: 1
+            disabled: false
+            disruptive-pw-required: true
+            disruptive-text-required: false
+            email-address: null
+            force-password-change: false
+            force-shared-secret-key-change: null
+            idle-timeout: 0
+            inactivity-timeout: 0
+            is-locked: false
+            ldap-server-definition-uri: null
+            max-failed-logins: 3
+            max-web-services-api-sessions: 1000
+            min-pw-change-time: 0
+            multi-factor-authentication-required: false
+            password: bla
+            password-expires: -1
+            password-rule-uri: /api/console/password-rules/passwordrule1
+            replication-overwrite-possible: false
+            session-timeout: 0
+            type: template
+            userid-on-ldap-server: null
+            verify-timeout: 15
+            web-services-api-session-idle-timeout: 360
+            user-roles:
+              - /api/user-roles/hmc-all-system-managed-objects
 
       user_roles:
         - properties:
@@ -213,6 +250,26 @@ hmc_definition:
             element-id: userpattern1
             name: User pattern 1
             description: "User pattern 1"
+            type: regular-expression
+            pattern: ".*@ibm.com"
+            domain-name-restrictions: null
+            domain-name-restrictions-ldap-server-definition-name: null
+            domain-name-restrictions-ldap-server-definition-uri: null
+            ldap-group-default-template-name: null
+            ldap-group-default-template-uri: null
+            ldap-group-ldap-server-definition-name: null
+            ldap-group-ldap-server-definition-uri: null
+            ldap-group-to-template-mappings: null
+            ldap-server-definition-name: null
+            ldap-server-definition-uri: null
+            replication-overwrite-possible: false
+            retention-time: 1
+            search-order-index: 2
+            specific-template-uri: null
+            template-name-override: null
+            template-name-override-default-template-uri: null
+            template-name-override-ldap-server-definition-uri: null
+            user-template-uri: null
 
       password_rules:
         - properties:

--- a/tests/end2end/mocked_hmc_z16.yaml
+++ b/tests/end2end/mocked_hmc_z16.yaml
@@ -158,6 +158,43 @@ hmc_definition:
             web-services-api-session-idle-timeout: 360
             user-roles:
               - /api/user-roles/hmc-all-system-managed-objects
+        - properties:
+            # class: created automatically
+            # parent: created automatically
+            # object-uri: created automatically
+            object-id: usertemplate1
+            name: USERTEMPLATE1
+            description: "User template 1"
+            allow-management-interfaces: true
+            allow-remote-access: true
+            authentication-type: local
+            default-group-uri: null
+            disable-delay: 1
+            disabled: false
+            disruptive-pw-required: true
+            disruptive-text-required: false
+            email-address: null
+            force-password-change: false
+            force-shared-secret-key-change: null
+            idle-timeout: 0
+            inactivity-timeout: 0
+            is-locked: false
+            ldap-server-definition-uri: null
+            max-failed-logins: 3
+            max-web-services-api-sessions: 1000
+            min-pw-change-time: 0
+            multi-factor-authentication-required: false
+            password: bla
+            password-expires: -1
+            password-rule-uri: /api/console/password-rules/passwordrule1
+            replication-overwrite-possible: false
+            session-timeout: 0
+            type: template
+            userid-on-ldap-server: null
+            verify-timeout: 15
+            web-services-api-session-idle-timeout: 360
+            user-roles:
+              - /api/user-roles/hmc-all-system-managed-objects
 
       user_roles:
         - properties:
@@ -213,6 +250,26 @@ hmc_definition:
             element-id: userpattern1
             name: "User pattern 1"
             description: "User pattern 1"
+            type: regular-expression
+            pattern: ".*@ibm.com"
+            domain-name-restrictions: null
+            domain-name-restrictions-ldap-server-definition-name: null
+            domain-name-restrictions-ldap-server-definition-uri: null
+            ldap-group-default-template-name: null
+            ldap-group-default-template-uri: null
+            ldap-group-ldap-server-definition-name: null
+            ldap-group-ldap-server-definition-uri: null
+            ldap-group-to-template-mappings: null
+            ldap-server-definition-name: null
+            ldap-server-definition-uri: null
+            replication-overwrite-possible: false
+            retention-time: 1
+            search-order-index: 2
+            specific-template-uri: null
+            template-name-override: null
+            template-name-override-default-template-uri: null
+            template-name-override-ldap-server-definition-uri: null
+            user-template-uri: null
 
       password_rules:
         - properties:

--- a/tests/end2end/test_zhmc_user_pattern.py
+++ b/tests/end2end/test_zhmc_user_pattern.py
@@ -1,0 +1,390 @@
+# Copyright 2024 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for zhmc_user_pattern module.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import uuid
+from unittest import mock
+import random
+from pprint import pformat
+import pytest
+import urllib3
+import zhmcclient
+# pylint: disable=line-too-long,unused-import
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+# pylint: enable=line-too-long,unused-import
+
+from plugins.modules import zhmc_user_pattern
+from .utils import mock_ansible_module, get_failure_msg
+
+urllib3.disable_warnings()
+
+# Print debug messages
+DEBUG = False
+
+LOG_FILE = 'zhmc_user_pattern.log' if DEBUG else None
+
+# Properties in the returned user pattern facts that are not always present, but
+# only under certain conditions. This includes artificial properties whose base
+# properties are not always present. The
+# comments state the condition under which the property is present.
+UPATTERN_CONDITIONAL_PROPS = (
+)
+
+
+# A standard test user pattern, as the Ansible module input properties (i.e.
+# using underscores, and limited to valid input parameters)
+STD_UPATTERN_MODULE_INPUT_PROPS = {
+    # 'name': provided in separate module input parameter
+    'description': "zhmc test user pattern",
+    'type': "glob-like",
+    'pattern': "zhmc*@*ibm.com",
+    'retention_time': 7,
+    'specific_template_name': None,  # if set to None, will be set in test fct
+}
+
+
+# A standard test user pattern, as the input properties for
+# UserPatternManager.create() (i.e. using dashes, and limited to valid input
+# parameters)
+STD_UPATTERN_HMC_INPUT_PROPS = {
+    # 'name': updated upon use
+    'description': "zhmc test user pattern",
+    'type': 'glob-like',
+    'pattern': "zhmc*@*ibm.com",
+    'retention-time': 7,
+    'specific-template-uri': None,  # if set to None, will be set in test fct
+}
+
+
+def new_upattern_name():
+    """Return random unique user pattern name"""
+    upattern_name = f'test_{uuid.uuid4()}'
+    return upattern_name
+
+
+def get_module_output(mod_obj):
+    """
+    Return the module output as a tuple (changed, properties) (i.e.
+    the arguments of the call to exit_json()).
+    If the module failed, return None.
+    """
+
+    def func(changed, user_pattern):
+        return changed, user_pattern
+
+    if not mod_obj.exit_json.called:
+        return None
+    call_args = mod_obj.exit_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])
+
+
+def assert_upattern_props(upattern_props, exp_upattern_props, where):
+    """
+    Assert the properties of the output object of the zhmc_user_pattern module
+
+    upattern_props: Actual properties returned by the module, with underscores
+      in property names, and including any artificial properties.
+    """
+
+    assert isinstance(upattern_props, dict), where  # Dict of User pattern props
+
+    # Assert presence of properties in the output
+    for prop_name in zhmc_user_pattern.ZHMC_USER_PATTERN_PROPERTIES:
+        prop_name_hmc = prop_name.replace('_', '-')
+        if prop_name_hmc in UPATTERN_CONDITIONAL_PROPS:
+            continue
+        where_prop = where + f", property {prop_name!r}"
+        assert prop_name in upattern_props, where_prop
+
+    # Assert values of non-artificial properties in the output
+    for prop_name_hmc, exp_value in exp_upattern_props.items():
+        prop_name = prop_name_hmc.replace('-', '_')
+        act_value = upattern_props[prop_name]
+        where_prop = where + f", property {prop_name!r}"
+        assert act_value == exp_value, where_prop
+
+    # TODO: Check values of artificial properties in the output
+
+
+@pytest.mark.parametrize(
+    "check_mode", [
+        pytest.param(False, id="check_mode=False"),
+        pytest.param(True, id="check_mode=True"),
+    ]
+)
+@mock.patch("plugins.modules.zhmc_user_pattern.AnsibleModule", autospec=True)
+def test_zhmc_user_pattern_facts(
+        ansible_mod_cls, check_mode, hmc_session):  # noqa: F811, E501
+    # pylint: disable=redefined-outer-name
+    """
+    Test the zhmc_user_pattern module with state=facts.
+    """
+
+    hd = hmc_session.hmc_definition
+    hmc_host = hd.host
+    hmc_auth = dict(userid=hd.userid, password=hd.password,
+                    ca_certs=hd.ca_certs, verify=hd.verify)
+
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+
+    faked_session = hmc_session if hd.mock_file else None
+
+    # Determine a random existing user pattern of the desired type to test.
+    upatterns = console.user_patterns.list()
+    upattern = random.choice(upatterns)
+    upattern.pull_full_properties()
+
+    where = f"user pattern '{upattern.name}'"
+
+    # Prepare module input parameters (must be all required + optional)
+    params = {
+        'hmc_host': hmc_host,
+        'hmc_auth': hmc_auth,
+        'name': upattern.name,
+        'state': 'facts',
+        'properties': None,
+        'log_file': LOG_FILE,
+        '_faked_session': faked_session,
+    }
+
+    # Prepare mocks for AnsibleModule object
+    mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+    # Exercise the code to be tested
+    with pytest.raises(SystemExit) as exc_info:
+        zhmc_user_pattern.main()
+    exit_code = exc_info.value.args[0]
+
+    # Assert module exit code
+    assert exit_code == 0, \
+        f"{where}: Module failed with exit code {exit_code} and message:\n" \
+        f"{get_failure_msg(mod_obj)}"
+
+    # Assert module output
+    changed, upattern_props = get_module_output(mod_obj)
+    assert changed is False, where
+    assert_upattern_props(upattern_props, upattern.properties, where)
+
+
+UPATTERN_ABSENT_PRESENT_TESTCASES = [
+    # The list items are tuples with the following items:
+    # - desc (string): description of the testcase.
+    # - initial_upattern_props (dict): HMC-formatted properties for initial
+    #    user pattern, in addition to STD_UPATTERN_HMC_INPUT_PROPS, or None for
+    #    no initial user pattern.
+    # - input_state (str): 'state' input parameter for module.
+    # - input_props (dict): 'properties' input parameter for module.
+    # - exp_upattern_props (dict): HMC-formatted properties for expected
+    #   properties of created user pattern.
+    # - exp_changed (bool): Boolean for expected 'changed' flag.
+
+    (
+        "Present with non-existing user pattern",
+        None,
+        'present',
+        STD_UPATTERN_MODULE_INPUT_PROPS,
+        STD_UPATTERN_HMC_INPUT_PROPS,
+        True,
+    ),
+    (
+        "Present with existing user pattern, no properties changed",
+        {},
+        'present',
+        None,
+        STD_UPATTERN_HMC_INPUT_PROPS,
+        False,
+    ),
+    (
+        "Present with existing user pattern, some properties changed",
+        {
+            'description': 'bla',
+        },
+        'present',
+        STD_UPATTERN_MODULE_INPUT_PROPS,
+        STD_UPATTERN_HMC_INPUT_PROPS,
+        True,
+    ),
+    (
+        "Absent with existing user pattern",
+        {},
+        'absent',
+        None,
+        None,
+        True,
+    ),
+    (
+        "Absent with non-existing user pattern",
+        None,
+        'absent',
+        None,
+        None,
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "check_mode", [
+        pytest.param(False, id="check_mode=False"),
+        pytest.param(True, id="check_mode=True"),
+    ]
+)
+@pytest.mark.parametrize(
+    "desc, initial_upattern_props, input_state, "
+    "input_props, exp_upattern_props, exp_changed",
+    UPATTERN_ABSENT_PRESENT_TESTCASES)
+@mock.patch("plugins.modules.zhmc_user_pattern.AnsibleModule", autospec=True)
+def test_zhmc_user_pattern_absent_present(
+        ansible_mod_cls,
+        desc, initial_upattern_props, input_state,
+        input_props, exp_upattern_props, exp_changed,
+        check_mode,
+        hmc_session):  # noqa: F811, E501
+    # pylint: disable=redefined-outer-name,unused-argument
+    """
+    Test the zhmc_user_pattern module with state=absent/present.
+    """
+
+    hd = hmc_session.hmc_definition
+    hmc_host = hd.host
+    hmc_auth = dict(userid=hd.userid, password=hd.password,
+                    ca_certs=hd.ca_certs, verify=hd.verify)
+
+    faked_session = hmc_session if hd.mock_file else None
+
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+
+    # Create a user pattern name that does not exist
+    upattern_name = new_upattern_name()
+
+    where = f"user pattern '{upattern_name}'"
+
+    # Pick a random user template in case we need it
+    user_templates = console.users.findall(type='template')
+    if not user_templates:
+        pytest.skip("HMC does not have a user template")
+    user_template = random.choice(user_templates)
+
+    if input_props is not None:
+
+        # Specify a random user template
+        if 'specific_template_name' in input_props and \
+                input_props['specific_template_name'] is None:
+            input_props = dict(input_props)
+            input_props['specific_template_name'] = user_template.name
+            if exp_upattern_props is not None:
+                exp_upattern_props = dict(exp_upattern_props)
+                exp_upattern_props['specific-template-uri'] = user_template.uri
+
+    # Create initial user pattern, if specified so
+    if initial_upattern_props is not None:
+        upattern_props = STD_UPATTERN_HMC_INPUT_PROPS.copy()
+        upattern_props.update(initial_upattern_props)
+        upattern_props['name'] = upattern_name
+
+        # Specify a random user template
+        if 'specific-template-uri' in upattern_props and \
+                upattern_props['specific-template-uri'] is None:
+            upattern_props['specific-template-uri'] = user_template.uri
+            if exp_upattern_props is not None:
+                exp_upattern_props = dict(exp_upattern_props)
+                exp_upattern_props['specific-template-uri'] = user_template.uri
+
+        try:
+            console.user_patterns.create(upattern_props)
+        except zhmcclient.HTTPError as exc:
+            if exc.http_status == 403 and exc.reason == 1:
+                # User is not permitted to create user patterns
+                pytest.skip(f"HMC user '{hd.userid}' is not permitted to "
+                            "create initial test user pattern")
+            else:
+                raise
+    else:
+        upattern_props = None
+
+    try:
+
+        # Prepare module input parameters (must be all required + optional)
+        params = {
+            'hmc_host': hmc_host,
+            'hmc_auth': hmc_auth,
+            'name': upattern_name,
+            'state': input_state,
+            'properties': input_props,
+            'log_file': LOG_FILE,
+            '_faked_session': faked_session,
+        }
+
+        mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+        # Exercise the code to be tested
+        with pytest.raises(SystemExit) as exc_info:
+            zhmc_user_pattern.main()
+        exit_code = exc_info.value.args[0]
+
+        if exit_code != 0:
+            msg = get_failure_msg(mod_obj)
+            if msg.startswith('HTTPError: 403,1'):
+                pytest.skip(f"HMC user '{hd.userid}' is not permitted to "
+                            "create test user pattern")
+            raise AssertionError(
+                f"{where}: Module failed with exit code {exit_code} and "
+                f"message:\n{msg}")
+
+        changed, output_props = get_module_output(mod_obj)
+        if changed != exp_changed:
+            upattern_props_sorted = \
+                dict(sorted(upattern_props.items(), key=lambda x: x[0])) \
+                if upattern_props is not None else None
+            input_props_sorted = \
+                dict(sorted(input_props.items(), key=lambda x: x[0])) \
+                if input_props is not None else None
+            output_props_sorted = \
+                dict(sorted(output_props.items(), key=lambda x: x[0])) \
+                if output_props is not None else None
+            upattern_props_str = pformat(upattern_props_sorted, indent=2)
+            input_props_str = pformat(input_props_sorted, indent=2)
+            output_props_str = pformat(output_props_sorted, indent=2)
+            raise AssertionError(
+                "Unexpected change flag returned: "
+                f"actual: {changed}, expected: {exp_changed}\n"
+                f"Initial user pattern properties:\n{upattern_props_str}\n"
+                f"Module input properties:\n{input_props_str}\n"
+                f"Resulting user pattern properties:\n{output_props_str}")
+        if input_state == 'present':
+            assert_upattern_props(output_props, exp_upattern_props, where)
+
+    finally:
+        # Delete user pattern, if it exists
+        try:
+            # We invalidate the name cache of our client, because the user pattern
+            # was possibly deleted by the Ansible module and not through our
+            # client instance.
+            console.user_patterns.invalidate_cache()
+            upattern = console.user_patterns.find_by_name(upattern_name)
+        except zhmcclient.NotFound:
+            upattern = None
+        if upattern:
+            upattern.delete()

--- a/tests/end2end/test_zhmc_user_pattern_list.py
+++ b/tests/end2end/test_zhmc_user_pattern_list.py
@@ -1,0 +1,162 @@
+# Copyright 2024 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for zhmc_user_pattern_list module.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from unittest import mock
+import pytest
+import urllib3
+import zhmcclient
+# pylint: disable=line-too-long,unused-import
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+# pylint: enable=line-too-long,unused-import
+
+from plugins.modules import zhmc_user_pattern_list
+from .utils import mock_ansible_module, get_failure_msg
+
+urllib3.disable_warnings()
+
+# Print debug messages
+DEBUG = False
+
+LOG_FILE = 'zhmc_user_pattern_list.log' if DEBUG else None
+
+
+def get_module_output(mod_obj):
+    """
+    Return the module output as a tuple (changed, user_properties) (i.e.
+    the arguments of the call to exit_json()).
+    If the module failed, return None.
+    """
+
+    def func(changed, user_patterns):
+        return changed, user_patterns
+
+    if not mod_obj.exit_json.called:
+        return None
+    call_args = mod_obj.exit_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])
+
+
+def assert_upattern_list(upattern_list, exp_upattern_dict):
+    """
+    Assert the output of the zhmc_user_pattern_list module
+    """
+    assert isinstance(upattern_list, list)
+    assert len(upattern_list) == len(exp_upattern_dict)
+    for upattern_item in upattern_list:
+        assert 'name' in upattern_item, \
+            f"Returned user pattern {upattern_item!r} does not have a 'name' " \
+            "property"
+        upattern_name = upattern_item['name']
+        assert upattern_name in exp_upattern_dict, \
+            f"Unexpected returned user pattern {upattern_name!r}"
+
+        exp_upattern = exp_upattern_dict[upattern_name]
+
+        # Convert expected properties to underscore names
+        exp_upattern_properties = {}
+        for pname_hmc, pvalue in exp_upattern.properties.items():
+            pname = pname_hmc.replace('-', '_')
+            exp_upattern_properties[pname] = pvalue
+
+        for pname, pvalue in upattern_item.items():
+            assert '-' not in pname, \
+                f"Property {pname!r} in user pattern {upattern_name!r} is " \
+                "returned with hyphens in the property name"
+            assert pname in exp_upattern_properties, \
+                f"Unexpected property {pname!r} in user pattern " \
+                f"{upattern_name!r}"
+            exp_value = exp_upattern_properties[pname]
+            assert pvalue == exp_value, \
+                f"Incorrect value for property {pname!r} of user pattern " \
+                f"{upattern_name!r}"
+
+
+@pytest.mark.parametrize(
+    "property_flags", [
+        pytest.param({}, id="property_flags()"),
+        pytest.param({'full_properties': True},
+                     id="property_flags(full_properties=True)"),
+    ]
+)
+@pytest.mark.parametrize(
+    "check_mode", [
+        pytest.param(False, id="check_mode=False"),
+        pytest.param(True, id="check_mode=True"),
+    ]
+)
+@mock.patch("plugins.modules.zhmc_user_pattern_list.AnsibleModule",
+            autospec=True)
+def test_zhmc_user_pattern_list(
+        ansible_mod_cls, check_mode, property_flags,
+        hmc_session):  # noqa: F811, E501
+    # pylint: disable=redefined-outer-name
+    """
+    Test the zhmc_user_pattern_list module.
+    """
+
+    hd = hmc_session.hmc_definition
+    hmc_host = hd.host
+    hmc_auth = dict(userid=hd.userid, password=hd.password,
+                    ca_certs=hd.ca_certs, verify=hd.verify)
+
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+
+    faked_session = hmc_session if hd.mock_file else None
+
+    full_properties = property_flags.get('full_properties', False)
+
+    # Determine the actual list of user patterns on the HMC.
+    act_upatterns = console.user_patterns.list(full_properties=full_properties)
+    act_upatterns_dict = {}
+    for r in act_upatterns:
+        act_upatterns_dict[r.name] = r
+
+    # Prepare module input parameters (must be all required + optional)
+    params = {
+        'hmc_host': hmc_host,
+        'hmc_auth': hmc_auth,
+        'full_properties': full_properties,
+        'log_file': LOG_FILE,
+        '_faked_session': faked_session,
+    }
+
+    # Prepare mocks for AnsibleModule object
+    mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+    # Exercise the code to be tested
+    with pytest.raises(SystemExit) as exc_info:
+        zhmc_user_pattern_list.main()
+    exit_code = exc_info.value.args[0]
+
+    # Assert module exit code
+    assert exit_code == 0, \
+        f"Module failed with exit code {exit_code} and message:\n" \
+        f"{get_failure_msg(mod_obj)}"
+
+    # Assert module output
+    changed, upattern_list = get_module_output(mod_obj)
+    assert changed is False
+
+    assert_upattern_list(upattern_list, act_upatterns_dict)

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -22,6 +22,8 @@ plugins/modules/zhmc_storage_group_attachment.py validate-modules:missing-gplv3-
 plugins/modules/zhmc_storage_group.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_volume.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_user_pattern_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_user_pattern.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -22,6 +22,8 @@ plugins/modules/zhmc_storage_group_attachment.py validate-modules:missing-gplv3-
 plugins/modules/zhmc_storage_group.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_volume.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_user_pattern_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_user_pattern.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -22,6 +22,8 @@ plugins/modules/zhmc_storage_group_attachment.py validate-modules:missing-gplv3-
 plugins/modules/zhmc_storage_group.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_volume.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_user_pattern_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_user_pattern.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -22,6 +22,8 @@ plugins/modules/zhmc_storage_group_attachment.py validate-modules:missing-gplv3-
 plugins/modules/zhmc_storage_group.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_storage_volume.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_user_pattern_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_user_pattern.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user_role.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_user.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0


### PR DESCRIPTION
For details, see the commit message.

Note, the end2end_mocked test has some new failures because https://github.com/zhmcclient/python-zhmcclient/pull/1582 is not yet merged. In a local test with that PR, there were no new failures.

Particular review points:
* These new modules return their properties with underscores in the property names.