### PR TITLE
1.10: Added safety ignore-unpinned; Addressed safety issues; Cleaned up py38 drop

### DIFF
--- a/.safety-policy-develop.yml
+++ b/.safety-policy-develop.yml
@@ -17,6 +17,12 @@ security:
     # Should be set to False.
     ignore-cvss-unknown-severity: False
 
+    # Ignore unpinned requirements
+    # Default is true. "Unpinned" in this case means anything else but "==".
+    # Since we are checking against the minimum-constraints file, this check
+    # is enabled (false).
+    ignore-unpinned-requirements: false
+
     # List of specific vulnerabilities to ignore.
     # {id}:                 # vulnerability ID
     #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports
@@ -28,6 +34,8 @@ security:
             reason: Fixed authlib version 1.6.4 requires Python>=3.9 and is used there
         82754:
             reason: Fixed filelock version 3.20.1 requires Python>=3.10 and is used there
+        84062:
+            reason: Fixed ansible-lint version 26.1.0 requires Python>=3.10 and ansible-core>=2.16 - too complex to use there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -17,6 +17,12 @@ security:
     # Should be set to False.
     ignore-cvss-unknown-severity: False
 
+    # Ignore unpinned requirements
+    # Default is true. "Unpinned" in this case means anything else but "==".
+    # Since we are checking against the minimum-constraints file, this check
+    # is enabled (false).
+    ignore-unpinned-requirements: false
+
     # List of specific vulnerabilities to ignore.
     # {id}:                 # vulnerability ID
     #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports

--- a/ansible-constraints.txt
+++ b/ansible-constraints.txt
@@ -37,5 +37,5 @@ MarkupSafe==2.0.0
 
 # ansible-test
 yamllint==1.25.0; python_version <= '3.9'
-yamllint==1.26.3; python_version >= '3.10'
-pathspec==0.9.0
+yamllint==1.30.0; python_version >= '3.10'
+pathspec==0.10.3

--- a/changelogs/fragments/noissue.safety.fix.yaml
+++ b/changelogs/fragments/noissue.safety.fix.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Fixed safety issues up to 2026-01-24.
+  - Fixed safety issues up to 2026-02-09.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -18,7 +18,7 @@ testfixtures==6.9.0
 colorama==0.4.6
 # packaging is covered in requirements.txt
 requests==2.32.4
-urllib3==2.6.0
+urllib3==2.6.3
 requests-mock==1.6.0
 immutabledict==4.2.0
 
@@ -35,8 +35,8 @@ coveralls==3.3.1; python_version >= '3.13'
 
 # ansible-test
 yamllint==1.25.0; python_version == '3.9'
-yamllint==1.26.3; python_version >= '3.10'
-pathspec==0.9.0
+yamllint==1.30.0; python_version >= '3.10'
+pathspec==0.10.3
 # rstcheck is used only in ansible <= 2.10 / ansible <= 4
 
 # antsibull-changelog
@@ -48,24 +48,23 @@ antsibull-fileutils==1.4.0
 antsibull-docutils==1.3.0
 
 # ansible-lint
-ansible-lint==6.14.0; python_version >= '3.10'
+ansible-lint==24.12.2; python_version >= '3.10'
 black==24.3.0; python_version >= '3.10'
 rich==12.0.0; python_version >= '3.10'
 wcmatch==8.5; python_version >= '3.10'
-ansible-compat==4.1.10; python_version >= '3.10'
+ansible-compat==24.10.0; python_version >= '3.10'
 subprocess-tee==0.4.1; python_version >= '3.10'
 
 # Safety CI by pyup.io
-safety==3.6.1
-safety-schemas==0.0.14
+safety==3.7.0
+safety-schemas==0.0.16
 dparse==0.6.4
-ruamel.yaml==0.17.21
+ruamel.yaml==0.19.1
 click==8.0.2
-Authlib==1.3.2; python_version == '3.8'
-Authlib==1.6.5; python_version >= '3.9'
-marshmallow==3.15.0
-pydantic==2.8.0
-pydantic_core==2.20.0
+Authlib==1.6.5
+marshmallow==3.26.2
+pydantic==2.12.0
+pydantic_core==2.41.1
 typer==0.16.0
 typer-cli==0.16.0
 typer-slim==0.16.0
@@ -131,7 +130,7 @@ pip-check-reqs==2.5.3; python_version >= '3.12'
 
 aiofiles==24.1.0
 alabaster==0.7.9
-annotated-types==0.4.0
+annotated-types==0.6.0
 anyio==4.10.0
 backports-datetime-fromisoformat==2.0.3
 bleach==3.3.0
@@ -143,7 +142,8 @@ configparser==4.0.2
 contextlib2==0.6.0
 distro==1.9.0
 exceptiongroup==1.0.2
