### PR TITLE
Removed PIP_NO_PYTHON_VERSION_WARNING as it is deprecated and noop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,6 @@ jobs:
     container: ${{ matrix.container }}
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
-      PIP_NO_PYTHON_VERSION_WARNING: 1
     steps:
     - name: Set run type (normal, scheduled, release)
       id: set-run-type


### PR DESCRIPTION
No review needed.