### PR TITLE
Added expand_names and fixes for zhmc_user, zhmc_user_list

### DIFF
--- a/docs/source/modules/zhmc_user.rst
+++ b/docs/source/modules/zhmc_user.rst
@@ -120,9 +120,15 @@ properties
 
   \* :literal:`user\_pattern\_uri`\ : Cannot be set directly, but indirectly via the artificial property :literal:`user\_pattern\_name`.
 
+  \* :literal:`user\_template\_uri`\ : Cannot be set directly, but indirectly via the artificial property :literal:`user\_template\_name`.
+
   \* :literal:`password\_rule\_uri`\ : Cannot be set directly, but indirectly via the artificial property :literal:`password\_rule\_name`.
 
   \* :literal:`ldap\_server\_definition\_uri`\ : Cannot be set directly, but indirectly via the artificial property :literal:`ldap\_server\_definition\_name`.
+
+  \* :literal:`primary\_mfa\_server\_definition\_uri`\ : Cannot be set directly, but indirectly via the artificial property :literal:`primary\_mfa\_server\_definition\_name`.
+
+  \* :literal:`backup\_mfa\_server\_definition\_uri`\ : Cannot be set directly, but indirectly via the artificial property :literal:`backup\_mfa\_server\_definition\_name`.
 
   \* :literal:`default\_group\_uri`\ : Cannot be set directly, but indirectly via the artificial property :literal:`default\_group\_name`.
 
@@ -139,6 +145,16 @@ expand
 
   | **required**: False
   | **type**: bool
+
+
+expand_names
+  Boolean that controls whether the returned user contains additional artificial properties for the names of referenced objects, such as user roles, password rule, etc.
+
+  For backwards compatibility, this parameter defaults to True.
+
+  | **required**: False
+  | **type**: bool
+  | **default**: True
 
 
 log_file
@@ -231,7 +247,10 @@ user
             "allow-management-interfaces": true,
             "allow-remote-access": true,
             "authentication-type": "local",
+            "backup-mfa-server-definition-name": null,
+            "backup-mfa-server-definition-uri": null,
             "class": "user",
+            "default-group-name": null,
             "default-group-uri": null,
             "description": "",
             "disable-delay": 1,
@@ -248,15 +267,22 @@ user
             "ldap-server-definition-uri": null,
             "max-failed-logins": 3,
             "max-web-services-api-sessions": 1000,
+            "mfa-policy": null,
+            "mfa-types": null,
+            "mfa-userid": null,
+            "mfa-userid-override": null,
             "min-pw-change-time": 0,
             "multi-factor-authentication-required": false,
             "name": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
             "object-id": "91773b88-0c99-11eb-b4d3-00106f237ab1",
             "object-uri": "/api/users/91773b88-0c99-11eb-b4d3-00106f237ab1",
             "parent": "/api/console",
+            "parent-name": "HMC1",
             "password-expires": 87,
             "password-rule-name": "ZaaS",
             "password-rule-uri": "/api/console/password-rules/518ac1d8-bf98-11e9-b9dd-00106f237ab1",
+            "primary-mfa-server-definition-name": null,
+            "primary-mfa-server-definition-uri": null,
             "replication-overwrite-possible": true,
             "session-timeout": 0,
             "type": "standard",
@@ -282,14 +308,14 @@ user
     | **type**: raw
 
   user-role-names
-    Name of the user roles referenced by property :literal:`user-roles`.
+    Only present if :literal:`expand\_names=true`\ : Name of the user roles referenced by property :literal:`user-roles`.
 
     | **type**: str
 
   user-role-objects
     Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
-    Only if :literal:`expand=true`\ : User roles referenced by property :literal:`user-roles`.
+    Only present if :literal:`expand=true`\ : User roles referenced by property :literal:`user-roles`.
 
     | **type**: dict
 
@@ -300,14 +326,14 @@ user
 
 
   user-pattern-name
-    Only for users with :literal:`type=pattern`\ : Name of the user pattern referenced by property :literal:`user-pattern-uri`.
+    Only present for users with :literal:`type=pattern` and if :literal:`expand\_names=true`\ : Name of the user pattern referenced by property :literal:`user-pattern-uri`.
 
     | **type**: str
 
   user-pattern
     Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
-    Only for users with :literal:`type=pattern` and if :literal:`expand=true`\ : User pattern referenced by property :literal:`user-pattern-uri`.
+    Only present for users with :literal:`type=pattern` and if :literal:`expand=true`\ : User pattern referenced by property :literal:`user-pattern-uri`.
 
     | **type**: dict
 
@@ -317,15 +343,33 @@ user
       | **type**: raw
 
 
+  user-template-name
+    Only present for users with :literal:`type=pattern` and if :literal:`expand\_names=true`\ : Name of the template user referenced by property :literal:`user-template-uri`.
+
+    | **type**: str
+
+  user-template
+    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+
+    Only present for users with :literal:`type=pattern` and if :literal:`expand=true`\ : User template referenced by property :literal:`user-template-uri`.
+
+    | **type**: dict
+
+    {property}
+      Properties of the template user, as described in the data model of the 'User' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (-) as described in that book.
+
+      | **type**: raw
+
+
   password-rule-name
-    Only for users with :literal:`authentication-type=local`\ : Name of the password rule referenced by property :literal:`password-rule-uri`.
+    Only present if :literal:`expand\_names=true`\ : Name of the password rule referenced by property :literal:`password-rule-uri`.
 
     | **type**: str
 
   password-rule
     Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
-    Only for users with :literal:`authentication-type=local` and if :literal:`expand=true`\ : Password rule referenced by property :literal:`password-rule-uri`.
+    Only present if :literal:`expand=true`\ : Password rule referenced by property :literal:`password-rule-uri`.
 
     | **type**: dict
 
@@ -336,19 +380,73 @@ user
 
 
   ldap-server-definition-name
-    Only for users with :literal:`authentication-type=ldap`\ : Name of the LDAP server definition referenced by property :literal:`ldap-server-definition-uri`.
+    Only present if :literal:`expand\_names=true`\ : Name of the LDAP server definition referenced by property :literal:`ldap-server-definition-uri`.
 
     | **type**: str
 
   ldap-server-definition
     Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
-    Only for users with :literal:`authentication-type=ldap` and if :literal:`expand=true`\ : LDAP server definition referenced by property :literal:`ldap-server-definition-uri`.
+    Only present if :literal:`expand=true`\ : LDAP server definition referenced by property :literal:`ldap-server-definition-uri`.
 
     | **type**: dict
 
     {property}
       Properties of the LDAP server definition, as described in the data model of the 'LDAP Server Definition' object in the :ref:`HMC API <HMC API>` book. Write-only properties in the data model are not included. The property names have hyphens (-) as described in that book.
+
+      | **type**: raw
+
+
+  primary-mfa-server-definition-name
+    Only present if :literal:`expand\_names=true`\ : Name of the MFA server definition referenced by property :literal:`primary-mfa-server-definition-uri`.
+
+    | **type**: str
+
+  primary-mfa-server-definition
+    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+
+    Only present if :literal:`expand=true`\ : MFA server definition referenced by property :literal:`primary-mfa-server-definition-uri`.
+
+    | **type**: dict
+
+    {property}
+      Properties of the MFA server definition, as described in the data model of the 'MFA Server Definition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (-) as described in that book.
+
+      | **type**: raw
+
+
+  backup-mfa-server-definition-name
+    Only present if :literal:`expand\_names=true`\ : Name of the MFA server definition referenced by property :literal:`backup-mfa-server-definition-uri`.
+
+    | **type**: str
+
+  backup-mfa-server-definition
+    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+
+    Only present if :literal:`expand=true`\ : MFA server definition referenced by property :literal:`backup-mfa-server-definition-uri`.
+
+    | **type**: dict
+
+    {property}
+      Properties of the MFA server definition, as described in the data model of the 'MFA Server Definition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (-) as described in that book.
+
+      | **type**: raw
+
+
+  default-group-name
+    Only present if :literal:`expand\_names=true`\ : Name of the Group referenced by property :literal:`default-group-uri`.
+
+    | **type**: str
+
+  default-group
+    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+
+    Only present if :literal:`expand=true`\ : Group referenced by property :literal:`default-group-uri`.
+
+    | **type**: dict
+
+    {property}
+      Properties of the Group, as described in the data model of the 'Group' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (-) as described in that book.
 
       | **type**: raw
 

