### PR TITLE
1.9: Circumvented safety issue with import of typer module

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -44,6 +44,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Docs: Fixed Ansible Galaxy badge on README page. (issue #1136)
 
+* Dev: Circumvented safety issue with import of typer module by pinning typer
+  to <0.17.0.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -61,9 +61,10 @@ click>=8.0.2
 Authlib>=1.3.1
 marshmallow>=3.15.0
 pydantic>=2.8.0
-typer>=0.12.1
-typer-cli>=0.12.1
-typer-slim>=0.12.1
+# typer >=0.17.0 causes import issue for safety, see https://github.com/pyupio/safety/issues/778
+typer>=0.12.1,<0.17.0
+typer-cli>=0.12.1,<0.17.0
+typer-slim>=0.12.1,<0.17.0
 # safety 3.4.0 depends on psutil~=6.1.0
 psutil~=6.1.0
 


### PR DESCRIPTION
Rolls back PR #1191 into 1.9.