### PR TITLE
Added a zhmc_http module for direct HTTP requests

### DIFF
--- a/changelogs/fragments/1354.feature.yaml
+++ b/changelogs/fragments/1354.feature.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - Added a new module "zhmc_http" that issues direct HTTP requests against the
+    HMC WS-API in order to allow using operations that are not yet implemented
+    in other modules.

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -51,6 +51,7 @@ Modules targeting the HMC (i.e. not a specific CPC):
    modules/zhmc_user_pattern_list
    modules/zhmc_ldap_server_definition
    modules/zhmc_ldap_server_definition_list
+   modules/zhmc_http
 
 Modules supported with CPCs in any operational mode:
 

--- a/docs/source/modules/zhmc_http.rst
+++ b/docs/source/modules/zhmc_http.rst
@@ -1,0 +1,167 @@
+
+:github_url: https://github.com/ansible-collections/ibm_zos_core/blob/dev/plugins/modules/zhmc_http.py
+
+.. _zhmc_http_module:
+.. _ibm.ibm_zhmc.zhmc_http_module:
+
+
+zhmc_http -- Perform direct HTTP requests
+=========================================
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Perform a direct GET/POST/DELETE HTTP request against the HMC WS\-API.
+- This module can be used as a fallback for HMC WS\-API operations that are not yet supported with other modules of this collection.
+
+
+
+
+
+
+Parameters
+----------
+
+
+hmc_host
+  The hostnames or IP addresses of a single HMC or of a list of redundant HMCs. A single HMC can be specified as a string type or as an HMC list with one item. An HMC list can be specified as a list type or as a string type containing a Python list representation.
+
+  The first available HMC of a list of redundant HMCs is used for the entire execution of the module.
+
+  | **required**: True
+  | **type**: raw
+
+
+hmc_auth
+  The authentication credentials for the HMC.
+
+  | **required**: True
+  | **type**: dict
+
+
+  userid
+    The userid (username) for authenticating with the HMC. This is mutually exclusive with providing :literal:`hmc\_auth.session\_id`.
+
+    | **required**: False
+    | **type**: str
+
+
+  password
+    The password for authenticating with the HMC. This is mutually exclusive with providing :literal:`hmc\_auth.session\_id`.
+
+    | **required**: False
+    | **type**: str
+
+
+  session_id
+    HMC session ID to be used. This is mutually exclusive with providing :literal:`hmc\_auth.userid` and :literal:`hmc\_auth.password` and can be created as described in the :ref:`zhmc\_session module <zhmc_session_module>`.
+
+    | **required**: False
+    | **type**: str
+
+
+  ca_certs
+    Path name of certificate file or certificate directory to be used for verifying the HMC certificate. If null (default), the path name in the :envvar:`REQUESTS\_CA\_BUNDLE` environment variable or the path name in the :envvar:`CURL\_CA\_BUNDLE` environment variable is used, or if neither of these variables is set, the certificates in the Mozilla CA Certificate List provided by the 'certifi' Python package are used for verifying the HMC certificate.
+
+    | **required**: False
+    | **type**: str
+
+
+  verify
+    If True (default), verify the HMC certificate as specified in the :literal:`hmc\_auth.ca\_certs` parameter. If False, ignore what is specified in the :literal:`hmc\_auth.ca\_certs` parameter and do not verify the HMC certificate.
+
+    | **required**: False
+    | **type**: bool
+    | **default**: True
+
+
+
+method
+  The HTTP method to be executed, in lower case.
+
+  | **required**: True
+  | **type**: str
+  | **choices**: get, post, delete
+
+
+uri
+  The canonical URI of the targeted resource starting with '/api/', including any query parameters.
+
+  | **required**: True
+  | **type**: str
+
+
+request_body
+  The request body for the HTTP request.
+
+  Only permitted for :literal:`method=post`.
+
+  | **required**: False
+  | **type**: dict
+
+
+log_file
+  File path of a log file to which the logic flow of this module as well as interactions with the HMC are logged. If null, logging will be propagated to the Python root logger.
+
+  | **required**: False
+  | **type**: str
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+   
+   ---
+   - name: List Dual-Control Requests
+     zhmc_http:
+       hmc_host: "{{ my_hmc_host }}"
+       hmc_auth:
+         userid: "{{ my_hmc_userid }}"
+         password: "{{ my_hmc_password }}"
+         verify: true
+         ca_certs: "{{ my_certs_dir }}"
+       method: get
+       uri: /api/console/dual-control-requests
+     register: dual_control_result
+
+
+
+
+
+
+
+
+
+
+Return Values
+-------------
+
+
+changed
+  Indicates if any change has been made by the module. This will always be false for HTTP GET operations, and will always be true for HTTP POST and DELETE operations.
+
+  | **returned**: always
+  | **type**: bool
+
+msg
+  An error message that describes the failure. If an HTTP response was received, this will include HTTP status code, reason code and the message from the error response body.
+
+  | **returned**: failure
+  | **type**: str
+
+response_body
+  The response body of the HTTP operation. If no HTTP response was received, this will be null.
+
+  | **returned**: always
+  | **type**: dict
+

