### PR TITLE
Lifted size limit for ISO mount to above 2GB

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -132,6 +132,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Dev: Added commit message checker to test workflow. (issue #1137)
 
+* Lifted the size limit of 2GB for ISO images that can be mounted with the
+  'zhmc_partition' module using 'state=mount_iso'.
+
 **Cleanup:**
 
 * Removed the unnecessary .pylintrc file from the distribution archive of the

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -2072,17 +2072,14 @@ def ensure_iso_mount(params, check_mode):
 
         if image_name != current_image_name:
             # We need to mount the image
-            image = None
-            try:
-                with open(image_file, 'rb') as fp:
-                    if not check_mode:
-                        image = fp.read()
-            except OSError as exc:
-                raise ImageError(
-                    f"Cannot open ISO image file {image_file!r} for reading: "
-                    f"{exc}")
             if not check_mode:
-                partition.mount_iso_image(image, image_name, ins_file)
+                try:
+                    with open(image_file, 'rb') as fp:
+                        partition.mount_iso_image(fp, image_name, ins_file)
+                except OSError as exc:
+                    raise ImageError(
+                        f"Cannot open ISO image file {image_file!r} for "
+                        f"reading: {exc}")
             changed = True
         elif ins_file != current_ins_file:
             # We only need to update the INS file


### PR DESCRIPTION
For details, see the commit message.