### PR TITLE
Replaced immutable-view with immutabledict package

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -256,6 +256,9 @@ Availability: `AutomationHub`_, `Galaxy`_, `GitHub`_
   of the collection package, because Ansible EE does not expect them to be in
   the install dependencies.
 
+* Test: In test_common.py, replaced use of the "immutable-views" package with
+  "immutabledict".
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -20,7 +20,7 @@ colorama==0.4.6
 requests==2.32.4
 urllib3==2.5.0
 requests-mock==1.6.0
-immutable-views==0.6.0
+immutabledict==4.2.0
 
 # Unit test (indirect dependencies):
 pluggy==1.3.0

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -46,7 +46,7 @@ charset-normalizer==2.0.0
 decorator==4.0.11
 docopt==0.6.2
 idna==3.7
-immutable-views==0.6.0
+immutable-views==0.6.0  # to be replaced with immutabledict in a future zhmcclient version
 importlib-resources==5.0.0
 jsonschema==4.18.0
 jsonschema-specifications==2023.3.6

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -1257,8 +1257,7 @@ def underscore_properties(prop_dict):
 
           Note that this includes the following types:
             * a plain dict
-            * an immutable_views.DictView object as returned by
-              zhmcclient.BaseResource.properties
+            * immutabledict, as returned by zhmcclient.BaseResource.properties
 
     Returns:
         dict: Converted property dict, recursively.

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -16,7 +16,7 @@ colorama>=0.4.6
 requests>=2.32.4
 urllib3>=2.5.0
 requests-mock>=1.6.0
-immutable-views>=0.6.0
+immutabledict>=4.2.0
 
 # Unit test (indirect dependencies):
 pluggy>=1.3.0

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -25,7 +25,7 @@ from copy import deepcopy
 from collections.abc import Sequence, Mapping, Set
 from types import ModuleType
 import pytest
-from immutable_views import DictView
+from immutabledict import immutabledict
 
 from zhmcclient import BaseResource
 
@@ -180,8 +180,8 @@ COMMON_UNDER_PROPS_TESTCASES = [
         None,
     ),
     (
-        "Empty DictView",
-        DictView({}),
+        "Empty immutabledict",
+        immutabledict({}),
         {},
         None,
     ),
@@ -216,8 +216,8 @@ COMMON_UNDER_PROPS_TESTCASES = [
         None,
     ),
     (
-        "DictView",
-        DictView({
+        "immutabledict",
+        immutabledict({
             'prop-name-1': 'value-1',
             'prop_name_2': ['value-2a', 'value_2b'],
         }),
@@ -228,8 +228,8 @@ COMMON_UNDER_PROPS_TESTCASES = [
         None,
     ),
     (
-        "DictView, 1 level recursive",
-        DictView({
+        "immutabledict, 1 level recursive",
+        immutabledict({
             'prop-name-1': 'value1',
             'prop_name_2': {
                 'prop-name-3': 'value-3',


### PR DESCRIPTION
For details, see the commit message.

The immutable-views package is still referenced in the `minimum-constraints-install.txt` file because it is still an indirect dependency of the zhmcclient package at this point. It will also be replaced with immutabledict in a future zhmcclient release, and by that time, the indirect dependency in this repo here also needs to be updated.

Note: There is a slight inconsistency in this PR related to the change - ideally this PR should wait until zhmcclient 1.24 with support for immutabledict has been released.