### PR TITLE
1.9: Cleaned up pydantic/-core package dependencies

### DIFF
--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -57,6 +57,7 @@ click==8.0.2
 Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
+pydantic_core==2.20.0
 typer==0.16.0
 typer-cli==0.16.0
 typer-slim==0.16.0

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -60,6 +60,7 @@ click>=8.0.2
 Authlib>=1.3.1
 marshmallow>=3.15.0
 pydantic>=2.8.0
+pydantic_core>=2.20.0
 # safety 3.6.1 depends on typer>=0.16.0
 typer>=0.16.0
 typer-cli>=0.16.0


### PR DESCRIPTION
Rolls back PR #1229 into 1.9.