### PR TITLE
1.9: Circumvention for HTTP error 500.12 when creating Hipersocket NICs

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -40,6 +40,10 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Test: Fixed duplicate 'description' properties in test YAML files.
   (issue #1097)
 
+* Circumvention for HTTP error 500.12 when creating NICs on Hipersocket
+  adapters on z16 when the PartitionLink feature is enabled. This is a
+  temporary circumvention until the defect will be fixed.
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #1121 into 1.9.