-filelock==3.16.1
+filelock==3.16.1; python_version == '3.9'
+filelock==3.20.1; python_version >= '3.10'
 gitdb==4.0.8
 h11==0.16.0
 httpcore==1.0.9
@@ -178,7 +178,7 @@ tenacity==8.5.0
 toml==0.10.0
 tqdm==4.67.1
 types-docutils==0.18.3
-typing-inspection==0.4.1
+typing-inspection==0.4.2
 wcwidth==0.1.7
 webencodings==0.5.1
 zipp==3.19.1

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -8,8 +8,7 @@
 
 # Base dependencies (must be consistent with requirements-base.txt)
 
-pip==25.0; python_version == '3.8'
-pip==25.2; python_version >= '3.9'
+pip==25.2
 setuptools==78.1.1
 wheel==0.38.1
 
@@ -65,6 +64,6 @@ six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
 stomp.py==8.1.1
 tomli==1.1.0
-typing_extensions==4.12.2
-urllib3==2.6.0
+typing-extensions==4.14.1
+urllib3==2.6.3
 websocket-client==1.8.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -4,7 +4,6 @@
 
 # Base dependencies (must be consistent with minimum-constraints-install.txt)
 
-pip>=25.0; python_version == '3.8'
-pip>=25.2; python_version >= '3.9'
+pip>=25.2
 setuptools>=78.1.1
 wheel>=0.38.1

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -14,7 +14,7 @@ testfixtures>=6.9.0
 colorama>=0.4.6
 # packaging is covered in requirements.txt
 requests>=2.32.4
-urllib3>=2.6.0
+urllib3>=2.6.3
 requests-mock>=1.6.0
 immutabledict>=4.2.0
 
@@ -38,20 +38,21 @@ coveralls>=3.3.1; python_version >= '3.13'  # 4.0 pins Python to <3.13
 
 # ansible-test
 yamllint>=1.25.0; python_version == '3.9'
-yamllint>=1.26.3; python_version >= '3.10'
-pathspec>=0.9.0
+yamllint>=1.30.0; python_version >= '3.10'
+pathspec>=0.10.3
 # rstcheck is used only in ansible <= 2.10 / ansible <= 4
 
 # ansible-lint
 # ansible-lint is run only on officially supported ansible-core versions
-# ansible-lint 6.0.0 requires ansible-core>=2.12, so it does not run on py39 with minimum package levels, so it is run only on py>=310
-# ansible-lint 6.14.0 depends on yamllint>=1.26.3, ansible-core>=2.12.0, and the packages listed below
-ansible-lint>=6.14.0; python_version >= '3.10'
+# ansible-lint 24.12.2 requires ansible-core>=2.13.0 and is the latest version
+#   that requires ansible-core<=2.15, so it runs on py>=310
+# ansible-lint 24.12.2 requires pathspec>=0.10.3, yamllint>=1.30.0, ansible-compat>=24.10.0, ruamel.yaml>=0.18.5
+ansible-lint>=24.12.2; python_version >= '3.10'
 black>=22.8.0; python_version >= '3.10'
 rich>=12.0.0; python_version >= '3.10'
 # wcmatch 8.5 fixes an AttributeError on Python 3.12
 wcmatch>=8.5; python_version >= '3.10'
-ansible-compat>=4.1.10; python_version >= '3.10'
+ansible-compat>=24.10.0; python_version >= '3.10'
 
 # antsibull-changelog
 antsibull-changelog>=0.32.0
@@ -64,22 +65,21 @@ antsibull-docutils>=1.3.0
 # Safety CI by pyup.io
 # safety 3.6.1 fixes the issue with typer >=0.17.0, see https://github.com/pyupio/safety/issues/778
 # pydantic 2.8.0 fixes an install issue on Python 3.13.
-safety>=3.6.1
-safety-schemas>=0.0.14
+safety>=3.7.0
+safety-schemas>=0.0.16
 dparse>=0.6.4
-ruamel.yaml>=0.17.21
+# ruamel.yaml starting with 0.18.17 requires ruamel.yaml.clibz
+ruamel.yaml>=0.19.1
 click>=8.0.2
-Authlib>=1.3.2; python_version == '3.8'
-Authlib>=1.6.5; python_version >= '3.9'
-marshmallow>=3.15.0
-pydantic>=2.8.0
-pydantic_core>=2.20.0
+Authlib>=1.6.5
+marshmallow>=3.26.2
+pydantic>=2.12.0
+pydantic_core>=2.41.1
 # safety 3.6.1 depends on typer>=0.16.0
 typer>=0.16.0
 typer-cli>=0.16.0
 typer-slim>=0.16.0
-# safety 3.4.0 depends on psutil~=6.1.0
-psutil~=6.1.0
+psutil>=6.1.0
 
 # Bandit checker
 bandit>=1.7.8


### PR DESCRIPTION
Rolls back #1298 into 1.10, plus cleaned up remainders from dropping Python 3.8 support.