### PR TITLE
Docs: Ignored www.ansible.com in linkcheck, because it occasionally times out

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -274,4 +274,7 @@ linkcheck_ignore = [
 
     # Page exists, but linkchedck gets HTTP 403 "Forbidden"
     r'https://opensource.org/license/apache-2-0',
+
+    # Page exists, but linkchedck occasionally gets timeout"
+    r'https://www.ansible.com',
 ]

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -61,6 +61,8 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Docs: Fixed broken links to IBM documentation and updated permanently
   redirected links.
 
+* Docs: Ignored www.ansible.com in linkcheck, because it occasionally times out.
+
 **Enhancements:**
 
 * Support for ansible-core 2.18, by adding an ignore file for the sanity tests.


### PR DESCRIPTION
No review needed.