### PR TITLE
1.9: Lifted size limit for ISO mount to above 2GB

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -42,6 +42,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 **Enhancements:**
 
+* Lifted the size limit of 2GB for ISO images that can be mounted with the
+  'zhmc_partition' module using 'state=mount_iso'.
+
 **Cleanup:**
 
 **Known issues:**

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -2073,17 +2073,14 @@ def ensure_iso_mount(params, check_mode):
 
         if image_name != current_image_name:
             # We need to mount the image
-            image = None
-            try:
-                with open(image_file, 'rb') as fp:
-                    if not check_mode:
-                        image = fp.read()
-            except OSError as exc:
-                raise ImageError(
-                    f"Cannot open ISO image file {image_file!r} for reading: "
-                    f"{exc}")
             if not check_mode:
-                partition.mount_iso_image(image, image_name, ins_file)
+                try:
+                    with open(image_file, 'rb') as fp:
+                        partition.mount_iso_image(fp, image_name, ins_file)
+                except OSError as exc:
+                    raise ImageError(
+                        f"Cannot open ISO image file {image_file!r} for "
+                        f"reading: {exc}")
             changed = True
         elif ins_file != current_ins_file:
             # We only need to update the INS file


### PR DESCRIPTION
Rolls back PR #1152 into 1.9.