### PR TITLE
Fixed link to version 1.9.x change log

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ The collection's changelogs can be reviewed in the following table:
 | Version  | Status         | Release notes & change log |
 |----------|----------------|----------------------------|
 | 1.10.0   | In development | unreleased                 |
-| 1.9.0    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.9.0/release_notes.html) |
+| 1.9.5    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.9.5/release_notes.html) |
 | 1.8.3    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.8.3/release_notes.html) |
 | 1.7.4    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.7.4/release_notes.html) |
 | 1.6.1    | Released       | [Release notes & change log](https://zhmcclient.github.io/zhmc-ansible-modules/1.6.1/release_notes.html) |


### PR DESCRIPTION
No review needed.
No rollback to 1.9 needed, since it is correct there.