--- a/docs/source/modules/zhmc_user_list.rst
+++ b/docs/source/modules/zhmc_user_list.rst
@@ -93,6 +93,13 @@ full_properties
   | **type**: bool
 
 
+expand_names
+  If True and :literal:`full\_properties` is set, additional artificial properties will be returned for the names of referenced objects, such as user roles, password rule, etc. Default: False.
+
+  | **required**: False
+  | **type**: bool
+
+
 log_file
   File path of a log file to which the logic flow of this module as well as interactions with the HMC are logged. If null, logging will be propagated to the Python root logger.
 
@@ -177,5 +184,45 @@ users
     Additional properties requested via :literal:`full\_properties`. The property names will have underscores instead of hyphens.
 
     | **type**: raw
+
+  user_role_names
+    Only present if :literal:`expand\_names=true`\ : Name of the user roles referenced by property :literal:`user\_roles`.
+
+    | **type**: str
+
+  user_pattern_name
+    Only present for users with :literal:`type=pattern` and if :literal:`expand\_names=true`\ : Name of the user pattern referenced by property :literal:`user\_pattern\_uri`.
+
+    | **type**: str
+
+  user_template_name
+    Only present for users with :literal:`type=pattern` and if :literal:`expand\_names=true`\ : Name of the template user referenced by property :literal:`user\_template\_uri`.
+
+    | **type**: str
+
+  password_rule_name
+    Only present if :literal:`expand\_names=true`\ : Name of the password rule referenced by property :literal:`password\_rule\_uri`.
+
+    | **type**: str
+
+  ldap_server_definition_name
+    Only present if :literal:`expand\_names=true`\ : Name of the LDAP server definition referenced by property :literal:`ldap\_server\_definition\_uri`.
+
+    | **type**: str
+
+  primary_mfa_server_definition_name
+    Only present if :literal:`expand\_names=true`\ : Name of the MFA server definition referenced by property :literal:`primary\_mfa\_server\_definition\_uri`.
+
+    | **type**: str
+
+  backup_mfa_server_definition_name
+    Only present if :literal:`expand\_names=true`\ : Name of the MFA server definition referenced by property :literal:`backup\_mfa\_server\_definition\_uri`.
+
+    | **type**: str
+
+  default_group_name
+    Only present if :literal:`expand\_names=true`\ : Name of the Group referenced by property :literal:`default\_group\_uri`.
+
+    | **type**: str
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -77,6 +77,18 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Test: Fixed duplicate 'description' properties in test YAML files.
   (issue #1097)
 
+* Test: For the password-rule related properties of the 'zhmc_user' and
+  'zhmc_user_list' modules, fixed that they are always present, and not
+  dependent on auth-type=local.
+
+* Test: For the ldap-server-definition related properties of the 'zhmc_user' and
+  'zhmc_user_list' modules, fixed that they are always present, and not
+  dependent on auth-type=local.
+
+* Test: For the MFA related properties of the 'zhmc_user' and
+  'zhmc_user_list' modules, fixed that they are always present, and not
+  dependent on mfa-types or other MFA related properties.
+
 **Enhancements:**
 
 * Support for ansible-core 2.18, by adding an ignore file for the sanity tests.
@@ -87,6 +99,27 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Dev: Added display of environment variables and platform details in test
   workflow.
+
+* Added a boolean 'expand_names' parameter to the 'zhmc_user' module. This
+  allows disabling the addition of names for referenced objects. For
+  backwards compatibility, this parameter is True by default.
+
+* Added a boolean 'expand_names' parameter to the 'zhmc_user_list' module. This
+  allows enabling the addition of names for referenced objects, which improves
+  the performance compared to a loop of calls to the 'zhmc_user' module
+  with 'expand_names', because the data needed for translating the URIs to names
+  is retrieved only once. To save these extra retrieval operations by default,
+  this parameter is False by default.
+
+* Added support for the following properties and input parameters in the
+  'zhmc_user' and 'zhmc_user_list' modules:
+  - user-template related
+  - primary-mfa-server-definition related
+  - backup-mfa-server-definition related
+  - default-group related
+
+* Added a logged warning if the deprecated parameter 'expand' is used for
+  the 'zhmc_user' module.
 
 **Cleanup:**
 
@@ -119,6 +152,13 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Test: Accommodated rollout of Ubuntu 24.04 on GitHub Actions by using
   ubuntu-22.04 as the OS image for Python 3.8 based test runs.
+
+* Docs: In the parameter documentation for the 'zhmc_user' and 'zhmc_user_list'
+  modules, made the language more explicit that states under which conditions
+  each parameter is present.
+
+* Test: Removed the invalid combinations of type and auth-type from the end2end
+  test 'test_zhmc_user_facts()'.
 
 **Known issues:**
 

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -42,6 +42,9 @@ except ImportError:
 
 BLANKED_OUT = '********'  # Replacement for blanked out sensitive values
 
+# Default for get() indicating a property is not present
+NOT_PRESENT = "@@not-present@@"
+
 
 class Error(Exception):
     """

--- a/plugins/modules/zhmc_user.py
+++ b/plugins/modules/zhmc_user.py
@@ -141,11 +141,19 @@ options:
          current user roles, if specified."
       - "* C(user_pattern_uri): Cannot be set directly, but indirectly via
          the artificial property C(user_pattern_name)."
+      - "* C(user_template_uri): Cannot be set directly, but indirectly via
+         the artificial property C(user_template_name)."
       - "* C(password_rule_uri): Cannot be set directly, but indirectly via
          the artificial property C(password_rule_name)."
       - "* C(ldap_server_definition_uri): Cannot be set directly, but
          indirectly via the artificial property
          C(ldap_server_definition_name)."
+      - "* C(primary_mfa_server_definition_uri): Cannot be set directly, but
+         indirectly via the artificial property
+         C(primary_mfa_server_definition_name)."
+      - "* C(backup_mfa_server_definition_uri): Cannot be set directly, but
+         indirectly via the artificial property
+         C(backup_mfa_server_definition_name)."
       - "* C(default_group_uri): Cannot be set directly, but indirectly via
          the artificial property C(default_group_name)."
       - "Properties omitted in this dictionary will remain unchanged when the
@@ -170,6 +178,15 @@ options:
     type: bool
     required: false
     default: false
+  expand_names:
+    description:
+      - "Boolean that controls whether the returned user contains additional
+         artificial properties for the names of referenced objects, such as
+         user roles, password rule, etc."
+      - "For backwards compatibility, this parameter defaults to True."
+    type: bool
+    required: false
+    default: true
   log_file:
     description:
       - "File path of a log file to which the logic flow of this module as well
@@ -253,14 +270,14 @@ user:
         The property names have hyphens (-) as described in that book."
       type: raw
     user-role-names:
-      description: "Name of the user roles referenced by property
-        C(user-roles)."
+      description: "Only present if O(expand_names=true): Name of the user
+        roles referenced by property C(user-roles)."
       type: str
     user-role-objects:
       description:
         - "Deprecated: This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only if O(expand=true): User roles referenced by property
+        - "Only present if O(expand=true): User roles referenced by property
            C(user-roles)."
       type: dict
       contains:
@@ -271,14 +288,15 @@ user:
             The property names have hyphens (-) as described in that book."
           type: raw
     user-pattern-name:
-      description: "Only for users with C(type=pattern): Name of the user
-        pattern referenced by property C(user-pattern-uri)."
+      description: "Only present for users with C(type=pattern) and if
+        O(expand_names=true): Name of the user pattern referenced by property
+        C(user-pattern-uri)."
       type: str
     user-pattern:
       description:
         - "Deprecated: This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only for users with C(type=pattern) and if O(expand=true):
+        - "Only present for users with C(type=pattern) and if O(expand=true):
            User pattern referenced by property C(user-pattern-uri)."
       type: dict
       contains:
@@ -288,16 +306,33 @@ user:
             book.
             The property names have hyphens (-) as described in that book."
           type: raw
+    user-template-name:
+      description: "Only present for users with C(type=pattern) and if
+        O(expand_names=true): Name of the template user referenced by property
+        C(user-template-uri)."
+      type: str
+    user-template:
+      description:
+        - "Deprecated: This result property is deprecated because the
+           O(expand) parameter is deprecated."
+        - "Only present for users with C(type=pattern) and if O(expand=true):
+           User template referenced by property C(user-template-uri)."
+      type: dict
+      contains:
+        "{property}":
+          description: "Properties of the template user, as described in the
+            data model of the 'User' object in the R(HMC API,HMC API) book.
+            The property names have hyphens (-) as described in that book."
+          type: raw
     password-rule-name:
-      description: "Only for users with C(authentication-type=local): Name of
-        the password rule referenced by property C(password-rule-uri)."
+      description: "Only present if O(expand_names=true): Name of the password
+        rule referenced by property C(password-rule-uri)."
       type: str
     password-rule:
       description:
         - "Deprecated: This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only for users with C(authentication-type=local) and if
-           O(expand=true): Password rule referenced by property
+        - "Only present if O(expand=true): Password rule referenced by property
            C(password-rule-uri)."
       type: dict
       contains:
@@ -308,17 +343,16 @@ user:
             The property names have hyphens (-) as described in that book."
           type: raw
     ldap-server-definition-name:
-      description: "Only for users with C(authentication-type=ldap): Name of
-        the LDAP server definition referenced by property
+      description: "Only present if O(expand_names=true): Name of the LDAP
+        server definition referenced by property
         C(ldap-server-definition-uri)."
       type: str
     ldap-server-definition:
       description:
         - "Deprecated: This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only for users with C(authentication-type=ldap) and if
-           O(expand=true): LDAP server definition referenced by property
-           C(ldap-server-definition-uri)."
+        - "Only present if O(expand=true): LDAP server definition referenced by
+           property C(ldap-server-definition-uri)."
       type: dict
       contains:
         "{property}":
@@ -328,12 +362,70 @@ user:
             Write-only properties in the data model are not included.
             The property names have hyphens (-) as described in that book."
           type: raw
+    primary-mfa-server-definition-name:
+      description: "Only present if O(expand_names=true): Name of the MFA
+        server definition referenced by property
+        C(primary-mfa-server-definition-uri)."
+      type: str
+    primary-mfa-server-definition:
+      description:
+        - "Deprecated: This result property is deprecated because the
+           O(expand) parameter is deprecated."
+        - "Only present if O(expand=true): MFA server definition referenced by
+           property C(primary-mfa-server-definition-uri)."
+      type: dict
+      contains:
+        "{property}":
+          description: "Properties of the MFA server definition, as described
+            in the data model of the 'MFA Server Definition' object in the
+            R(HMC API,HMC API) book.
+            The property names have hyphens (-) as described in that book."
+          type: raw
+    backup-mfa-server-definition-name:
+      description: "Only present if O(expand_names=true): Name of the MFA
+        server definition referenced by property
+        C(backup-mfa-server-definition-uri)."
+      type: str
+    backup-mfa-server-definition:
+      description:
+        - "Deprecated: This result property is deprecated because the
+           O(expand) parameter is deprecated."
+        - "Only present if O(expand=true): MFA server definition referenced by
+           property C(backup-mfa-server-definition-uri)."
+      type: dict
+      contains:
+        "{property}":
+          description: "Properties of the MFA server definition, as described
+            in the data model of the 'MFA Server Definition' object in the
+            R(HMC API,HMC API) book.
+            The property names have hyphens (-) as described in that book."
+          type: raw
+    default-group-name:
+      description: "Only present if O(expand_names=true): Name of the Group
+        referenced by property C(default-group-uri)."
+      type: str
+    default-group:
+      description:
+        - "Deprecated: This result property is deprecated because the
+           O(expand) parameter is deprecated."
+        - "Only present if O(expand=true): Group referenced by property
+           C(default-group-uri)."
+      type: dict
+      contains:
+        "{property}":
+          description: "Properties of the Group, as described in the data model
+            of the 'Group' object in the R(HMC API,HMC API) book.
+            The property names have hyphens (-) as described in that book."
+          type: raw
   sample:
     {
         "allow-management-interfaces": true,
         "allow-remote-access": true,
         "authentication-type": "local",
+        "backup-mfa-server-definition-name": null,
+        "backup-mfa-server-definition-uri": null,
         "class": "user",
+        "default-group-name": null,
         "default-group-uri": null,
         "description": "",
         "disable-delay": 1,
@@ -350,15 +442,22 @@ user:
         "ldap-server-definition-uri": null,
         "max-failed-logins": 3,
         "max-web-services-api-sessions": 1000,
+        "mfa-policy": null,
+        "mfa-types": null,
+        "mfa-userid": null,
+        "mfa-userid-override": null,
         "min-pw-change-time": 0,
         "multi-factor-authentication-required": false,
         "name": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
         "object-id": "91773b88-0c99-11eb-b4d3-00106f237ab1",
         "object-uri": "/api/users/91773b88-0c99-11eb-b4d3-00106f237ab1",
         "parent": "/api/console",
+        "parent-name": "HMC1",
         "password-expires": 87,
         "password-rule-name": "ZaaS",
         "password-rule-uri": "/api/console/password-rules/518ac1d8-bf98-11e9-b9dd-00106f237ab1",
+        "primary-mfa-server-definition-name": null,
+        "primary-mfa-server-definition-uri": null,
         "replication-overwrite-possible": true,
         "session-timeout": 0,
         "type": "standard",
@@ -383,7 +482,7 @@ from ..module_utils.common import log_init, open_session, close_session, \
     hmc_auth_parameter, Error, ParameterError, to_unicode, \
     process_normal_property, missing_required_lib, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params, \
-    blanked_dict, removed_dict  # noqa: E402
+    blanked_dict, removed_dict, NOT_PRESENT  # noqa: E402
 
 try:
     import urllib3
@@ -431,8 +530,6 @@ ZHMC_USER_PROPERTIES = {
     # update-only properties:
     'default_group_uri': (False, False, True, None, None, None),
     # default_group_uri: Modified via default_group_name.
-    'default_group_name': (True, True, True, True, None, None),
-    # default_group_name: Artificial property, based on default_group_uri
 
     # create+update properties:
     'name': (False, True, True, True, None, None),
@@ -442,20 +539,13 @@ ZHMC_USER_PROPERTIES = {
     'authentication_type': (True, True, True, True, None, None),
     'user_roles': (False, False, False, None, None, None),
     # user_roles: Modified via user_role_names.
-    'user_role_names': (True, True, True, True, None, None),
-    # user_role_names: Artificial property, based on user_roles
     'password_rule_uri': (False, True, True, None, None, None),
     # password_rule_uri: Modified via password_rule_name.
-    'password_rule_name': (True, True, True, True, None, None),
-    # password_rule_name: Artificial property, based on password_rule_uri
     'password': (True, True, True, True, None, None),
     # password: Write-only
     'force_password_change': (True, True, True, True, None, bool),
     'ldap_server_definition_uri': (False, True, True, None, None, None),
     # ldap_server_definition_uri: Modified via ldap_server_definition_name.
-    'ldap_server_definition_name': (True, True, True, True, None, None),
-    # ldap_server_definition_name: Artificial property, based on
-    # ldap_server_definition_uri
     'userid_on_ldap_server': (True, True, True, True, None, None),
     'session_timeout': (True, True, True, True, None, int),
     'verify_timeout': (True, True, True, True, None, int),
@@ -484,15 +574,30 @@ ZHMC_USER_PROPERTIES = {
     'parent': (False, False, False, None, None, None),
     'class': (False, False, False, None, None, None),
     'user_pattern_uri': (False, False, False, None, None, None),
+    'user_template_uri': (False, False, False, None, None, None),
     'password_expires': (False, False, False, None, None, None),
     'replication_overwrite_possible': (False, False, False, None, None, None),
 
     # read-only artificial if-expand properties:
+    'user_role_objects': (False, False, False, None, None, None),
     'user_pattern': (False, False, False, None, None, None),
-    'default_group': (False, False, False, None, None, None),
+    'user_template': (False, False, False, None, None, None),
     'password_rule': (False, False, False, None, None, None),
     'ldap_server_definition': (False, False, False, None, None, None),
-    'user_role_objects': (False, False, False, None, None, None),
+    'primary_mfa_server_definition': (False, False, False, None, None, None),
+    'backup_mfa_server_definition': (False, False, False, None, None, None),
+    'default_group': (False, False, False, None, None, None),
+
+    # artificial if-expand-names properties:
+    # Can be specxified as input, but are in output only if expand_names.
+    'user_role_names': (True, True, True, True, None, None),
+    'user_pattern_name': (True, True, True, True, None, None),
+    'user_template_name': (True, True, True, True, None, None),
+    'password_rule_name': (True, True, True, True, None, None),
+    'ldap_server_definition_name': (True, True, True, True, None, None),
+    'primary_mfa_server_definition_name': (True, True, True, True, None, None),
+    'backup_mfa_server_definition_name': (True, True, True, True, None, None),
+    'default_group_name': (True, True, True, True, None, None),
 }
 
 # Write-only properties (blanked out in logs and removed in output)
@@ -625,6 +730,25 @@ def process_properties(console, user, params):
                 update_props['user-pattern-uri'] = user_pattern_uri
             continue
 
+        if prop_name == 'user_template_name':
+            user_template_name = input_props[prop_name]
+            if user_template_name:
+                try:
+                    user_template = console.users.find_by_name(
+                        user_template_name)
+                except zhmcclient.NotFound:
+                    raise ParameterError(
+                        f"Template user {user_template_name!r} specified in "
+                        f"parameter {prop_name!r} does not exist.")
+                user_template_uri = user_template.uri
+            else:
+                user_template_uri = None
+            if user is None:
+                create_props['user-template-uri'] = user_template_uri
+            elif user.prop('user-template-uri') != user_template_uri:
+                update_props['user-template-uri'] = user_template_uri
+            continue
+
         if prop_name == 'password_rule_name':
             password_rule_name = input_props[prop_name]
             if password_rule_name:
@@ -663,11 +787,65 @@ def process_properties(console, user, params):
                 update_props['ldap-server-definition-uri'] = ldap_srv_def_uri
             continue
 
+        if prop_name == 'primary_mfa_server_definition_name':
+            pri_mfa_srv_def_name = input_props[prop_name]
+            if pri_mfa_srv_def_name:
+                try:
+                    pri_mfa_srv_def = \
+                        console.mfa_server_definitions.find_by_name(
+                            pri_mfa_srv_def_name)
+                except zhmcclient.NotFound:
+                    raise ParameterError(
+                        f"MFA server definition {pri_mfa_srv_def_name!r} "
+                        f"specified in parameter {prop_name!r} does not exist.")
+                pri_mfa_srv_def_uri = pri_mfa_srv_def.uri
+            else:
+                pri_mfa_srv_def_uri = None
+            if user is None:
+                create_props['primary-mfa-server-definition-uri'] = \
+                    pri_mfa_srv_def_uri
+            elif user.prop('primary-mfa-server-definition-uri') != \
+                    pri_mfa_srv_def_uri:
+                update_props['primary-mfa-server-definition-uri'] = \
+                    pri_mfa_srv_def_uri
+            continue
+
+        if prop_name == 'backup_mfa_server_definition_name':
+            bac_mfa_srv_def_name = input_props[prop_name]
+            if bac_mfa_srv_def_name:
+                try:
+                    bac_mfa_srv_def = \
+                        console.mfa_server_definitions.find_by_name(
+                            bac_mfa_srv_def_name)
+                except zhmcclient.NotFound:
+                    raise ParameterError(
+                        f"MFA server definition {bac_mfa_srv_def_name!r} "
+                        f"specified in parameter {prop_name!r} does not exist.")
+                bac_mfa_srv_def_uri = bac_mfa_srv_def.uri
+            else:
+                bac_mfa_srv_def_uri = None
+            if user is None:
+                create_props['backup-mfa-server-definition-uri'] = \
+                    bac_mfa_srv_def_uri
+            elif user.prop('backup-mfa-server-definition-uri') != \
+                    bac_mfa_srv_def_uri:
+                update_props['backup-mfa-server-definition-uri'] = \
+                    bac_mfa_srv_def_uri
+            continue
+
         if prop_name == 'default_group_name':
             default_group_name = input_props[prop_name]
-            # TODO: Add support for Group objects to zhmcclient
-            # default_group = console.groups.find_by_name(default_group_name)
-            default_group_uri = f'fake-uri-{default_group_name}'
+            if default_group_name:
+                try:
+                    default_group = console.groups.find_by_name(
+                        default_group_name)
+                except zhmcclient.NotFound:
+                    raise ParameterError(
+                        f"Group {default_group_name!r} "
+                        f"specified in parameter {prop_name!r} does not exist.")
+                default_group_uri = default_group.uri
+            else:
+                default_group_uri = None
             if user is None:
                 create_props['default-group-uri'] = default_group_uri
             elif user.prop('default-group-uri') != default_group_uri:
@@ -684,18 +862,23 @@ def process_properties(console, user, params):
     return create_props, update_props, add_roles, rem_roles
 
 
-def add_artificial_properties(user_properties, console, user, expand):
+def add_artificial_properties(
+        user_properties, console, user, expand, expand_names):
     """
     Add artificial properties to the user_properties dict.
 
     Upon return, the user_properties dict has been extended by these properties:
 
+    If O(expand_names) is True:
+
     * 'user-role-names': Names of UserRole objects corresponding to the URIs
       in the 'user-roles' property.
 
     * 'user-pattern-name': Name of UserPattern object corresponding to the URI
-      in the 'user-pattern-uri' property. That property only exists for
-      type='pattern-based'.
+      in the 'user-pattern-uri' property, if type='pattern-based'.
+
+    * 'user-template-name': Name of UserTemplate object corresponding to the
+      URI in the 'user-template-uri' property, if type='pattern-based'.
 
     * 'password-rule-name': Name of PasswordRule object corresponding to the
       URI in the 'password-rule-uri' property.
@@ -703,11 +886,16 @@ def add_artificial_properties(user_properties, console, user, expand):
     * 'ldap-server-definition-name': Name of LdapServerDefinition object
       corresponding to the URI in the 'ldap-server-definition-uri' property.
 
-    * 'default-group-name': Name of Group object corresponding to the URI in
-      the 'default-group-uri' property.
+    * 'primary-mfa-server-definition-name': Name of MfaServerDefinition object
+      corresponding to the URI in the 'primary-mfa-server-definition-uri'
+      property.
 
-      TODO: Implement default-group-name; requires support for Group objects in
-      zhmcclient
+    * 'backup-mfa-server-definition-name': Name of MfaServerDefinition object
+      corresponding to the URI in the 'backup-mfa-server-definition-uri'
+      property.
+
+    * 'default-group-name': Name of the Group object corresponding to the URI
+      in the 'default-group-uri' property.
 
     If O(expand) (deprecated) is True, in addition:
 
@@ -715,8 +903,10 @@ def add_artificial_properties(user_properties, console, user, expand):
       URIs in the 'user-roles' property.
 
     * 'user-pattern': UserPattern object corresponding to the URI in the
-      'user-pattern-uri' property. That property only exists for
-      type='pattern-based'.
+      'user-pattern-uri' property, if type='pattern-based'.
+
+    * 'user-template': UserTemplate object corresponding to the URI in the
+      'user-template-uri' property, if type='pattern-based'.
 
     * 'password-rule': PasswordRule object corresponding to the URI in the
       'password-rule-uri' property.
@@ -724,97 +914,183 @@ def add_artificial_properties(user_properties, console, user, expand):
     * 'ldap-server-definition': LdapServerDefinition object corresponding to
       the URI in the 'ldap-server-definition-uri' property.
 
+    * 'primary-mfa-server-definition': MfaServerDefinition object corresponding
+      to the URI in the 'primary-mfa-server-definition-uri' property.
+
+    * 'backup-mfa-server-definition': MfaServerDefinition object corresponding
+      to the URI in the 'backup-mfa-server-definition-uri' property.
+
     * 'default-group': Group object corresponding to the URI in the
       'default-group-uri' property.
-
-      TODO: Implement default-group; requires support for Group objects in
-      zhmcclient
     """
 
-    # The User object either exists on the HMC, or in case of creating a user
-    # in check mode it is a local User object that does not exist on the HMC.
-    # In that case, we cannot retrieve properties from the HMC, so we take them
-    # from the user object directly.
-    type_ = user.properties['type']
-    auth_type = user.properties['authentication-type']
+    if expand or expand_names:
 
-    if type_ == 'pattern-based':
-        # For that type, the property exists, but may be null.
-        # Note: For other types, the property does not exist.
-        user_pattern_uri = user.properties['user-pattern-uri']
-        if user_pattern_uri is not None:
-            user_pattern = \
-                console.user_patterns.resource_object(user_pattern_uri)
-            # We pull the properties, since that is done anyway in .name,
-            # so that in case of expand it is not done twice.
-            user_pattern.pull_full_properties()
-            user_properties['user-pattern-name'] = user_pattern.name
-            if expand:
-                user_properties['user-pattern'] = dict(user_pattern.properties)
-    # Make sure that the artificial properties exist exactly when the uri
-    # property does
-    if 'user-pattern-uri' in user.properties and \
-            'user-pattern-name' not in user_properties:
-        user_properties['user-pattern-name'] = None
+        # Handle User Role references
+        user_role_uris = user.properties['user-roles']
+        # This property always exists
+        all_uroles_by_uri = {ur.uri: ur for ur in console.user_roles.list()}
+        uroles = [all_uroles_by_uri[uri] for uri in user_role_uris]
+        if expand_names:
+            user_properties['user-role-names'] = [ur.name for ur in uroles]
         if expand:
-            user_properties['user-pattern'] = None
+            user_role_objects = []
+            for urole in uroles:
+                urole.pull_full_properties()
+                user_role_objects.append(dict(urole.properties))
+            user_properties['user-role-objects'] = user_role_objects
 
-    if auth_type == 'local':
-        # For that auth type, the property exists and is non-null.
-        # Note: For other auth types, the property does not exist.
+        # Handle User Pattern reference
+        if user.properties['type'] == 'pattern-based':
+
+            # The 'user-pattern-uri' property exists only for
+            # type='pattern-based', and will not be None.
+            user_pattern_uri = user.properties['user-pattern-uri']
+            if user_pattern_uri is None:  # Defensive programming
+                if expand_names:
+                    user_properties['user-pattern-name'] = None
+                if expand:
+                    user_properties['user-pattern'] = None
+            else:
+                user_pattern = \
+                    console.user_patterns.resource_object(user_pattern_uri)
+                # Note: Accessing 'name' triggers a full pull, and the
+                # User Pattern object does not support selective get.
+                user_pattern.pull_full_properties()
+                if expand_names:
+                    user_properties['user-pattern-name'] = user_pattern.name
+                if expand:
+                    user_properties['user-pattern'] = \
+                        dict(user_pattern.properties)
+
+            # The 'user-template-uri' property exists only for
+            # type='pattern-based' and if the user is template-based, and may
+            # be None.
+            user_template_uri = user.properties.get(
+                'user-template-uri', NOT_PRESENT)
+            if user_template_uri == NOT_PRESENT:
+                pass
+            elif user_template_uri is None:
+                if expand_names:
+                    user_properties['user-template-name'] = None
+                if expand:
+                    user_properties['user-template'] = None
+            else:
+                user_template = console.users.resource_object(user_template_uri)
+                # Note: Accessing 'name' triggers a full pull, and the
+                # User object does not support selective get.
+                user_template.pull_full_properties()
+                if expand_names:
+                    user_properties['user-template-name'] = user_template.name
+                if expand:
+                    user_properties['user-template'] = \
+                        dict(user_template.properties)
+
+        # Handle Password Rule reference
         password_rule_uri = user.properties['password-rule-uri']
-        if password_rule_uri is not None:
+        # This property always exists. It will be non-Null for
+        # auth-type='local'.
+        if password_rule_uri is None:
+            if expand_names:
+                user_properties['password-rule-name'] = None
+            if expand:
+                user_properties['password-rule'] = None
+        else:
             password_rule = console.password_rules.resource_object(
                 password_rule_uri)
-            # We pull the properties, since that is done anyway in .name,
-            # so that in case of expand it is not done twice.
+            # Note: Accessing 'name' triggers a full pull, and the
+            # Password Rule object does not support selective get.
             password_rule.pull_full_properties()
-            user_properties['password-rule-name'] = password_rule.name
+            if expand_names:
+                user_properties['password-rule-name'] = password_rule.name
             if expand:
                 user_properties['password-rule'] = \
                     dict(password_rule.properties)
-    # Make sure that the artificial properties exist exactly when the uri
-    # property does
-    if 'password-rule-uri' in user.properties and \
-            'password-rule-name' not in user_properties:
-        user_properties['password-rule-name'] = None
-        if expand:
-            user_properties['password-rule'] = None
 
-    if auth_type == 'ldap':
-        # For that auth type, the property exists and is non-null.
-        # Note: For other auth types, the property exists and is null.
+        # Handle LDAP Server Definition reference
         ldap_srv_def_uri = user.properties['ldap-server-definition-uri']
-        if ldap_srv_def_uri is not None:
+        # This property always exists and is non-Null for auth.-type='ldap'.
+        if ldap_srv_def_uri is None:
+            if expand_names:
+                user_properties['ldap-server-definition-name'] = None
+            if expand:
+                user_properties['ldap-server-definition'] = None
+        else:
             ldap_srv_def = console.ldap_server_definitions.resource_object(
                 ldap_srv_def_uri)
-            # We pull the properties, since that is done anyway in .name,
-            # so that in case of expand it is not done twice.
+            # Note: Accessing 'name' triggers a full pull, and the
+            # LDAP Server Definition object does not support selective get.
             ldap_srv_def.pull_full_properties()
-            user_properties['ldap-server-definition-name'] = ldap_srv_def.name
+            if expand_names:
+                user_properties['ldap-server-definition-name'] = \
+                    ldap_srv_def.name
             if expand:
                 user_properties['ldap-server-definition'] = \
                     dict(ldap_srv_def.properties)
-    # Make sure that the artificial properties exist exactly when the uri
-    # property does
-    if 'ldap-server-definition-uri' in user.properties and \
-            'ldap-server-definition-name' not in user_properties:
-        user_properties['ldap-server-definition-name'] = None
-        if expand:
-            user_properties['ldap-server-definition'] = None
 
-    all_uroles = console.user_roles.list()
-    all_uroles_by_uri = {}
-    for urole in all_uroles:
-        all_uroles_by_uri[urole.uri] = urole
-    uroles = [all_uroles_by_uri[uri] for uri in user.properties['user-roles']]
-    user_properties['user-role-names'] = [ur.name for ur in uroles]
-    if expand:
-        user_role_objects = []
-        for urole in uroles:
-            urole.pull_full_properties()
-            user_role_objects.append(dict(urole.properties))
-        user_properties['user-role-objects'] = user_role_objects
+        # Handle primary MFA Server Definition reference
+        pri_mfa_srv_def_uri = \
+            user.properties['primary-mfa-server-definition-uri']
+        # This property always exists and may be None
+        if pri_mfa_srv_def_uri is None:
+            if expand_names:
+                user_properties['primary-mfa-server-definition-name'] = None
+            if expand:
+                user_properties['primary-mfa-server-definition'] = None
+        else:
+            pri_mfa_srv_def = console.mfa_server_definitions.resource_object(
+                pri_mfa_srv_def_uri)
+            # Note: Accessing 'name' triggers a full pull, and the
+            # MFA Server Definition object does not support selective get.
+            pri_mfa_srv_def.pull_full_properties()
+            if expand_names:
+                user_properties['primary-mfa-server-definition-name'] = \
+                    pri_mfa_srv_def.name
+            if expand:
+                user_properties['primary-mfa-server-definition'] = \
+                    dict(pri_mfa_srv_def.properties)
+
+        # Handle backu0p MFA Server Definition reference
+        bac_mfa_srv_def_uri = \
+            user.properties['backup-mfa-server-definition-uri']
+        # This property always exists and may be None
+        if bac_mfa_srv_def_uri is None:
+            if expand_names:
+                user_properties['backup-mfa-server-definition-name'] = None
+            if expand:
+                user_properties['backup-mfa-server-definition'] = None
+        else:
+            bac_mfa_srv_def = console.mfa_server_definitions.resource_object(
+                bac_mfa_srv_def_uri)
+            # Note: Accessing 'name' triggers a full pull, and the
+            # MFA Server Definition object does not support selective get.
+            bac_mfa_srv_def.pull_full_properties()
+            if expand_names:
+                user_properties['backup-mfa-server-definition-name'] = \
+                    bac_mfa_srv_def.name
+            if expand:
+                user_properties['backup-mfa-server-definition'] = \
+                    dict(bac_mfa_srv_def.properties)
+
+        # Handle default Group reference
+        default_group_uri = user.properties['default-group-uri']
+        # This property always exists, and may be None
+        if default_group_uri is None:
+            if expand_names:
+                user_properties['default-group-name'] = None
+            if expand:
+                user_properties['default-group'] = None
+        else:
+            default_group = console.groups.resource_object(
+                default_group_uri)
+            # Note: Accessing 'name' triggers a full pull, and the
+            # Password Rule object does not support selective get.
+            default_group.pull_full_properties()
+            if expand_names:
+                user_properties['default-group-name'] = default_group.name
+            if expand:
+                user_properties['default-group'] = \
+                    dict(default_group.properties)
 
 
 def create_check_mode_user(console, create_props, update_props):
@@ -882,37 +1158,36 @@ def create_check_mode_user(console, create_props, update_props):
         'multi-factor-authentication-required': False,
         'email-address': None,
         'mfa-types': None,
+        'password-rule-uri': None,
+        'force-password-change': True,
+        'min-pw-change-time': 0,
+        'ldap-server-definition-uri': None,
+        'primary-mfa-server-definition-uri': None,
+        'backup-mfa-server-definition-uri': None,
+        'mfa-policy': None,
+        'mfa-userid-override': None,
     }
 
     # Defaults for optional properties that depend on the case
     if user_type == 'pattern-based':
         props['user-pattern-uri'] = None
-    if user_type == 'template':
         props['user-template-uri'] = None
     if user_type != 'template':
         props['disabled'] = False
-    if auth_type == 'local':
-        props['password-rule-uri'] = None
-        props['password'] = None
         props['password-expires'] = None
-        props['force-password-change'] = True
-        props['min-pw-change-time'] = 0
-    if auth_type == 'ldap':
-        props['ldap-server-definition-uri'] = None
-        if user_type != 'template':
-            props['userid-on-ldap-server'] = ''
+        props['userid-on-ldap-server'] = ''
+    if auth_type == 'local':
+        props['password'] = None
     mfa_required = input_props.get(
         'multi-factor-authentication-required', False)
     if mfa_required:
         props['force-shared-secret-key-change'] = False
-    if 'mfa-server' in mfa_types:
-        props['primary-mfa-server-definition-uri'] = None
-        props['backup-mfa-server-definition-uri'] = None
-        props['mfa-policy'] = None
-        if user_type != 'template':
-            props['mfa-userid'] = name
-        if user_type == 'template':
-            props['mfa-userid-override'] = None
+    else:
+        props['force-shared-secret-key-change'] = None
+    if 'mfa-server' in mfa_types and user_type != 'template':
+        props['mfa-userid'] = name
+    else:
+        props['mfa-userid'] = None
 
     # Apply specified input properties on top of the defaults
     props.update(input_props)
@@ -934,6 +1209,7 @@ def ensure_present(params, check_mode):
 
     user_name = params['name']
     expand = params['expand']
+    expand_names = params['expand_names']
 
     changed = False
     result = {}
@@ -1032,7 +1308,8 @@ def ensure_present(params, check_mode):
         if not user:
             raise AssertionError()
 
-        add_artificial_properties(result, console, user, expand)
+        add_artificial_properties(
+            result, console, user, expand, expand_names)
 
         result = removed_dict(result, WRITEONLY_PROPERTIES_HYPHEN)
 
@@ -1089,6 +1366,7 @@ def facts(params, check_mode):
 
     user_name = params['name']
     expand = params['expand']
+    expand_names = params['expand_names']
 
     changed = False
     result = {}
@@ -1103,7 +1381,8 @@ def facts(params, check_mode):
         user.pull_full_properties()
 
         result = dict(user.properties)
-        add_artificial_properties(result, console, user, expand)
+        add_artificial_properties(
+            result, console, user, expand, expand_names)
 
         return changed, result
 
@@ -1144,6 +1423,7 @@ def main():
                    choices=['absent', 'present', 'facts']),
         properties=dict(required=False, type='dict', default=None),
         expand=dict(required=False, type='bool', default=False),
+        expand_names=dict(required=False, type='bool', default=True),
         log_file=dict(required=False, type='str', default=None),
         _faked_session=dict(required=False, type='raw'),
     )
@@ -1172,6 +1452,10 @@ def main():
     if LOGGER.isEnabledFor(logging.DEBUG):
         LOGGER.debug("Module entry: params: %r",
                      blanked_params(module.params, WRITEONLY_PROPERTIES_USCORE))
+
+    if module.params['expand']:
+        LOGGER.warning(
+            "Deprecated parameter 'expand' is used for zhmc_user module")
 
     try:
 

--- a/tests/end2end/test_zhmc_user.py
+++ b/tests/end2end/test_zhmc_user.py
@@ -48,32 +48,27 @@ LOG_FILE = 'zhmc_user.log' if DEBUG else None
 # comments state the condition under which the property is present.
 USER_CONDITIONAL_PROPS = (
     'user-pattern-uri',  # type == 'pattern-based'
-    'user-pattern-name',  # artificial: type == 'pattern-based'
-    'user-pattern',  # artificial: type == 'pattern-based' and expand
-    'user-template-uri',  # type == 'template'
-    'user-template-name',  # artificial: type == 'template'
-    'disabled',  # type != 'template'
-    'password-rule-uri',  # auth-type == 'local'
-    'password-rule-name',  # artificial: auth-type == 'local'
-    'password-rule',  # artificial: auth-type == 'local' and expand
-    'password-expires',  # artificial: auth-type == 'local', but this is not
-    # stated in HMC WS-API book
-    'password',  # never present
-    'force-password-change',  # auth-type == 'local'
-    'ldap-server-definition-uri',  # auth-type == 'ldap'
-    'ldap-server-definition-name',  # artificial: auth-type == 'ldap'
-    'ldap-server-definition',  # artificial: auth-type == 'ldap' and expand
-    'userid-on-ldap-server',  # auth-type == 'ldap' and type != 'template'
-    'min-pw-change-time',  # auth-type == 'local'
+    'user-pattern-name',  # artificial: see URI and expand_names
+    'user-pattern',  # artificial: see URI and expand
+    'user-template-uri',  # type == 'pattern-based' and user is template-based
+    'user-template-name',  # artificial: see URI and expand_names
+    'user-template',  # artificial: see URI and expand
+    'password-rule-name',  # artificial: expand_names
+    'password-rule',  # artificial: expand
+    'ldap-server-definition-name',  # artificial: expand_names
+    'ldap-server-definition',  # artificial: expand
+    'primary-mfa-server-definition-name',  # artificial: expand_names
+    'primary-mfa-server-definition',  # artificial: expand
+    'backup-mfa-server-definition-name',  # artificial: expand_names
+    'backup-mfa-server-definition',  # artificial: expand
+    'user-role-names',  # artificial: expand_names
     'user-role-objects',  # artificial: expand
+    'default-group-name',  # artificial: expand_names
     'default-group',  # artificial: expand
-    'default-group-name',  # artificial, not yet implemented (TODO: Implement)
-    'force-shared-secret-key-change',  # multi-factor-auth-required == True
-    'primary-mfa-server-definition-uri',  # mfa-types contains "mfa-server"
-    'backup-mfa-server-definition-uri',  # mfa-types contains "mfa-server"
-    'mfa-policy',  # mfa-types contains "mfa-server"
-    'mfa-userid',  # type != "template" and mfa-types contains "mfa-server"
-    'mfa-userid-override',  # type == "template" and mfa-types contains "mfa-server"
+    'password',  # never present
+    'disabled',  # type != 'template'
+    'password-expires',  # type != 'template'
+    'userid-on-ldap-server',  # type != 'template'
 )
 
 # A standard test user, as specified for the 'properties' module input parm
@@ -183,7 +178,7 @@ def get_module_output(mod_obj):
     return func(*call_args[0], **call_args[1])
 
 
-def assert_user_props(user_props, expand, where):
+def assert_user_props(user_props, expand, expand_names, where):
     """
     Assert the output object of the zhmc_user module
     """
@@ -197,32 +192,90 @@ def assert_user_props(user_props, expand, where):
         assert prop_name_hmc in user_props, where
 
     user_type = user_props['type']
-    auth_type = user_props['authentication-type']
 
     # Assert presence of the conditional and artificial properties
 
-    if user_type == 'pattern-based':
-        assert 'user-pattern-uri' in user_props, where
-        assert 'user-pattern-name' in user_props, where
-        if expand:
-            assert 'user-pattern' in user_props, where
-
-    if auth_type == 'local':
-        assert 'password-rule-uri' in user_props, where
-        assert 'password-rule-name' in user_props, where
-        if expand:
-            assert 'password-rule' in user_props, where
-
-    if auth_type == 'ldap':
-        assert 'ldap-server-definition-uri' in user_props, where
-        assert 'ldap-server-definition-name' in user_props, where
-        if expand:
-            assert 'ldap-server-definition' in user_props, where
-
     assert 'user-roles' in user_props, where  # Base property with the URIs
-    assert 'user-role-names' in user_props, where
+    if expand_names:
+        assert 'user-role-names' in user_props, where
+    else:
+        assert 'user-role-names' not in user_props, where
     if expand:
         assert 'user-role-objects' in user_props, where
+    else:
+        assert 'user-role-objects' not in user_props, where
+
+    if user_type == 'pattern-based':
+
+        assert 'user-pattern-uri' in user_props, where
+        if expand_names:
+            assert 'user-pattern-name' in user_props, where
+        else:
+            assert 'user-pattern-name' not in user_props, where
+        if expand:
+            assert 'user-pattern' in user_props, where
+        else:
+            assert 'user-pattern' not in user_props, where
+
+        assert 'user-template-uri' in user_props, where
+        if expand_names:
+            assert 'user-template-name' in user_props, where
+        else:
+            assert 'user-template-name' not in user_props, where
+        if expand:
+            assert 'user-template' in user_props, where
+        else:
+            assert 'user-template' not in user_props, where
+
+    assert 'password-rule-uri' in user_props, where
+    if expand_names:
+        assert 'password-rule-name' in user_props, where
+    else:
+        assert 'password-rule-name' not in user_props, where
+    if expand:
+        assert 'password-rule' in user_props, where
+    else:
+        assert 'password-rule' not in user_props, where
+
+    assert 'ldap-server-definition-uri' in user_props, where
+    if expand_names:
+        assert 'ldap-server-definition-name' in user_props, where
+    else:
+        assert 'ldap-server-definition-name' not in user_props, where
+    if expand:
+        assert 'ldap-server-definition' in user_props, where
+    else:
+        assert 'ldap-server-definition' not in user_props, where
+
+    assert 'primary-mfa-server-definition-uri' in user_props, where
+    if expand_names:
+        assert 'primary-mfa-server-definition-name' in user_props, where
+    else:
+        assert 'primary-mfa-server-definition-name' not in user_props, where
+    if expand:
+        assert 'primary-mfa-server-definition' in user_props, where
+    else:
+        assert 'primary-mfa-server-definition' not in user_props, where
+
+    assert 'backup-mfa-server-definition-uri' in user_props, where
+    if expand_names:
+        assert 'backup-mfa-server-definition-name' in user_props, where
+    else:
+        assert 'backup-mfa-server-definition-name' not in user_props, where
+    if expand:
+        assert 'backup-mfa-server-definition' in user_props, where
+    else:
+        assert 'backup-mfa-server-definition' not in user_props, where
+
+    assert 'default-group-uri' in user_props, where
+    if expand_names:
+        assert 'default-group-name' in user_props, where
+    else:
+        assert 'default-group-name' not in user_props, where
+    if expand:
+        assert 'default-group' in user_props, where
+    else:
+        assert 'default-group' not in user_props, where
 
     # Assert that none of the write-only properties is in the output object
     for prop_name in zhmc_user.WRITEONLY_PROPERTIES_HYPHEN:
@@ -242,18 +295,22 @@ def assert_user_props(user_props, expand, where):
     ]
 )
 @pytest.mark.parametrize(
+    "expand_names", [
+        pytest.param(False, id="expand_names=False"),
+        pytest.param(True, id="expand_names=True"),
+    ]
+)
+@pytest.mark.parametrize(
     "user_type, auth_type", [
         pytest.param('standard', 'local', id="user_type=standard,auth_type=local"),
-        pytest.param('standard', 'ldap', id="user_type=standard,auth_type=ldap"),
         pytest.param('template', 'ldap', id="user_type=template,auth_type=ldap"),
-        pytest.param('pattern-based', 'local', id="user_type=pattern-based,auth_type=local"),
         pytest.param('pattern-based', 'ldap', id="user_type=pattern-based,auth_type=ldap"),
         pytest.param('system-defined', 'local', id="user_type=system-defined,auth_type=local"),
     ]
 )
 @mock.patch("plugins.modules.zhmc_user.AnsibleModule", autospec=True)
 def test_zhmc_user_facts(
-        ansible_mod_cls, user_type, auth_type, expand, check_mode,
+        ansible_mod_cls, user_type, auth_type, expand, expand_names, check_mode,
         hmc_session):  # noqa: F811, E501
     # pylint: disable=redefined-outer-name
     """
@@ -290,6 +347,7 @@ def test_zhmc_user_facts(
         'state': 'facts',
         'properties': None,
         'expand': expand,
+        'expand_names': expand_names,
         'log_file': LOG_FILE,
         '_faked_session': faked_session,
     }
@@ -310,7 +368,7 @@ def test_zhmc_user_facts(
     # Assert module output
     changed, user_props = get_module_output(mod_obj)
     assert changed is False, where
-    assert_user_props(user_props, expand, where)
+    assert_user_props(user_props, expand, expand_names, where)
 
 
 USER_ABSENT_PRESENT_TESTCASES = [
@@ -411,6 +469,7 @@ def test_zhmc_user_absent_present(
     faked_session = hmc_session if hd.mock_file else None
 
     expand = False  # Expansion is tested elsewhere
+    expand_names = False  # Expansion is tested elsewhere
     client = zhmcclient.Client(hmc_session)
     console = client.consoles.console
 
@@ -459,6 +518,7 @@ def test_zhmc_user_absent_present(
             'state': input_state,
             'properties': input_props,
             'expand': expand,
+            'expand_names': expand_names,
             'log_file': LOG_FILE,
             '_faked_session': faked_session,
         }
@@ -501,7 +561,7 @@ def test_zhmc_user_absent_present(
                 f"Module input properties:\n{input_props_str}\n"
                 f"Resulting user properties:\n{output_props_str}")
         if input_state == 'present':
-            assert_user_props(output_props, expand, where)
+            assert_user_props(output_props, expand, expand_names, where)
 
     finally:
         # Delete user, if it exists
@@ -609,6 +669,7 @@ def test_zhmc_update_user_roles(
     faked_session = hmc_session if hd.mock_file else None
 
     expand = False  # Expansion is tested elsewhere
+    expand_names = False  # Expansion is tested elsewhere
     client = zhmcclient.Client(hmc_session)
     console = client.consoles.console
 
@@ -645,7 +706,8 @@ def test_zhmc_update_user_roles(
             'properties': {
                 'user_role_names': input_urole_names,
             },
-            'expand': False,
+            'expand': expand,
+            'expand_names': expand_names,
             'log_file': LOG_FILE,
             '_faked_session': faked_session,
         }
@@ -662,7 +724,10 @@ def test_zhmc_update_user_roles(
             f"message:\n{get_failure_msg(mod_obj)}"
 
         changed, output_props = get_module_output(mod_obj)
-        output_urole_names = output_props['user-role-names']
+        if expand_names:
+            output_urole_names = output_props['user-role-names']
+        else:
+            output_urole_names = []
 
         if changed != exp_changed:
             initial_uroles_sorted = sorted(initial_urole_names)
@@ -678,9 +743,16 @@ def test_zhmc_update_user_roles(
                 f"Module input user roles:\n{input_uroles_str}\n"
                 f"Resulting user roles:\n{output_uroles_str}")
 
-        assert_user_props(output_props, expand, where)
+        assert_user_props(output_props, expand, expand_names, where)
 
-        assert set(output_urole_names) == set(exp_urole_names)
+        # We need to compare the output based on URIs, because the names will
+        # only be in the output when expand_names is set.
+        output_urole_uris = set(output_props['user-roles'])
+        exp_urole_uris = set()
+        for urole_name in exp_urole_names:
+            urole = console.user_roles.find(name=urole_name)
+            exp_urole_uris.add(urole.uri)
+        assert output_urole_uris == exp_urole_uris
 
     finally:
         # Delete user

--- a/tests/end2end/test_zhmc_user_list.py
+++ b/tests/end2end/test_zhmc_user_list.py
@@ -108,11 +108,100 @@ def assert_user_list(user_list, exp_user_dict):
                 f"Incorrect value for property {pname!r} of user {user_name!r}"
 
 
+def add_artificial_properties(user_properties, console, user):
+    """
+    Add artificial properties to the user_properties dict.
+
+    This is a straight forward implementation to make sure the test functions
+    remain simple.
+    """
+
+    # Handle User Role references
+    all_uroles_by_uri = {ur.uri: ur for ur in console.user_roles.list()}
+    uroles = [all_uroles_by_uri[uri] for uri in user.properties['user-roles']]
+    user_properties['user-role-names'] = [ur.name for ur in uroles]
+
+    # Handle User Pattern reference
+    if user.properties['type'] == 'pattern-based':
+
+        # This property exists only for type='pattern-based', and will not be
+        # None.
+        user_pattern_uri = user.properties['user-pattern-uri']
+        if user_pattern_uri is None:  # Defensive programming
+            user_properties['user-pattern-name'] = None
+        else:
+            user_pattern = \
+                console.user_patterns.resource_object(user_pattern_uri)
+            user_properties['user-pattern-name'] = user_pattern.name
+
+        # This property exists only for type='pattern-based' and if the user
+        # is template-based, and may be None.
+        user_template_uri = user.properties['user-template-uri']
+        if user_template_uri is None:
+            user_properties['user-template-name'] = None
+        else:
+            user_template = console.users.resource_object(user_template_uri)
+            user_properties['user-template-name'] = user_template.name
+
+    # Handle Password Rule reference
+    password_rule_uri = user.properties['password-rule-uri']
+    # This property always exists. It will be non-Null for auth-type='local'.
+    if password_rule_uri is None:
+        user_properties['password-rule-name'] = None
+    else:
+        password_rule = console.password_rules.resource_object(
+            password_rule_uri)
+        user_properties['password-rule-name'] = password_rule.name
+
+    # Handle LDAP Server Definition reference
+    ldap_srv_def_uri = user.properties['ldap-server-definition-uri']
+    # This property always exists and is non-Null for auth.-type='ldap'.
+    if ldap_srv_def_uri is None:
+        user_properties['ldap-server-definition-name'] = None
+    else:
+        ldap_srv_def = console.ldap_server_definitions.resource_object(
+            ldap_srv_def_uri)
+        user_properties['ldap-server-definition-name'] = ldap_srv_def.name
+
+    # Handle primary MFA Server Definition reference
+    pri_mfa_srv_def_uri = user.properties['primary-mfa-server-definition-uri']
+    # This property always exists and is non-Null for auth.-type='mfa'.
+    if pri_mfa_srv_def_uri is None:
+        user_properties['primary-mfa-server-definition-name'] = None
+    else:
+        pri_mfa_srv_def = console.mfa_server_definitions.resource_object(
+            pri_mfa_srv_def_uri)
+        user_properties['primary-mfa-server-definition-name'] = \
+            pri_mfa_srv_def.name
+
+    # Handle backup MFA Server Definition reference
+    bac_mfa_srv_def_uri = user.properties['backup-mfa-server-definition-uri']
+    # This property always exists and is non-Null for auth.-type='mfa'.
+    if bac_mfa_srv_def_uri is None:
+        user_properties['backup-mfa-server-definition-name'] = None
+    else:
+        bac_mfa_srv_def = console.mfa_server_definitions.resource_object(
+            bac_mfa_srv_def_uri)
+        user_properties['backup-mfa-server-definition-name'] = \
+            bac_mfa_srv_def.name
+
+    # Handle default Group reference
+    default_group_uri = user.properties['default-group-uri']
+    # This property always exists, and may be None
+    if default_group_uri is None:
+        user_properties['default-group-name'] = None
+    else:
+        default_group = console.users.resource_object(default_group_uri)
+        user_properties['default-group-name'] = default_group.name
+
+
 @pytest.mark.parametrize(
     "property_flags", [
         pytest.param({}, id="property_flags()"),
         pytest.param({'full_properties': True},
                      id="property_flags(full_properties=True)"),
+        pytest.param({'full_properties': True, 'expand_names': True},
+                     id="property_flags(full_properties=True,expand_names=True)"),
     ]
 )
 @pytest.mark.parametrize(
@@ -142,22 +231,27 @@ def test_zhmc_user_list(
     faked_session = hmc_session if hd.mock_file else None
 
     full_properties = property_flags.get('full_properties', False)
+    expand_names = property_flags.get('expand_names', False)
 
     # Determine the expected list of users.
     exp_users = console.users.list(full_properties=full_properties)
     exp_user_dict = {}
     for user in exp_users:
-        exp_properties = {}
-        for pname_hmc, pvalue in user.properties.items():
+        user_properties = dict(user.properties)
+        if full_properties and expand_names:
+            add_artificial_properties(user_properties, console, user)
+        user_properties_under = {}
+        for pname_hmc, pvalue in user_properties.items():
             pname = pname_hmc.replace('-', '_')
-            exp_properties[pname] = pvalue
-        exp_user_dict[user.name] = exp_properties
+            user_properties_under[pname] = pvalue
+        exp_user_dict[user.name] = user_properties_under
 
     # Prepare module input parameters (must be all required + optional)
     params = {
         'hmc_host': hmc_host,
         'hmc_auth': hmc_auth,
         'full_properties': full_properties,
+        'expand_names': expand_names,
         'log_file': LOG_FILE,
         '_faked_session': faked_session,
     }


### PR DESCRIPTION
This PR started out as an idea for improving the performance of getting a user list with all properties and names for any referenced objects (instead of their URIs). So far, that is done by listing the users with the zhmc_user_list module, and then looping through the resulting users to retrieve their facts with the zhmc_user module, which adds artificial properties for the names of referenced objects. That causes each invocation of the zhmc_user to list the 7 possible kinds of referenced objects for the name lookup, and is slow. The solution implemented in this PR is an "expand_names" parameter for the zhmc_user_list module, which allows getting the names for any referenced objects in one invocation of the module. The module then performs only a single listing of the possible kinds of referenced objects for the name lookup.

In order to improve performance of the zhmc_user module, an "expand_names" parameter was added that allows disabling the name lookup.

While implementing this, it turned out that various other fixes needed to be done, and that support for the referenced user templates and default groups needed to be added.

The end2end tests for zhmc_user and zhmc_user_list have been extended and fixed accordingly.

For details, see the commit message.

I tested this change with the end2end tests for zhmc_user and zhmc_user_list on T224.