### PR TITLE
Docs: Fixed inocrrect module name in examples for zhmc_nic

### DIFF
--- a/docs/source/modules/zhmc_nic.rst
+++ b/docs/source/modules/zhmc_nic.rst
@@ -162,7 +162,7 @@ Examples
    # Note: The following examples assume that some variables named 'my_*' are set.
 
    - name: Ensure NIC exists in the partition
-     zhmc_partition:
+     zhmc_nic:
        hmc_host: "{{ my_hmc_host }}"
        hmc_auth: "{{ my_hmc_auth }}"
        cpc_name: "{{ my_cpc_name }}"
@@ -177,7 +177,7 @@ Examples
      register: nic1
 
    - name: Ensure NIC does not exist in the partition
-     zhmc_partition:
+     zhmc_nic:
        hmc_host: "{{ my_hmc_host }}"
        hmc_auth: "{{ my_hmc_auth }}"
        cpc_name: "{{ my_cpc_name }}"
@@ -186,7 +186,7 @@ Examples
        state: absent
 
    - name: Gather facts about a NIC
-     zhmc_partition:
+     zhmc_nic:
        hmc_host: "{{ my_hmc_host }}"
        hmc_auth: "{{ my_hmc_auth }}"
        cpc_name: "{{ my_cpc_name }}"

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -103,6 +103,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Dev: Made order of names in AUTHORS.md reliable. (issue #1141)
 
+* Docs: Fixed incorrect module name in examples for the 'zhmc_nic' module.
+  (issue #1058)
+
 **Enhancements:**
 
 * Test: Added Python 3.13 to the tests in GitHub Actions.

--- a/plugins/modules/zhmc_nic.py
+++ b/plugins/modules/zhmc_nic.py
@@ -187,7 +187,7 @@ EXAMPLES = """
 # Note: The following examples assume that some variables named 'my_*' are set.
 
 - name: Ensure NIC exists in the partition
-  zhmc_partition:
+  zhmc_nic:
     hmc_host: "{{ my_hmc_host }}"
     hmc_auth: "{{ my_hmc_auth }}"
     cpc_name: "{{ my_cpc_name }}"
@@ -202,7 +202,7 @@ EXAMPLES = """
   register: nic1
 
 - name: Ensure NIC does not exist in the partition
-  zhmc_partition:
+  zhmc_nic:
     hmc_host: "{{ my_hmc_host }}"
     hmc_auth: "{{ my_hmc_auth }}"
     cpc_name: "{{ my_cpc_name }}"
@@ -211,7 +211,7 @@ EXAMPLES = """
     state: absent
 
 - name: Gather facts about a NIC
-  zhmc_partition:
+  zhmc_nic:
     hmc_host: "{{ my_hmc_host }}"
     hmc_auth: "{{ my_hmc_auth }}"
     cpc_name: "{{ my_cpc_name }}"


### PR DESCRIPTION
No review needed.