### PR TITLE
Removed use of pytz package

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -377,6 +377,10 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Docs: Adjusted README file to new Ansible Automation Hub requirements.
   (issue #993)
 
+* In order to reduce dependencies to other packages, the use of the pytz
+  package was removed, by replacing 'pytz.utc' with the built-in
+  'datetime.timezone.utc'.
+
 
 Version 1.8.1
 -------------

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -28,8 +28,6 @@ ansible-core==2.18.0; python_version >= '3.13'
 
 requests==2.32.4
 
-pytz==2019.1
-
 zhmcclient==1.23.1
 
 

--- a/plugins/modules/zhmc_lpar_messages.py
+++ b/plugins/modules/zhmc_lpar_messages.py
@@ -282,6 +282,7 @@ messages:
 
 import logging  # noqa: E402
 import traceback  # noqa: E402
+from datetime import timezone  # noqa: E402
 from ansible.module_utils.basic import AnsibleModule, \
     missing_required_lib  # noqa: E402
 
@@ -300,12 +301,6 @@ try:
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
     IMP_ZHMCCLIENT_ERR = traceback.format_exc()
-
-try:
-    import pytz
-    IMP_PYTZ_ERR = None
-except ImportError:
-    IMP_PYTZ_ERR = traceback.format_exc()
 
 # Python logger name for this module
 LOGGER_NAME = 'zhmc_lpar'
@@ -384,7 +379,8 @@ def perform_os_messages(params):
             if hmc_ts == -1:
                 timestamp = None
             else:
-                dt = zhmcclient.datetime_from_timestamp(hmc_ts, tzinfo=pytz.utc)
+                dt = zhmcclient.datetime_from_timestamp(
+                    hmc_ts, tzinfo=timezone.utc)
                 timestamp = dt.isoformat()
             result_message = {
                 "sequence_number": os_message.get('sequence-number'),
@@ -437,10 +433,6 @@ def main():
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),
                          exception=IMP_ZHMCCLIENT_ERR)
-
-    if IMP_PYTZ_ERR is not None:
-        module.fail_json(msg=missing_required_lib("pytz"),
-                         exception=IMP_PYTZ_ERR)
 
     common_fail_on_import_errors(module)
 

--- a/plugins/modules/zhmc_partition_messages.py
+++ b/plugins/modules/zhmc_partition_messages.py
@@ -257,6 +257,7 @@ messages:
 
 import logging  # noqa: E402
 import traceback  # noqa: E402
+from datetime import timezone  # noqa: E402
 from ansible.module_utils.basic import AnsibleModule, \
     missing_required_lib  # noqa: E402
 
@@ -275,12 +276,6 @@ try:
     IMP_ZHMCCLIENT_ERR = None
 except ImportError:
     IMP_ZHMCCLIENT_ERR = traceback.format_exc()
-
-try:
-    import pytz
-    IMP_PYTZ_ERR = None
-except ImportError:
-    IMP_PYTZ_ERR = traceback.format_exc()
 
 # Python logger name for this module
 LOGGER_NAME = 'zhmc_part'
@@ -352,7 +347,8 @@ def perform_os_messages(params):
             if hmc_ts == -1:
                 timestamp = None
             else:
-                dt = zhmcclient.datetime_from_timestamp(hmc_ts, tzinfo=pytz.utc)
+                dt = zhmcclient.datetime_from_timestamp(
+                    hmc_ts, tzinfo=timezone.utc)
                 timestamp = dt.isoformat()
             result_message = {
                 "sequence_number": os_message.get('sequence-number'),
@@ -402,10 +398,6 @@ def main():
     if IMP_ZHMCCLIENT_ERR is not None:
         module.fail_json(msg=missing_required_lib("zhmcclient"),
                          exception=IMP_ZHMCCLIENT_ERR)
-
-    if IMP_PYTZ_ERR is not None:
-        module.fail_json(msg=missing_required_lib("pytz"),
-                         exception=IMP_PYTZ_ERR)
 
     common_fail_on_import_errors(module)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,6 @@ ansible-core>=2.18.0; python_version >= '3.13'
 
 requests>=2.32.4
 
-pytz>=2019.1
-
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
 zhmcclient>=1.23.1
 


### PR DESCRIPTION
For details, see the commit message.
No review needed.

Tested with local `try_playbooks/partition_messages.yml` playbook on AHPS with a modified partition_messages module that adds an HMC timestamp for `datetime.now()` in UTC, if no timestamp is returned from the HMC. Verified that the version before the change (using `pytz.utc`) has the correct result, as well as the version with the change (using `timezone.utc`).

Here is the modification to the partition_messages module for the test:
```
--- a/plugins/modules/zhmc_partition_messages.py
+++ b/plugins/modules/zhmc_partition_messages.py
@@ -348,10 +348,14 @@ def perform_os_messages(params):
         result = []
         for os_message in result_dict['os-messages']:
             hmc_ts = os_message.get('timestamp')
+            if hmc_ts == -1:
+                from datetime import datetime, timezone
+                now_dt = datetime.now(tz=timezone.utc)
+                hmc_ts = zhmcclient.timestamp_from_datetime(now_dt)
             if hmc_ts == -1:
                 timestamp = None
             else:
-                dt = zhmcclient.datetime_from_timestamp(hmc_ts, tzinfo=pytz.utc)
+                dt = zhmcclient.datetime_from_timestamp(hmc_ts, tzinfo=timezone.utc)
                 timestamp = dt.isoformat()
             result_message = {
                 "sequence_number": os_message.get('sequence-number'),
```