### PR TITLE
Removed use of urllib3

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -224,6 +224,14 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
   standard version from 'ansible.module_utils.basic' because the extensions
   were not used.
 
+* In order to reduce dependencies to other packages, the use of the urllib3
+  package was removed. The urllib3 package was used to disable its warnings,
+  but for an Ansible module that is not needed.
+
+* In order to reduce dependencies to other packages, the use of the pytz
+  package was removed, by replacing 'pytz.utc' with the built-in
+  'datetime.timezone.utc'.
+
 **Known issues:**
 
 * See `list of open issues`_.
@@ -376,10 +384,6 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 
 * Docs: Adjusted README file to new Ansible Automation Hub requirements.
   (issue #993)
-
-* In order to reduce dependencies to other packages, the use of the pytz
-  package was removed, by replacing 'pytz.utc' with the built-in
-  'datetime.timezone.utc'.
 
 
 Version 1.8.1

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -17,7 +17,8 @@ pytest==6.2.5
 testfixtures==6.9.0
 colorama==0.4.6
 # packaging is covered in requirements.txt
-# requests is covered in requirements.txt
+requests==2.32.4
+urllib3==2.5.0
 requests-mock==1.6.0
 immutable-views==0.6.0
 

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -26,8 +26,6 @@ ansible-core==2.15.13; python_version <= '3.11'
 ansible-core==2.16.13; python_version == '3.12'
 ansible-core==2.18.0; python_version >= '3.13'
 
-requests==2.32.4
-
 zhmcclient==1.23.1
 
 
@@ -48,7 +46,6 @@ PyYAML==6.0.2
 
 python-dateutil==2.8.2
 jsonschema==4.18.2
-urllib3==2.5.0
 
 
 # All other indirect dependencies for install that are not in requirements.txt

--- a/plugins/modules/zhmc_adapter.py
+++ b/plugins/modules/zhmc_adapter.py
@@ -354,12 +354,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -949,12 +943,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_adapter_list.py
+++ b/plugins/modules/zhmc_adapter_list.py
@@ -283,12 +283,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -459,12 +453,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_console.py
+++ b/plugins/modules/zhmc_console.py
@@ -241,12 +241,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -396,12 +390,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_cpc.py
+++ b/plugins/modules/zhmc_cpc.py
@@ -420,12 +420,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -882,12 +876,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_cpc_capacity.py
+++ b/plugins/modules/zhmc_cpc_capacity.py
@@ -454,12 +454,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     underscore_properties, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -817,12 +811,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_cpc_list.py
+++ b/plugins/modules/zhmc_cpc_list.py
@@ -226,12 +226,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -313,12 +307,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_crypto_attachment.py
+++ b/plugins/modules/zhmc_crypto_attachment.py
@@ -378,12 +378,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     parse_hmc_host, blanked_params, UNKNOWN_NAME  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -1077,12 +1071,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_hba.py
+++ b/plugins/modules/zhmc_hba.py
@@ -250,12 +250,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -610,12 +604,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_ldap_server_definition.py
+++ b/plugins/modules/zhmc_ldap_server_definition.py
@@ -249,12 +249,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params, blanked_dict, removed_dict  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -662,12 +656,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_ldap_server_definition_list.py
+++ b/plugins/modules/zhmc_ldap_server_definition_list.py
@@ -166,12 +166,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -229,12 +223,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_lpar.py
+++ b/plugins/modules/zhmc_lpar.py
@@ -625,12 +625,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     parse_hmc_host, blanked_params, removed_dict  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -1318,12 +1312,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_lpar_command.py
+++ b/plugins/modules/zhmc_lpar_command.py
@@ -215,12 +215,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -407,12 +401,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_lpar_list.py
+++ b/plugins/modules/zhmc_lpar_list.py
@@ -241,12 +241,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -405,12 +399,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_lpar_messages.py
+++ b/plugins/modules/zhmc_lpar_messages.py
@@ -291,12 +291,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -423,12 +417,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_nic.py
+++ b/plugins/modules/zhmc_nic.py
@@ -284,12 +284,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -878,12 +872,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_nic_list.py
+++ b/plugins/modules/zhmc_nic_list.py
@@ -200,12 +200,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -285,12 +279,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -630,12 +630,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     UNKNOWN_NAME, object_from_uri, object_properties  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -2228,12 +2222,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_partition_command.py
+++ b/plugins/modules/zhmc_partition_command.py
@@ -215,12 +215,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -408,12 +402,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_partition_list.py
+++ b/plugins/modules/zhmc_partition_list.py
@@ -238,12 +238,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -398,12 +392,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_partition_messages.py
+++ b/plugins/modules/zhmc_partition_messages.py
@@ -266,12 +266,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -388,12 +382,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_password_rule.py
+++ b/plugins/modules/zhmc_password_rule.py
@@ -267,12 +267,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -654,12 +648,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_password_rule_list.py
+++ b/plugins/modules/zhmc_password_rule_list.py
@@ -180,12 +180,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -249,12 +243,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_session.py
+++ b/plugins/modules/zhmc_session.py
@@ -225,12 +225,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -338,12 +332,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_storage_group.py
+++ b/plugins/modules/zhmc_storage_group.py
@@ -584,12 +584,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -1125,12 +1119,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_storage_group_attachment.py
+++ b/plugins/modules/zhmc_storage_group_attachment.py
@@ -231,12 +231,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -438,12 +432,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_storage_volume.py
+++ b/plugins/modules/zhmc_storage_volume.py
@@ -282,12 +282,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -687,12 +681,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_user.py
+++ b/plugins/modules/zhmc_user.py
@@ -487,12 +487,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     object_properties  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -1404,12 +1398,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_user_list.py
+++ b/plugins/modules/zhmc_user_list.py
@@ -230,12 +230,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params, NOT_PRESENT, ObjectsByUriCache  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -424,12 +418,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_user_pattern.py
+++ b/plugins/modules/zhmc_user_pattern.py
@@ -295,12 +295,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -927,12 +921,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_user_pattern_list.py
+++ b/plugins/modules/zhmc_user_pattern_list.py
@@ -200,12 +200,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     common_fail_on_import_errors, parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -258,12 +252,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_user_role.py
+++ b/plugins/modules/zhmc_user_role.py
@@ -456,12 +456,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -1304,12 +1298,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_user_role_list.py
+++ b/plugins/modules/zhmc_user_role_list.py
@@ -185,12 +185,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -254,12 +248,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_versions.py
+++ b/plugins/modules/zhmc_versions.py
@@ -249,12 +249,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -351,12 +345,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/plugins/modules/zhmc_virtual_function.py
+++ b/plugins/modules/zhmc_virtual_function.py
@@ -245,12 +245,6 @@ from ..module_utils.common import log_init, open_session, close_session, \
     parse_hmc_host, blanked_params  # noqa: E402
 
 try:
-    import urllib3
-    IMP_URLLIB3_ERR = None
-except ImportError:
-    IMP_URLLIB3_ERR = traceback.format_exc()
-
-try:
     import zhmcclient
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
@@ -588,12 +582,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
-
-    if IMP_URLLIB3_ERR is not None:
-        module.fail_json(msg=missing_required_lib("requests"),
-                         exception=IMP_URLLIB3_ERR)
-
-    urllib3.disable_warnings()
 
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -13,7 +13,8 @@ pytest>=6.2.5
 testfixtures>=6.9.0
 colorama>=0.4.6
 # packaging is covered in requirements.txt
-# requests is covered in requirements.txt
+requests>=2.32.4
+urllib3>=2.5.0
 requests-mock>=1.6.0
 immutable-views>=0.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,6 @@ ansible-core>=2.15.13; python_version <= '3.11'
 ansible-core>=2.16.13; python_version == '3.12'
 ansible-core>=2.18.0; python_version >= '3.13'
 
-requests>=2.32.4
-
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
 zhmcclient>=1.23.1
 
@@ -63,5 +61,3 @@ python-dateutil>=2.8.2
 jsonschema>=4.18.2
 # TODO: Python 3.13 support requires pyo3-ffi fixing its issue with Python 3.13
 #       (see https://github.com/PyO3/pyo3/issues/4038#issuecomment-2156363013)
-
-urllib3>=2.5.0


### PR DESCRIPTION
For details, see the commit message.
No review needed.

Tested this by running a local playbook (`try_playbooks/partition_messages.yml`) with the `log_file`parameter specified, and the `-vvvvv` option of the `ansible-playbook` command, and with HMC credentials that set `verify: false` (which produces urllib3 warnings when used with just the zhmcclient library). Verified that the log file and the `ansible-playbook` command output do not contain any urllib3 warnings.