### PR TITLE
1.9: Upgrade nltk to 3.9.1 to make it compatible with safety 3.6.1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -78,6 +78,8 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Dev: Made order of names in AUTHORS.md reliable. (issue #1141)
 
+* Dev: Upgrade nltk to 3.9.1 to fix the wordnet error, see https://github.com/nltk/nltk/issues/3416
+
 **Enhancements:**
 
 * Lifted the size limit of 2GB for ISO images that can be mounted with the

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -142,7 +142,7 @@ importlib-resources==1.4.0
 keyring==21.4.0
 levenshtein==0.25.1
 more-itertools==5.0.0
-nltk==3.9
+nltk==3.9.1
 pathlib2==2.2.1
 ply==3.10
 py==1.11.0  # Still required by pytest 6.2.5


### PR DESCRIPTION
Rolls back PR #1205 into 1.9.