### PR TITLE
Fixed return and logging of password-like props in clear text

### DIFF
--- a/docs/source/modules/zhmc_ldap_server_definition.rst
+++ b/docs/source/modules/zhmc_ldap_server_definition.rst
@@ -228,7 +228,7 @@ ldap_server_definition
     | **type**: str
 
   {property}
-    Additional properties of the LDAP Server Definition, as described in the data model of the 'LDAP Server Definition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (-) as described in that book.
+    Additional properties of the LDAP Server Definition, as described in the data model of the 'LDAP Server Definition' object in the :ref:`HMC API <HMC API>` book. Write-only properties in the data model are not included. The property names have hyphens (-) as described in that book.
 
     | **type**: raw
 

--- a/docs/source/modules/zhmc_lpar.rst
+++ b/docs/source/modules/zhmc_lpar.rst
@@ -560,7 +560,7 @@ lpar
     | **type**: str
 
   {property}
-    Additional properties of the LPAR, as described in the data model of the 'Logical Partition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (-) as described in that book.
+    Additional properties of the LPAR, as described in the data model of the 'Logical Partition' object in the :ref:`HMC API <HMC API>` book. Write-only properties in the data model are not included. The property names have hyphens (-) as described in that book.
 
     | **type**: raw
 

--- a/docs/source/modules/zhmc_partition.rst
+++ b/docs/source/modules/zhmc_partition.rst
@@ -515,7 +515,7 @@ partition
     | **type**: str
 
   {property}
-    Additional properties of the partition, as described in the data model of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (-) as described in that book.
+    Additional properties of the partition, as described in the data model of the 'Partition' object in the :ref:`HMC API <HMC API>` book. Write-only properties in the data model are not included. The property names have hyphens (-) as described in that book.
 
     | **type**: raw
 

--- a/docs/source/modules/zhmc_user.rst
+++ b/docs/source/modules/zhmc_user.rst
@@ -277,7 +277,7 @@ user
     | **type**: str
 
   {property}
-    Additional properties of the user, as described in the data model of the 'User' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (-) as described in that book.
+    Additional properties of the user, as described in the data model of the 'User' object in the :ref:`HMC API <HMC API>` book. Write-only properties in the data model are not included. The property names have hyphens (-) as described in that book.
 
     | **type**: raw
 
@@ -348,7 +348,7 @@ user
     | **type**: dict
 
     {property}
-      Properties of the LDAP server definition, as described in the data model of the 'LDAP Server Definition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (-) as described in that book.
+      Properties of the LDAP server definition, as described in the data model of the 'LDAP Server Definition' object in the :ref:`HMC API <HMC API>` book. Write-only properties in the data model are not included. The property names have hyphens (-) as described in that book.
 
       | **type**: raw
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -37,7 +37,16 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Fixed safety issues up to 2024-11-21.
 
