### PR TITLE
1.9: Docs: Ignored www.ansible.com in linkcheck, because it occasionally times out

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -274,4 +274,7 @@ linkcheck_ignore = [
 
     # Page exists, but linkchedck gets HTTP 403 "Forbidden"
     r'https://opensource.org/license/apache-2-0',
+
+    # Page exists, but linkchedck occasionally gets timeout"
+    r'https://www.ansible.com',
 ]

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -33,6 +33,8 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Bug fixes:**
 
+* Docs: Ignored www.ansible.com in linkcheck, because it occasionally times out.
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #1091 into 1.9.3.