### PR TITLE
Test: Added end2end tests for adding and removing user roles to/from users

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -123,6 +123,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Added new Ansible modules 'zhmc_user_pattern_list' and 'zhmc_user_pattern'
   for listing and managing user patterns on the HMC. (issue #361)
 
+* Test: Added end2end tests for adding and removing user roles to/from existing
+  users. (related to issue #716)
+
 **Cleanup:**
 
 * Modernized the code to match the minimum Python version 3.8 (use of f-strings,


### PR DESCRIPTION
For details, see the commit message.

Note: This PR requires PR https://github.com/zhmcclient/python-zhmcclient/pull/1584. Not having that PR in the test workflow is why the new end2end testcases have failures in "make end2end_mocked". I have tested it locally with that PR.

Update: I have now re-run the test workflow with PR https://github.com/zhmcclient/python-zhmcclient/pull/1584 merged, and now the new testcases in the end2end_mocked tests pass.