-* Increased zhmcclient version to 1.18.0 to pick up fixes. (issue #1074)
+* Increased zhmcclient version to 1.18.2 to pick up fixes. (issue #1074)
+
+* Fixed that all password-like input parameters that were written in clear text
+  to the module entry log are now blanked out. This affected the following
+  modules: zhmc_ldap_server_definition, zhmc_lpar, zhmc_partition, zhmc_user.
+
+* Fixed that all password-like input parameters that were added to the
+  module return value in clear text for 'state' values that created or updated
+  the resource are now removed from the return value. This affected the
+  following modules: zhmc_ldap_server_definition, zhmc_lpar, zhmc_partition.
 
 * Sanity test: Fixed the sanity test on AutomationHub which failed because the
   "compile" and "import" tests were run for all target node Python versions,
@@ -66,6 +75,10 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 **Enhancements:**
 
 * Support for ansible-core 2.18, by adding an ignore file for the sanity tests.
+
+* The 'hmc_auth' input parameter is no longer completely removed from the
+  module entry log, but instead its sensitive items 'password' and 'session_id'
+  are now blanked out.
 
 **Cleanup:**
 

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -38,7 +38,7 @@ requests==2.32.2
 
 pytz==2019.1
 
-zhmcclient==1.18.0
+zhmcclient==1.18.2
 
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with requirements.txt)
@@ -57,7 +57,7 @@ packaging==22.0
 PyYAML==6.0.2
 
 python-dateutil==2.8.2
-jsonschema==4.18.1
+jsonschema==4.18.2
 urllib3==1.26.19
 
 

--- a/plugins/modules/zhmc_adapter.py
+++ b/plugins/modules/zhmc_adapter.py
@@ -350,7 +350,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, eq_hex, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -966,9 +966,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_adapter_list.py
+++ b/plugins/modules/zhmc_adapter_list.py
@@ -279,7 +279,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, \
-    missing_required_lib, parse_hmc_host  # noqa: E402
+    missing_required_lib, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -474,9 +474,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_console.py
+++ b/plugins/modules/zhmc_console.py
@@ -237,7 +237,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -413,9 +413,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_cpc.py
+++ b/plugins/modules/zhmc_cpc.py
@@ -416,7 +416,8 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, StatusError, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, pull_properties, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, pull_properties, parse_hmc_host, \
+    blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -899,9 +900,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_cpc_capacity.py
+++ b/plugins/modules/zhmc_cpc_capacity.py
@@ -451,7 +451,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
     common_fail_on_import_errors, parse_hmc_host, \
-    underscore_properties  # noqa: E402
+    underscore_properties, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -835,9 +835,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_cpc_list.py
+++ b/plugins/modules/zhmc_cpc_list.py
@@ -222,7 +222,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -330,9 +330,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_crypto_attachment.py
+++ b/plugins/modules/zhmc_crypto_attachment.py
@@ -374,7 +374,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 
 try:
@@ -1091,9 +1091,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_hba.py
+++ b/plugins/modules/zhmc_hba.py
@@ -246,7 +246,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, wait_for_transition_completion, \
     eq_hex, to_unicode, process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -627,9 +627,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_ldap_server_definition_list.py
+++ b/plugins/modules/zhmc_ldap_server_definition_list.py
@@ -162,7 +162,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -246,9 +246,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_lpar_command.py
+++ b/plugins/modules/zhmc_lpar_command.py
@@ -211,7 +211,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, NotificationThread, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -424,9 +424,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = True
     try:

--- a/plugins/modules/zhmc_lpar_list.py
+++ b/plugins/modules/zhmc_lpar_list.py
@@ -237,7 +237,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -422,9 +422,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_lpar_messages.py
+++ b/plugins/modules/zhmc_lpar_messages.py
@@ -286,7 +286,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -448,9 +448,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_nic.py
+++ b/plugins/modules/zhmc_nic.py
@@ -279,7 +279,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, wait_for_transition_completion, \
     eq_hex, eq_mac, to_unicode, process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -753,9 +753,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_nic_list.py
+++ b/plugins/modules/zhmc_nic_list.py
@@ -196,7 +196,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -302,9 +302,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_partition_command.py
+++ b/plugins/modules/zhmc_partition_command.py
@@ -211,7 +211,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, NotificationThread, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -425,9 +425,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = True
     try:

--- a/plugins/modules/zhmc_partition_list.py
+++ b/plugins/modules/zhmc_partition_list.py
@@ -234,7 +234,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -415,9 +415,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_partition_messages.py
+++ b/plugins/modules/zhmc_partition_messages.py
@@ -261,7 +261,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -413,9 +413,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_password_rule.py
+++ b/plugins/modules/zhmc_password_rule.py
@@ -263,7 +263,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -671,9 +671,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_password_rule_list.py
+++ b/plugins/modules/zhmc_password_rule_list.py
@@ -176,7 +176,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -266,9 +266,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_session.py
+++ b/plugins/modules/zhmc_session.py
@@ -221,7 +221,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, \
-    missing_required_lib, parse_hmc_host  # noqa: E402
+    missing_required_lib, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -353,9 +353,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     # We do not count session creation or deletion as a change
     changed = False

--- a/plugins/modules/zhmc_storage_group.py
+++ b/plugins/modules/zhmc_storage_group.py
@@ -580,7 +580,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -1142,9 +1142,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_storage_group_attachment.py
+++ b/plugins/modules/zhmc_storage_group_attachment.py
@@ -227,7 +227,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -455,9 +455,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_storage_volume.py
+++ b/plugins/modules/zhmc_storage_volume.py
@@ -278,7 +278,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, eq_hex, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -704,9 +704,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_user_list.py
+++ b/plugins/modules/zhmc_user_list.py
@@ -181,7 +181,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -271,9 +271,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_user_pattern.py
+++ b/plugins/modules/zhmc_user_pattern.py
@@ -291,7 +291,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, underscore_properties, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -944,9 +944,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_user_pattern_list.py
+++ b/plugins/modules/zhmc_user_pattern_list.py
@@ -197,7 +197,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
     underscore_properties_list, common_fail_on_import_errors, \
-    parse_hmc_host  # noqa: E402
+    parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -276,9 +276,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_user_role.py
+++ b/plugins/modules/zhmc_user_role.py
@@ -452,7 +452,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -1321,9 +1321,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_user_role_list.py
+++ b/plugins/modules/zhmc_user_role_list.py
@@ -181,7 +181,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -271,9 +271,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     changed = False
     try:

--- a/plugins/modules/zhmc_versions.py
+++ b/plugins/modules/zhmc_versions.py
@@ -245,7 +245,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -368,9 +368,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/plugins/modules/zhmc_virtual_function.py
+++ b/plugins/modules/zhmc_virtual_function.py
@@ -241,7 +241,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, wait_for_transition_completion, \
     eq_hex, to_unicode, process_normal_property, missing_required_lib, \
-    common_fail_on_import_errors, parse_hmc_host  # noqa: E402
+    common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
     import urllib3
@@ -605,9 +605,9 @@ def main():
 
     module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
 
-    _params = dict(module.params)
-    del _params['hmc_auth']
-    LOGGER.debug("Module entry: params: %r", _params)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
 
     try:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ requests>=2.32.2
 pytz>=2019.1
 
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.18.0
+zhmcclient>=1.18.2
 
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with minimum-constraints-install.txt)
@@ -74,6 +74,8 @@ PyYAML>=6.0.2
 python-dateutil>=2.8.2
 
 # jsonschema
