### PR TITLE
1.9: Fixed password blanked in zhmc_user module

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -37,6 +37,10 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Dev: Fixed removal of some files in the Makefile.
 
+* Fixed that the zhmc_user module blanked out the 'password' property in
+  the input params before passing them on to the zhmcclient
+  'User.update_properties()' method. (issue #1081)
+
 **Enhancements:**
 
 * Support for ansible-core 2.18, by adding an ignore file for the sanity tests.

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -26,6 +26,7 @@ import platform
 import sys
 import re
 from collections.abc import Mapping
+from copy import deepcopy
 
 try:
     from zhmcclient import Session, ClientAuthError
@@ -1408,3 +1409,29 @@ class NotificationThread(threading.Thread):
         The timeout is an int or float in seconds.
         """
         return self._ready_event.wait(timeout)
+
+
+def params_deepcopy(params):
+    """
+    Return a deep copy of the module input parameters, for dict items where
+    a deep copy is possible.
+
+    For items where a deep copy is not possible, it keeps the original value.
+
+    Reason for this function (instead of simply using `copy.deepcopy()`) is
+    the fact that in this collection, the module input params may contain
+    an optional '_faked_session' item with a value that cannot be copied.
+
+    Parameters:
+      params (dict): Module input parameters.
+
+    Returns:
+      dict: Deep copy of params, where possible.
+    """
+    copy_params = {}
+    for key, value in params.items():
+        try:
+            copy_params[key] = deepcopy(value)
+        except TypeError:
+            copy_params[key] = value
+    return copy_params

--- a/plugins/modules/zhmc_user.py
+++ b/plugins/modules/zhmc_user.py
@@ -380,7 +380,8 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host, BLANKED_OUT  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, BLANKED_OUT, \
+    params_deepcopy  # noqa: E402
 
 try:
     import urllib3
@@ -1167,7 +1168,10 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
+    # We need to deepcopy the input parameters, because the dict in which we
+    # blank out the password is at the second level. With a shallow copy,
+    # that would blank out the password in the original params.
+    _params = params_deepcopy(module.params)
     del _params['hmc_auth']
     if _params['properties'] and 'password' in _params['properties']:
         # This is not a hard-coded password. Added # nosec to avoid

--- a/tests/end2end/test_zhmc_user.py
+++ b/tests/end2end/test_zhmc_user.py
@@ -31,6 +31,7 @@ import zhmcclient
 from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
 # pylint: enable=line-too-long,unused-import
 
+from plugins.module_utils.common import params_deepcopy
 from plugins.modules import zhmc_user
 from .utils import mock_ansible_module, get_failure_msg
 
@@ -460,6 +461,9 @@ def test_zhmc_user_absent_present(
 
         mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
 
+        # Save the input params
+        saved_params = params_deepcopy(params)
+
         # Exercise the code to be tested
         with pytest.raises(SystemExit) as exc_info:
             zhmc_user.main()
@@ -468,6 +472,9 @@ def test_zhmc_user_absent_present(
         assert exit_code == 0, \
             f"{where}: Module failed with exit code {exit_code} and " \
             f"message:\n{get_failure_msg(mod_obj)}"
+
+        # Check that the input params have not been changed
+        assert params == saved_params
 
         changed, output_props = get_module_output(mod_obj)
         if changed != exp_changed:


### PR DESCRIPTION
Rolls back PR #1087 into 1.9.2.