### PR TITLE
Fixed doc typos in 'zhmc_lpar_messages' and 'zhmc_partition_messages'

### DIFF
--- a/docs/source/modules/zhmc_lpar_messages.rst
+++ b/docs/source/modules/zhmc_lpar_messages.rst
@@ -281,7 +281,7 @@ messages
     | **type**: str
 
   os_name
-    The name of the operating system that generated this omessage, or null indicating there is no operating system name  associated with this message.
+    The name of the operating system that generated this message, or null indicating there is no operating system name  associated with this message.
 
     This name is determined by the operating system and may be unrelated to the name of the LPAR in which the operating system is running.
 

--- a/docs/source/modules/zhmc_partition_messages.rst
+++ b/docs/source/modules/zhmc_partition_messages.rst
@@ -254,7 +254,7 @@ messages
     | **type**: str
 
   os_name
-    The name of the operating system that generated this omessage, or null indicating there is no operating system name  associated with this message.
+    The name of the operating system that generated this message, or null indicating there is no operating system name  associated with this message.
 
     This name is determined by the operating system and may be unrelated to the name of the partition in which the operating system is running.
 

--- a/plugins/modules/zhmc_lpar_messages.py
+++ b/plugins/modules/zhmc_lpar_messages.py
@@ -247,7 +247,7 @@ messages:
       type: str
     os_name:
       description:
-        - "The name of the operating system that generated this omessage, or
+        - "The name of the operating system that generated this message, or
            null indicating there is no operating system name  associated with
            this message."
         - "This name is determined by the operating system and may be unrelated

--- a/plugins/modules/zhmc_partition_messages.py
+++ b/plugins/modules/zhmc_partition_messages.py
@@ -222,7 +222,7 @@ messages:
       type: str
     os_name:
       description:
-        - "The name of the operating system that generated this omessage, or
+        - "The name of the operating system that generated this message, or
            null indicating there is no operating system name  associated with
            this message."
         - "This name is determined by the operating system and may be unrelated


### PR DESCRIPTION
No review needed.