### PR TITLE
Upgrade nltk to 3.9.1 to make it compatible with safety 3.6.1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -129,6 +129,8 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
   single version (2.17), Added link to HMC Help, Updated HMC Security book to
   2.17, Removed the HMC Operations Guide which no longer exists.
 
+* Dev: Upgrade nltk to 3.9.1 to fix the wordnet error, see https://github.com/nltk/nltk/issues/3416
+
 **Enhancements:**
 
 * Test: Added Python 3.13 to the tests in GitHub Actions.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -143,7 +143,7 @@ importlib-resources==5.0
 keyring==21.4.0
 levenshtein==0.25.1
 more-itertools==5.0.0
-nltk==3.9
+nltk==3.9.1
 pathlib2==2.2.1
 ply==3.10
 py==1.11.0  # Still required by pytest 6.2.5


### PR DESCRIPTION
* Fix the wordnet error on nltk 3.9