### PR TITLE
Test: Fixed exception handling in end2end tests for password rules

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -69,6 +69,8 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Test: Fixed that coverage was calculated only for the Ansible module
   source files, but not for the utility files in module_utils. (issue #1020)
 
+* Test: Fixed exception handling in end2end tests for password rules.
+
 **Enhancements:**
 
 * Test: Added tests for Ansible 10. The testing of Ansible 3 was dropped

--- a/tests/end2end/test_zhmc_password_rule.py
+++ b/tests/end2end/test_zhmc_password_rule.py
@@ -286,6 +286,7 @@ def test_zhmc_password_rule_absent_present(
                 # User is not permitted to create password rules
                 pytest.skip(f"HMC user '{hd.userid}' is not permitted to "
                             "create initial test password rule")
+            raise
     else:
         pwrule_props = None
 


### PR DESCRIPTION
For details, see the commit message.
No review needed.