-jsonschema>=4.18.1
+jsonschema>=4.18.2
+# TODO: Python 3.13 support requires pyo3-ffi fixing its issue with Python 3.13
+#       (see https://github.com/PyO3/pyo3/issues/4038#issuecomment-2156363013)
 
 urllib3>=1.26.19

--- a/tests/end2end/test_zhmc_lpar.py
+++ b/tests/end2end/test_zhmc_lpar.py
@@ -172,6 +172,10 @@ def assert_lpar_props(act_props, exp_props, where):
                               f"Actual: {act_value!r}")
         assert act_value == exp_value, where_prop
 
+    # Assert that none of the write-only properties is in the output object
+    for prop_name in zhmc_lpar.WRITEONLY_PROPERTIES_HYPHEN:
+        assert prop_name not in act_props, where
+
 
 def ensure_lpar_status(logger, lpar, iap, status):
     """

--- a/tests/end2end/test_zhmc_partition.py
+++ b/tests/end2end/test_zhmc_partition.py
@@ -115,6 +115,7 @@ STD_LINUX_PARTITION_HMC_INPUT_PROPS = {
     'initial-memory': MIN_MEMORY,
     'maximum-memory': MIN_MEMORY,
 }
+STD_LINUX_PARTITION_HMC_EXP_PROPS = dict(STD_LINUX_PARTITION_HMC_INPUT_PROPS)
 STD_SSC_PARTITION_HMC_INPUT_PROPS = {
     # 'name': updated upon use
     'description': "zhmc test partition",
@@ -126,6 +127,8 @@ STD_SSC_PARTITION_HMC_INPUT_PROPS = {
     'ssc-master-userid': 'sscuser',
     'ssc-master-pw': 'Need2ChangeSoon!',
 }
+STD_SSC_PARTITION_HMC_EXP_PROPS = dict(STD_SSC_PARTITION_HMC_INPUT_PROPS)
+del STD_SSC_PARTITION_HMC_EXP_PROPS['ssc-master-pw']
 
 
 def storage_mgmt_enabled(cpc):
@@ -499,6 +502,10 @@ def assert_partition_props(act_props, exp_props, where):
         exp_boot_sv_name = exp_props['boot-storage-volume-name']
         assert act_props['boot-storage-volume-name'] == exp_boot_sv_name
 
+    # Assert that none of the write-only properties is in the output object
+    for prop_name in zhmc_partition.WRITEONLY_PROPERTIES_HYPHEN:
+        assert prop_name not in act_props, where
+
 
 PARTITION_FACTS_TESTCASES = [
     # The list items are tuples with the following items:
@@ -727,7 +734,7 @@ PARTITION_STATE_TESTCASES = [
         'stopped',
         STD_LINUX_PARTITION_MODULE_INPUT_PROPS,
         None,
-        STD_LINUX_PARTITION_HMC_INPUT_PROPS,
+        STD_LINUX_PARTITION_HMC_EXP_PROPS,
         True,
         True,
     ),
@@ -739,7 +746,7 @@ PARTITION_STATE_TESTCASES = [
         'stopped',
         None,
         None,
-        STD_LINUX_PARTITION_HMC_INPUT_PROPS,
+        STD_LINUX_PARTITION_HMC_EXP_PROPS,
         False,
         True,
     ),
@@ -751,7 +758,7 @@ PARTITION_STATE_TESTCASES = [
         'stopped',
         None,
         None,
-        STD_LINUX_PARTITION_HMC_INPUT_PROPS,
+        STD_LINUX_PARTITION_HMC_EXP_PROPS,
         True,
         True,
     ),
@@ -791,7 +798,7 @@ PARTITION_STATE_TESTCASES = [
         'stopped',
         STD_LINUX_PARTITION_MODULE_INPUT_PROPS,
         None,
-        STD_LINUX_PARTITION_HMC_INPUT_PROPS,
+        STD_LINUX_PARTITION_HMC_EXP_PROPS,
         True,
         True,
     ),
@@ -802,7 +809,7 @@ PARTITION_STATE_TESTCASES = [
         'stopped',
         STD_SSC_PARTITION_MODULE_INPUT_PROPS,
         None,
-        STD_SSC_PARTITION_HMC_INPUT_PROPS,
+        STD_SSC_PARTITION_HMC_EXP_PROPS,
         True,
         True,
     ),
@@ -818,7 +825,7 @@ PARTITION_STATE_TESTCASES = [
         'stopped',
         None,
         None,
-        STD_SSC_PARTITION_HMC_INPUT_PROPS,
+        STD_SSC_PARTITION_HMC_EXP_PROPS,
         False,
         True,
     ),
@@ -830,7 +837,7 @@ PARTITION_STATE_TESTCASES = [
         'active',
         None,
         None,  # Code ignores "HTTPError: 409,131"
-        STD_SSC_PARTITION_HMC_INPUT_PROPS,
+        STD_SSC_PARTITION_HMC_EXP_PROPS,
         True,
         True,
     ),
@@ -844,7 +851,7 @@ PARTITION_STATE_TESTCASES = [
         'stopped',
         STD_SSC_PARTITION_MODULE_INPUT_PROPS,
         None,
-        STD_SSC_PARTITION_HMC_INPUT_PROPS,
+        STD_SSC_PARTITION_HMC_EXP_PROPS,
         True,
         True,
     ),

--- a/tests/end2end/test_zhmc_user.py
+++ b/tests/end2end/test_zhmc_user.py
@@ -224,6 +224,10 @@ def assert_user_props(user_props, expand, where):
     if expand:
         assert 'user-role-objects' in user_props, where
 
+    # Assert that none of the write-only properties is in the output object
+    for prop_name in zhmc_user.WRITEONLY_PROPERTIES_HYPHEN:
+        assert prop_name not in user_props, where
+
 
 @pytest.mark.parametrize(
     "check_mode", [


### PR DESCRIPTION
For details, see the commit message.

End2end tests:

* Tested on A224 with a playbook with `log_file` enabled that creates an LDAP server definition with bind password - checked the module output and the log file - passed
* Ran `TESTCASES=test_zhmc_ldap_server_definition.py make end2end` on A224 - passed
* Ran `TESTCASES=test_zhmc_user.py make end2end` on A224 - passed
* Ran `TESTCASES=test_zhmc_partition.py make end2end` on A224 - passed
* Tested that the updated end2end testcases from this PR with the collection code from the master branch fail due to the password-like properties in the module output, with `TESTCASES=test_zhmc_ldap_server_definition.py make end2end` on A224 - passed

Note: test_zhmc_lpar.py was not run.