### PR TITLE
Moved ansible/ansible-core reqs to development dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,13 +395,15 @@ endif
 	@echo "Makefile: $@ done."
 
 .PHONY: check_reqs
-check_reqs: _check_version $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done minimum-constraints-develop.txt minimum-constraints-install.txt requirements.txt
+check_reqs: _check_version $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done minimum-constraints-develop.txt minimum-constraints-install.txt requirements.txt requirements-ansible.txt
 ifeq ($(PACKAGE_LEVEL),ansible)
 	@echo "Makefile: Warning: Skipping the checking of missing dependencies for PACKAGE_LEVEL=ansible" >&2
 else
 	@echo "Makefile: Checking missing dependencies of this package"
-	pip-missing-reqs $(src_py_dir) --requirements-file=requirements.txt
+	bash -c "cat requirements.txt requirements-ansible.txt >tmp_requirements.txt"
+	pip-missing-reqs $(src_py_dir) --requirements-file=tmp_requirements.txt
 	pip-missing-reqs $(src_py_dir) --requirements-file=minimum-constraints-install.txt
+	rm tmp_requirements.txt
 	@echo "Makefile: Done checking missing dependencies of this package"
 	@echo "Makefile: Checking missing dependencies of some development packages"
 	bash -c "cat minimum-constraints-develop.txt minimum-constraints-install.txt >tmp_minimum-constraints.txt"
@@ -496,11 +498,11 @@ else
 	@true >/dev/null
 endif
 
-$(done_dir)/install_deps_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(done_dir)/base_$(pymn)_$(PACKAGE_LEVEL).done requirements.txt
-	$(PYTHON_CMD) -m pip install $(pip_level_opts) $(pip_level_opts_new) -r requirements.txt
+$(done_dir)/install_deps_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(done_dir)/base_$(pymn)_$(PACKAGE_LEVEL).done requirements.txt requirements-ansible.txt
+	$(PYTHON_CMD) -m pip install $(pip_level_opts) $(pip_level_opts_new) -r requirements.txt -r requirements-ansible.txt
 	echo "done" >$@
 
-$(done_dir)/install_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(done_dir)/base_$(pymn)_$(PACKAGE_LEVEL).done $(done_dir)/install_deps_$(pymn)_$(PACKAGE_LEVEL).done $(dist_file) requirements.txt
+$(done_dir)/install_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(done_dir)/base_$(pymn)_$(PACKAGE_LEVEL).done $(done_dir)/install_deps_$(pymn)_$(PACKAGE_LEVEL).done $(dist_file)
 	ansible-galaxy collection install --force $(dist_file)
 	echo "done" >$@
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -239,6 +239,11 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
 * Added missing dependencies to the minimum constraints files. They now contain
   all direct and indirect dependencies.
 
+* Moved the Python package dependencies for 'ansible' and 'ansible-core' from
+  requirements.txt to a separate file requirements-ansible.txt that is not part
+  of the collection package, because Ansible EE does not expect them to be in
+  the install dependencies.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -13,7 +13,7 @@ setuptools==78.1.1
 wheel==0.38.1
 
 
-# Direct dependencies for install (must be consistent with requirements.txt)
+# Direct dependencies on ansible/ansible-core for install (must be consistent with requirements-ansible.txt)
 
 ansible==8.0.0; python_version <= '3.11'
 ansible==9.0.1; python_version == '3.12'
@@ -22,6 +22,9 @@ ansible==11.0.0; python_version >= '3.13'
 ansible-core==2.15.13; python_version <= '3.11'
 ansible-core==2.16.13; python_version == '3.12'
 ansible-core==2.18.0; python_version >= '3.13'
+
+
+# Direct dependencies for install, except ansible/ansible-core (must be consistent with requirements.txt)
 
 zhmcclient==1.23.1
 

--- a/requirements-ansible.txt
+++ b/requirements-ansible.txt
@@ -1,0 +1,25 @@
+# Pip requirements file for install dependencies on ansible/ansible-core
+
+# Note: These are actually install dependencies, but since Ansible EE does not expect dependencies
+# to ansible or ansible-core in the package's requirements file, they have been moved to a separate
+# requirements file.
+
+
+# Direct dependencies on ansible/ansible-core (must be consistent with minimum-constraints-install.txt)
+
+# Keep minimum versions consistent with table for 'minimum' packages in development.rst and with minimum-constraints-install.txt
+# ansible 8 (ansible-core 2.15) requires Python >=3.9 and its sanity test supports Python 3.9 to 3.11.
+# ansible 9 (ansible-core 2.16) requires Python >=3.10 and its sanity test supports Python 3.10 to 3.12.
+# ansible 10 (ansible-core 2.17) requires Python >=3.10 and its sanity test supports Python 3.10 to 3.12.
+# ansible 11 (ansible-core 2.18) requires Python >=3.11 and its sanity test supports Python 3.11 to 3.13.
+# ansible 12 (ansible-core 2.19) requires Python >=3.11 and its sanity test supports Python 3.11 to 3.13.
+# Ansible 8 requires Python >=3.9 - this is the check that no Python version below 3.9 is used.
+# Apart from that, we require the lowest Ansible version that supports a given Python version.
+ansible>=8.0.0; python_version <= '3.11'
+ansible>=9.0.1; python_version == '3.12'
+ansible>=11.0.0; python_version >= '3.13'
+
+# ansible-core is pulled in by ansible, but is needed for pip-check-reqs checks.
+ansible-core>=2.15.13; python_version <= '3.11'
+ansible-core>=2.16.13; python_version == '3.12'
+ansible-core>=2.18.0; python_version >= '3.13'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,24 +4,11 @@
 # need to be installed by the user of this Ansible collection.
 
 
-# Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
+# Direct dependencies for install, except ansible/ansible-core (must be consistent with minimum-constraints-install.txt)
 
-# Keep minimum versions consistent with table for 'minimum' packages in development.rst and with minimum-constraints-install.txt
-# ansible 8 (ansible-core 2.15) requires Python >=3.9 and its sanity test supports Python 3.9 to 3.11.
-# ansible 9 (ansible-core 2.16) requires Python >=3.10 and its sanity test supports Python 3.10 to 3.12.
-# ansible 10 (ansible-core 2.17) requires Python >=3.10 and its sanity test supports Python 3.10 to 3.12.
-# ansible 11 (ansible-core 2.18) requires Python >=3.11 and its sanity test supports Python 3.11 to 3.13.
-# ansible 12 (ansible-core 2.19) requires Python >=3.11 and its sanity test supports Python 3.11 to 3.13.
-# Ansible 8 requires Python >=3.9 - this is the check that no Python version below 3.9 is used.
-# Apart from that, we require the lowest Ansible version that supports a given Python version.
-ansible>=8.0.0; python_version <= '3.11'
-ansible>=9.0.1; python_version == '3.12'
-ansible>=11.0.0; python_version >= '3.13'
-
-# ansible-core is pulled in by ansible, but is needed for pip-check-reqs checks.
-ansible-core>=2.15.13; python_version <= '3.11'
-ansible-core>=2.16.13; python_version == '3.12'
-ansible-core>=2.18.0; python_version >= '3.13'
+# Note: The dependencies to ansible and ansible-core are actually install dependencies, but since Ansible EE does not
+# expect dependencies to ansible or ansible-core in the package's requirements file, they have been moved to a separate
+# requirements file requirements-ansible.txt that is not part of the Ansible collection package.
 
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
 zhmcclient>=1.23.1


### PR DESCRIPTION
For details, see the commit message.
No review needed.