### PR TITLE
Removed the pinning on typer version <0.17.0 with safety 3.6.1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -114,8 +114,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Docs: Fixed Ansible Galaxy badge on README page. (issue #1136)
 
-* Dev: Circumvented safety issue with import of typer module by pinning typer
-  to <0.17.0.
+* Dev: Removed the pinning of typer version to <0.17.0 with the new release of safety 3.6.1 and
+  also upgraded minimum version of safety to be 3.6.1 to fix the issue with typer>=0.17.0,
+  see  https://github.com/pyupio/safety/issues/778
 
 * Fixed that for z17 CPCs, NICs backed by OSA or HiperSocket adapters could not
   be created or updated to change their backing adapter. (issue #1178)

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -51,7 +51,7 @@ ansible-compat==4.1.10; python_version >= '3.10'
 subprocess-tee==0.4.1; python_version >= '3.10'
 
 # Safety CI by pyup.io
-safety==3.4.0
+safety==3.6.1
 safety-schemas==0.0.14
 dparse==0.6.4
 ruamel.yaml==0.17.21
@@ -59,9 +59,9 @@ click==8.0.2
 Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
-typer==0.12.1
-typer-cli==0.12.1
-typer-slim==0.12.1
+typer==0.16.0
+typer-cli==0.16.0
+typer-slim==0.16.0
 psutil==6.1.0
 
 # Bandit checker

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -53,10 +53,9 @@ wcmatch>=8.5; python_version >= '3.10'
 ansible-compat>=4.1.10; python_version >= '3.10'
 
 # Safety CI by pyup.io
-# safety 3.4.0 supports marshmallow>=4.0.0, see https://github.com/pyupio/safety/issues/715
-# safety 3.4.0 started using httpx and tenacity
+# safety 3.6.1 fixes the issue with typer >=0.17.0, see https://github.com/pyupio/safety/issues/778
 # pydantic 2.8.0 fixes an install issue on Python 3.13.
-safety>=3.4.0
+safety>=3.6.1
 safety-schemas>=0.0.14
 dparse>=0.6.4
 ruamel.yaml>=0.17.21
@@ -64,10 +63,10 @@ click>=8.0.2
 Authlib>=1.3.1
 marshmallow>=3.15.0
 pydantic>=2.8.0
-# typer >=0.17.0 causes import issue for safety, see https://github.com/pyupio/safety/issues/778
-typer>=0.12.1,<0.17.0
-typer-cli>=0.12.1,<0.17.0
-typer-slim>=0.12.1,<0.17.0
+# safety 3.6.1 depends on typer>=0.16.0
+typer>=0.16.0
+typer-cli>=0.16.0
+typer-slim>=0.16.0
 # safety 3.4.0 depends on psutil~=6.1.0
 psutil~=6.1.0
 


### PR DESCRIPTION
* Typer version was pinned to 0.17.0 due to pyupio/safety#778
* The issue is fixed with safety 3.6.1
* We no longer need to pin that version