### PR TITLE
Fixed duplicate 'description' property in test YAML files

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -63,6 +63,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Docs: Ignored www.ansible.com in linkcheck, because it occasionally times out.
 
+* Test: Fixed duplicate 'description' properties in test YAML files.
+  (issue #1097)
+
 **Enhancements:**
 
 * Support for ansible-core 2.18, by adding an ignore file for the sanity tests.

--- a/tests/end2end/mocked_hmc_z14.yaml
+++ b/tests/end2end/mocked_hmc_z14.yaml
@@ -315,11 +315,10 @@ hmc_definition:
         - properties:
             element-id: lsd1
             name: LDAP server definition 1
-            description: LDAP server definition 1
+            description: "LSD 1"
             primary-hostname-ipaddr: 10.11.12.13
             search-distinguished-name: "test{0}"
             replication-overwrite-possible: false
-            description: "LSD 1"
             connection-port: null
             backup-hostname-ipaddr: null
             use-ssl: false

--- a/tests/end2end/mocked_hmc_z16.yaml
+++ b/tests/end2end/mocked_hmc_z16.yaml
@@ -315,11 +315,10 @@ hmc_definition:
         - properties:
             element-id: lsd1
             name: LDAP server definition 1
-            description: LDAP server definition 1
+            description: "LSD 1"
             primary-hostname-ipaddr: 10.11.12.13
             search-distinguished-name: "test{0}"
             replication-overwrite-possible: false
-            description: "LSD 1"
             connection-port: null
             backup-hostname-ipaddr: null
             use-ssl: false


### PR DESCRIPTION
No review needed.