--- a/plugins/modules/zhmc_http.py
+++ b/plugins/modules/zhmc_http.py
@@ -1,0 +1,371 @@
+#!/usr/bin/python
+# Copyright 2026 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# For information on the format of the ANSIBLE_METADATA, DOCUMENTATION,
+# EXAMPLES, and RETURN strings, see
+# http://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['stableinterface'],
+    'supported_by': 'community',
+    'shipped_by': 'other',
+    'other_repo_url': 'https://github.com/zhmcclient/zhmc-ansible-modules'
+}
+
+DOCUMENTATION = """
+---
+module: zhmc_http
+version_added: "2.9.0"
+short_description: Perform direct HTTP requests
+description:
+  - Perform a direct GET/POST/DELETE HTTP request against the HMC WS-API.
+  - This module can be used as a fallback for HMC WS-API operations that are
+    not yet supported with other modules of this collection.
+author:
+  - Andreas Maier (@andy-maier)
+requirements: []
+options:
+  hmc_host:
+    description:
+      - The hostnames or IP addresses of a single HMC or of a list of redundant
+        HMCs. A single HMC can be specified as a string type or as an HMC list
+        with one item. An HMC list can be specified as a list type or as a
+        string type containing a Python list representation.
+      - The first available HMC of a list of redundant HMCs is used for the
+        entire execution of the module.
+    type: raw
+    required: true
+  hmc_auth:
+    description:
+      - The authentication credentials for the HMC.
+    type: dict
+    required: true
+    suboptions:
+      userid:
+        description:
+          - The userid (username) for authenticating with the HMC.
+            This is mutually exclusive with providing O(hmc_auth.session_id).
+        type: str
+        required: false
+        default: null
+      password:
+        description:
+          - The password for authenticating with the HMC.
+            This is mutually exclusive with providing O(hmc_auth.session_id).
+        type: str
+        required: false
+        default: null
+      session_id:
+        description:
+          - HMC session ID to be used.
+            This is mutually exclusive with providing O(hmc_auth.userid) and
+            O(hmc_auth.password) and can be created as described in the
+            R(zhmc_session module,zhmc_session_module).
+        type: str
+        required: false
+        default: null
+      ca_certs:
+        description:
+          - Path name of certificate file or certificate directory to be used
+            for verifying the HMC certificate. If null (default), the path name
+            in the E(REQUESTS_CA_BUNDLE) environment variable or the path name
+            in the E(CURL_CA_BUNDLE) environment variable is used, or if neither
+            of these variables is set, the certificates in the Mozilla CA
+            Certificate List provided by the 'certifi' Python package are used
+            for verifying the HMC certificate.
+        type: str
+        required: false
+        default: null
+      verify:
+        description:
+          - If True (default), verify the HMC certificate as specified in the
+            O(hmc_auth.ca_certs) parameter. If False, ignore what is specified in the
+            O(hmc_auth.ca_certs) parameter and do not verify the HMC certificate.
+        type: bool
+        required: false
+        default: true
+  method:
+    description:
+      - "The HTTP method to be executed, in lower case."
+    type: str
+    required: true
+    choices: ['get', 'post', 'delete']
+  uri:
+    description:
+      - "The canonical URI of the targeted resource starting with '/api/',
+         including any query parameters."
+    type: str
+    required: true
+  request_body:
+    description:
+      - "The request body for the HTTP request."
+      - "Only permitted for C(method=post)."
+    type: dict
+    required: false
+  log_file:
+    description:
+      - "File path of a log file to which the logic flow of this module as well
+         as interactions with the HMC are logged. If null, logging will be
+         propagated to the Python root logger."
+    type: str
+    required: false
+    default: null
+  _faked_session:
+    description:
+      - "An internal parameter used for testing the module."
+    type: raw
+    required: false
+    default: null
+"""
+
+EXAMPLES = """
+---
+- name: List Dual-Control Requests
+  zhmc_http:
+    hmc_host: "{{ my_hmc_host }}"
+    hmc_auth:
+      userid: "{{ my_hmc_userid }}"
+      password: "{{ my_hmc_password }}"
+      verify: true
+      ca_certs: "{{ my_certs_dir }}"
+    method: get
+    uri: /api/console/dual-control-requests
+  register: dual_control_result
+"""
+
+RETURN = """
+changed:
+  description: Indicates if any change has been made by the module.
+    This will always be false for HTTP GET operations, and will always be true
+    for HTTP POST and DELETE operations.
+  returned: always
+  type: bool
+msg:
+  description: An error message that describes the failure. If an HTTP response
+    was received, this will include HTTP status code, reason code and the
+    message from the error response body.
+  returned: failure
+  type: str
+response_body:
+  description: The response body of the HTTP operation.
+    If no HTTP response was received, this will be null.
+  returned: always
+  type: dict
+"""
+
+import logging  # noqa: E402
+import traceback  # noqa: E402
+from ansible.module_utils.basic import AnsibleModule, \
+    missing_required_lib  # noqa: E402
+
+from ..module_utils.common import log_init, open_session, close_session, \
+    hmc_auth_parameter, Error, ParameterError, common_fail_on_import_errors, \
+    parse_hmc_host, blanked_params  # noqa: E402
+
+try:
+    import zhmcclient
+    IMP_ZHMCCLIENT_ERR = None
+except ImportError:
+    IMP_ZHMCCLIENT_ERR = traceback.format_exc()
+
+# Python logger name for this module
+LOGGER_NAME = 'zhmc_http'
+
+LOGGER = logging.getLogger(LOGGER_NAME)
+
+
+def http_get(params, check_mode):
+    # pylint: disable=unused-argument
+    """
+    Perform the HTTP GET method.
+
+    This is performed regardless of check mode.
+
+    Returns:
+      tuple(changed, response_body)
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+    uri = params['uri']
+    request_body = params.get('request_body')
+    if request_body is not None:
+        raise ParameterError(
+            "Module parameter 'request_body' is not permitted for HTTP GET")
+
+    changed = False
+    session, logoff = open_session(params)
+    try:
+        result = session.get(uri)
+        return changed, result
+    finally:
+        close_session(session, logoff)
+
+
+def http_post(params, check_mode):
+    # pylint: disable=unused-argument
+    """
+    Perform the HTTP POST method.
+
+    In check mode, this operation is not performed and the returned result
+    body will be null.
+
+    Returns:
+      tuple(changed, response_body)
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+    uri = params['uri']
+    request_body = params.get('request_body')
+
+    changed = True
+
+    if check_mode:
+        return changed, None
+
+    session, logoff = open_session(params)
+    try:
+        result = session.post(uri, body=request_body, wait_for_completion=True)
+        return changed, result
+    finally:
+        close_session(session, logoff)
+
+
+def http_delete(params, check_mode):
+    # pylint: disable=unused-argument
+    """
+    Perform the HTTP DELETE method.
+
+    In check mode, this HTTP method is not performed and the returned
+    response_body will be null.
+
+    Returns:
+      tuple(changed, response_body)
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+    uri = params['uri']
+    request_body = params.get('request_body')
+    if request_body is not None:
+        raise ParameterError(
+            "Module parameter 'request_body' is not permitted for HTTP DELETE")
+
+    changed = True
+
+    if check_mode:
+        return changed, None
+
+    session, logoff = open_session(params)
+    try:
+        result = session.delete(uri)
+        return changed, result
+    finally:
+        close_session(session, logoff)
+
+
+def perform_task(params, check_mode):
+    """
+    Perform the task for this module, dependent on the 'method' module
+    parameter.
+
+    If check_mode is True, check whether changes would occur, but don't
+    actually perform any changes.
+
+    Raises:
+      ParameterError: An issue with the module parameters.
+      StatusError: An issue with the partition status.
+      zhmcclient.Error: Any zhmcclient exception can happen.
+    """
+    methods = {
+        "get": http_get,
+        "post": http_post,
+        "delete": http_delete,
+    }
+    return methods[params['method']](params, check_mode)
+
+
+def main():
+    """Main function"""
+
+    # The following definition of module input parameters must match the
+    # description of the options in the DOCUMENTATION string.
+    argument_spec = dict(
+        hmc_host=dict(required=True, type='raw'),
+        hmc_auth=hmc_auth_parameter(),
+        method=dict(required=True, type='str',
+                    choices=['get', 'post', 'delete']),
+        uri=dict(required=True, type='str'),
+        request_body=dict(required=False, type='dict', default=None),
+        log_file=dict(required=False, type='str', default=None),
+        _faked_session=dict(required=False, type='raw'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True)
+
+    if IMP_ZHMCCLIENT_ERR is not None:
+        module.fail_json(msg=missing_required_lib("zhmcclient"),
+                         exception=IMP_ZHMCCLIENT_ERR)
+
+    common_fail_on_import_errors(module)
+
+    log_file = module.params['log_file']
+    log_init(LOGGER_NAME, log_file)
+
+    module.params['hmc_host'] = parse_hmc_host(module.params['hmc_host'])
+
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Module entry: params: %r",
+                     blanked_params(module.params))
+
+    changed = False
+    try:
+
+        changed, response_body = perform_task(module.params, module.check_mode)
+
+    except zhmcclient.HTTPError as exc:
+        msg = f"{exc.__class__.__name__}: {exc}"
+        response_body = exc.body
+        LOGGER.debug(
+            "Module exit (failure): changed: %r, msg: %s", changed, msg)
+        module.fail_json(changed=changed, msg=msg, response_body=response_body)
+    except (Error, zhmcclient.Error) as exc:
+        msg = f"{exc.__class__.__name__}: {exc}"
+        LOGGER.debug(
+            "Module exit (failure): changed: %r, msg: %s", changed, msg)
+        module.fail_json(changed=changed, msg=msg)
+    # The exceptions handled above are considered errors in the environment or
+    # in user input. They have a proper message that stands on its own, so we
+    # simply pass that message on and will not need a traceback.
+    # Other exceptions are considered module errors and are handled by Ansible
+    # by showing the traceback.
+
+    LOGGER.debug(
+        "Module exit (success): changed: %r", changed)
+    module.exit_json(changed=changed, response_body=response_body)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/end2end/test_zhmc_http.py
+++ b/tests/end2end/test_zhmc_http.py
@@ -1,0 +1,270 @@
+# Copyright 2026 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for zhmc_http module.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import uuid
+from unittest import mock
+import pytest
+import urllib3
+import zhmcclient
+# pylint: disable=line-too-long,unused-import
+from zhmcclient.testutils import hmc_definition, hmc_session  # noqa: F401, E501
+# pylint: enable=line-too-long,unused-import
+
+from plugins.modules import zhmc_http
+from .utils import mock_ansible_module, get_failure_msg
+
+urllib3.disable_warnings()
+
+# Print debug messages
+DEBUG = False
+
+LOG_FILE = 'zhmc_http.log' if DEBUG else None
+
+
+def new_urole_name():
+    """Return random unique user role name"""
+    urole_name = f'test_{uuid.uuid4()}'
+    return urole_name
+
+
+def get_module_output(mod_obj):
+    """
+    Return the module output as a tuple (changed, response_body) (i.e.
+    the arguments of the call to exit_json()).
+    If the module failed, return None.
+    """
+
+    def func(changed, response_body):
+        return changed, response_body
+
+    if not mod_obj.exit_json.called:
+        return None
+    call_args = mod_obj.exit_json.call_args
+
+    # The following makes sure we get the arguments regardless of whether they
+    # were specified as positional or keyword arguments:
+    return func(*call_args[0], **call_args[1])
+
+
+@pytest.mark.parametrize(
+    "check_mode", [
+        pytest.param(False, id="check_mode=False"),
+        pytest.param(True, id="check_mode=True"),
+    ]
+)
+@mock.patch("plugins.modules.zhmc_http.AnsibleModule", autospec=True)
+def test_zhmc_http_get(
+        ansible_mod_cls, check_mode, hmc_session):  # noqa: F811, E501
+    # pylint: disable=redefined-outer-name
+    """
+    Test GET HTTP method
+    """
+    hd = hmc_session.hmc_definition
+    hmc_host = hd.host
+    hmc_auth = dict(userid=hd.userid, password=hd.password,
+                    ca_certs=hd.ca_certs, verify=hd.verify)
+
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+
+    faked_session = hmc_session if hd.mock_file else None
+
+    # Prepare module input parameters (must be all required + optional)
+    params = {
+        'hmc_host': hmc_host,
+        'hmc_auth': hmc_auth,
+        'method': 'get',
+        'uri': '/api/console/user-roles',
+        'log_file': LOG_FILE,
+        '_faked_session': faked_session,
+    }
+
+    # Prepare mocks for AnsibleModule object
+    mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+    # Exercise the code to be tested
+    with pytest.raises(SystemExit) as exc_info:
+        zhmc_http.main()
+    exit_code = exc_info.value.args[0]
+
+    # Assert module exit code
+    assert exit_code == 0, (
+        f"Module failed with exit code {exit_code} and message:\n"
+        f"{get_failure_msg(mod_obj)}")
+
+    # Assert module output
+    changed, response_body = get_module_output(mod_obj)
+    assert changed is False
+
+    urole_names = [urole['name'] for urole in response_body['user-roles']]
+
+    exp_uroles = console.user_roles.list()
+    assert len(exp_uroles) == len(urole_names)
+    for exp_urole in exp_uroles:
+        name = exp_urole.name
+        assert name in urole_names
+
+
+@pytest.mark.parametrize(
+    "check_mode", [
+        pytest.param(False, id="check_mode=False"),
+        pytest.param(True, id="check_mode=True"),
+    ]
+)
+@mock.patch("plugins.modules.zhmc_http.AnsibleModule", autospec=True)
+def test_zhmc_http_post(
+        ansible_mod_cls, check_mode, hmc_session):  # noqa: F811, E501
+    # pylint: disable=redefined-outer-name
+    """
+    Test POST HTTP method
+    """
+    hd = hmc_session.hmc_definition
+    hmc_host = hd.host
+    hmc_auth = dict(userid=hd.userid, password=hd.password,
+                    ca_certs=hd.ca_certs, verify=hd.verify)
+
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+
+    faked_session = hmc_session if hd.mock_file else None
+
+    urole_name = new_urole_name()
+
+    # Prepare module input parameters (must be all required + optional)
+    params = {
+        'hmc_host': hmc_host,
+        'hmc_auth': hmc_auth,
+        'method': 'post',
+        'uri': '/api/console/user-roles',
+        'request_body': {'name': urole_name},
+        'log_file': LOG_FILE,
+        '_faked_session': faked_session,
+    }
+
+    # Prepare mocks for AnsibleModule object
+    mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+    # Exercise the code to be tested
+    with pytest.raises(SystemExit) as exc_info:
+        zhmc_http.main()
+    exit_code = exc_info.value.args[0]
+
+    # Assert module exit code
+    assert exit_code == 0, (
+        f"Module failed with exit code {exit_code} and message:\n"
+        f"{get_failure_msg(mod_obj)}")
+
+    created_urole = None
+    try:
+
+        # Assert module output
+        changed, response_body = get_module_output(mod_obj)
+        assert changed is True
+
+        if check_mode:
+            assert response_body is None
+        else:
+            assert 'object-uri' in response_body
+            urole_uri = response_body['object-uri']
+            found = False
+            uroles = console.user_roles.list()
+            for urole in uroles:
+                if urole.uri == urole_uri:
+                    found = True
+                    created_urole = urole
+                    assert urole.name == urole_name
+                    break
+            assert found is True
+
+    finally:
+        if created_urole:
+            created_urole.delete()
+
+
+@pytest.mark.parametrize(
+    "check_mode", [
+        pytest.param(False, id="check_mode=False"),
+        pytest.param(True, id="check_mode=True"),
+    ]
+)
+@mock.patch("plugins.modules.zhmc_http.AnsibleModule", autospec=True)
+def test_zhmc_http_delete(
+        ansible_mod_cls, check_mode, hmc_session):  # noqa: F811, E501
+    # pylint: disable=redefined-outer-name
+    """
+    Test DELETE HTTP method
+    """
+    hd = hmc_session.hmc_definition
+    hmc_host = hd.host
+    hmc_auth = dict(userid=hd.userid, password=hd.password,
+                    ca_certs=hd.ca_certs, verify=hd.verify)
+
+    client = zhmcclient.Client(hmc_session)
+    console = client.consoles.console
+
+    faked_session = hmc_session if hd.mock_file else None
+
+    urole_name = new_urole_name()
+
+    created_urole = console.user_roles.create(properties={'name': urole_name})
+
+    try:
+
+        # Prepare module input parameters (must be all required + optional)
+        params = {
+            'hmc_host': hmc_host,
+            'hmc_auth': hmc_auth,
+            'method': 'delete',
+            'uri': created_urole.uri,
+            'log_file': LOG_FILE,
+            '_faked_session': faked_session,
+        }
+
+        # Prepare mocks for AnsibleModule object
+        mod_obj = mock_ansible_module(ansible_mod_cls, params, check_mode)
+
+        # Exercise the code to be tested
+        with pytest.raises(SystemExit) as exc_info:
+            zhmc_http.main()
+        exit_code = exc_info.value.args[0]
+
+        # Assert module exit code
+        assert exit_code == 0, (
+            f"Module failed with exit code {exit_code} and message:\n"
+            f"{get_failure_msg(mod_obj)}")
+
+        # Assert module output
+        changed, response_body = get_module_output(mod_obj)
+        assert changed is True
+        assert response_body is None
+
+        if not check_mode:
+            uroles = console.user_roles.list(
+                filter_args={'object-uri': created_urole.uri})
+            assert len(uroles) == 0
+
+    finally:
+        # Clean up in case the deletion via module did not work
+        if created_urole:
+            try:
+                created_urole.delete()
+            except zhmcclient.HTTPError:
+                pass

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -6,6 +6,7 @@ plugins/modules/zhmc_cpc_list.py validate-modules:missing-gplv3-license  # Licen
 plugins/modules/zhmc_cpc.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_crypto_attachment.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_hba.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_http.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_command.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -6,6 +6,7 @@ plugins/modules/zhmc_cpc_list.py validate-modules:missing-gplv3-license  # Licen
 plugins/modules/zhmc_cpc.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_crypto_attachment.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_hba.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_http.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_command.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -6,6 +6,7 @@ plugins/modules/zhmc_cpc_list.py validate-modules:missing-gplv3-license  # Licen
 plugins/modules/zhmc_cpc.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_crypto_attachment.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_hba.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_http.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_command.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -6,6 +6,7 @@ plugins/modules/zhmc_cpc_list.py validate-modules:missing-gplv3-license  # Licen
 plugins/modules/zhmc_cpc.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_crypto_attachment.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_hba.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_http.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_command.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -6,6 +6,7 @@ plugins/modules/zhmc_cpc_list.py validate-modules:missing-gplv3-license  # Licen
 plugins/modules/zhmc_cpc.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_crypto_attachment.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_hba.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
+plugins/modules/zhmc_http.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition_list.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_ldap_server_definition.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0
 plugins/modules/zhmc_lpar_command.py validate-modules:missing-gplv3-license  # Licensed under Apache 2.0


### PR DESCRIPTION
I ran the new end2end test against the HMC of A224, and all tests passed:

```
TESTHMC=A224 TESTCASES=test_zhmc_http.py make end2end
```