### PR TITLE
Clarified expansion parms; Deprecated z13 return props in zhmc_partition

### DIFF
--- a/changelogs/fragments/noissue.expand.feature.yaml
+++ b/changelogs/fragments/noissue.expand.feature.yaml
@@ -1,0 +1,15 @@
+minor_changes:
+  - "Docs - Clarified the documentation of input parameters that control the
+    expansion of references to names or entire objects and their corresponding
+    properties in the module return values of the following modules:
+    'zhmc_nic_list', 'zhmc_partition', 'zhmc_storage_group', 'zhmc_user',
+    'zhmc_user_list'."
+deprecated_features:
+  - The 'partition.virtual-functions' property in the return value of the
+    'zhmc_partition' module has been deprecated because zEDC adapters were
+    last supported on z13 systems.
+    The property will be removed in release 2.0.0 of this collection.
+  - The 'partition.hbas' property in the return value of the
+    'zhmc_partition' module has been deprecated because managing HBAs
+    directly was last supported on z13 systems.
+    The property will be removed in release 2.0.0 of this collection.

--- a/docs/source/modules/zhmc_nic_list.rst
+++ b/docs/source/modules/zhmc_nic_list.rst
@@ -109,7 +109,7 @@ full_properties
 
 
 expand_names
-  If True and :literal:`full\_properties` is set, additional artificial properties will be returned for the names and other identification of the backing adapter and port. Default: False.
+  If True and :literal:`full\_properties` is True, additional artificial properties will be returned for the names and other identification of the backing adapter and port. See the return value for details.
 
   | **required**: False
   | **type**: bool
@@ -211,17 +211,23 @@ nics
     | **type**: raw
 
   adapter_id
-    Only present if :literal:`expand\_names=true` and :literal:`full\_properties=true`\ : Adapter ID (PCHID) of the backing adapter of the NIC.
+    Adapter ID (PCHID) of the backing adapter of the NIC.
+
+    Only present if :literal:`expand\_names` is True and :literal:`full\_properties` is True.
 
     | **type**: str
 
   adapter_name
-    Only present if :literal:`expand\_names=true` and :literal:`full\_properties=true`\ : Name of the backing adapter of the NIC.
+    Name of the backing adapter of the NIC.
+
+    Only present if :literal:`expand\_names` is True and :literal:`full\_properties` is True.
 
     | **type**: str
 
   adapter_port
-    Only present if :literal:`expand\_names=true` and :literal:`full\_properties=true`\ : Port index of the backing port of the NIC.
+    Port index of the backing port of the NIC.
+
+    Only present if :literal:`expand\_names` is True and :literal:`full\_properties` is True.
 
     | **type**: str
 

--- a/docs/source/modules/zhmc_partition.rst
+++ b/docs/source/modules/zhmc_partition.rst
@@ -200,14 +200,14 @@ ins_file
 
 
 expand_storage_groups
-  Boolean that controls whether the returned partition contains an additional artificial property :literal:`partition.storage\-groups` that is the list of storage groups attached to the partition, with properties as described for the zhmc\_storage\_group module with :literal:`expand=true`.
+  If True, the return value will contain an additional artificial property :literal:`partition.storage\-groups` that is the list of storage groups attached to the partition, with properties as described in the data model of the 'Storage Group' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
   | **required**: False
   | **type**: bool
 
 
 expand_crypto_adapters
-  Boolean that controls whether the returned partition contains an additional artificial property :literal:`crypto\-adapters` in its :literal:`crypto\-configuration` property that is the list of crypto adapters attached to the partition, with properties as described for the zhmc\_adapter module.
+  If True, the return value will contain an additional artificial property :literal:`partition.crypto\-configuration.crypto\-adapters` that is the list of crypto adapters used in the crypto configuration of the partition, with properties as described in the data model of the 'Adapter' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
   | **required**: False
   | **type**: bool
@@ -516,12 +516,22 @@ partition
     | **type**: str
 
   {property}
-    Additional properties of the partition, as described in the data model of the 'Partition' object in the :ref:`HMC API <HMC API>` book. Write\-only properties in the data model are not included. The property names have hyphens (\-) as described in that book.
+    Additional properties of the partition, as described in the data model of the 'Partition' object in the :ref:`HMC API <HMC API>` book.
+
+    If :literal:`expand\_crypto\_adapters` is True, the :literal:`partition.crypto\-configuration` property contains an additional artificial property :literal:`crypto\-adapters` that is the list of crypto adapters used in the crypto configuration of the partition, with properties as described in the data model of the 'Adapter' object in the :ref:`HMC API <HMC API>` book.
+
+    Write\-only properties in the data model are not included.
+
+    The property names will have hyphens (\-) as described in that book.
 
     | **type**: raw
 
   hbas
-    HBAs of the partition. If the CPC does not have the storage\-management feature enabled (ie. on z13), the list is empty.
+    HBAs of the partition.
+
+    Attaching HBAs directly to a partition was last supported on z13 systems. On later systems, the 'dpm\-storage\-management' feature is always enabled, HBAs are managed indirectly through storage groups, this property is still provided for compatibility but will always be an empty list.
+
+    :strong:`Deprecated`\ : This property will be removed in release 2.0.0 of this collection.
 
     | **type**: list
     | **elements**: dict
@@ -532,7 +542,7 @@ partition
       | **type**: str
 
     {property}
-      Additional properties of the HBA, as described in the data model of the 'HBA' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (\-) as described in that book.
+      Additional properties of the HBA, as described in the data model of the 'HBA' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
       | **type**: raw
 
@@ -549,13 +559,17 @@ partition
       | **type**: str
 
     {property}
-      Additional properties of the NIC, as described in the data model of the 'NIC' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (\-) as described in that book.
+      Additional properties of the NIC, as described in the data model of the 'NIC' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
       | **type**: raw
 
 
   virtual-functions
-    Virtual functions of the partition.
+    Virtual functions on zEDC accelerator adapters attached to the partition.
+
+    zEDC accelerator adapters were last supported on z13 systems. On later systems, this property is still provided for compatibility but will always be an empty list.
+
+    :strong:`Deprecated`\ : This property will be removed in release 2.0.0 of this collection.
 
     | **type**: list
     | **elements**: dict
@@ -566,13 +580,15 @@ partition
       | **type**: str
 
     {property}
-      Additional properties of the virtual function, as described in the data model of the 'Virtual Function' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (\-) as described in that book.
+      Additional properties of the virtual function, as described in the data model of the 'Virtual Function' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
       | **type**: raw
 
 
   storage-groups
-    Storage groups attached to the partition. Only present for :literal:`expand\_storage\_groups=true`.
+    Storage groups attached to the partition.
+
+    Only present if :literal:`expand\_storage\_groups` is True.
 
     | **type**: list
     | **elements**: dict
@@ -583,7 +599,7 @@ partition
       | **type**: str
 
     {property}
-      Additional properties of the storage group, as described for the zhmc\_storage\_group module with :literal:`expand=true`.
+      Additional properties of the storage group, as described in the data model of the 'Storage Group' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
       | **type**: raw
 

--- a/docs/source/modules/zhmc_partition.rst
+++ b/docs/source/modules/zhmc_partition.rst
@@ -200,14 +200,14 @@ ins_file
 
 
 expand_storage_groups
-  Boolean that controls whether the returned partition contains an additional artificial property :literal:`partition.storage\-groups` that is the list of storage groups attached to the partition, with properties as described for the zhmc\_storage\_group module with :literal:`expand=true`.
+  If True, the return value will contain an additional artificial property :literal:`partition.storage\-groups` that is the list of storage groups attached to the partition, with properties as described in the data model of the 'Storage Group' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
   | **required**: False
   | **type**: bool
 
 
 expand_crypto_adapters
-  Boolean that controls whether the returned partition contains an additional artificial property :literal:`crypto\-adapters` in its :literal:`crypto\-configuration` property that is the list of crypto adapters attached to the partition, with properties as described for the zhmc\_adapter module.
+  If True, the return value will contain an additional artificial property :literal:`partition.crypto\-configuration.crypto\-adapters` that is the list of crypto adapters used in the crypto configuration of the partition, with properties as described in the data model of the 'Adapter' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
   | **required**: False
   | **type**: bool
@@ -530,12 +530,22 @@ partition
     | **type**: str
 
   {property}
-    Additional properties of the partition, as described in the data model of the 'Partition' object in the :ref:`HMC API <HMC API>` book. Write\-only properties in the data model are not included. The property names have hyphens (\-) as described in that book.
+    Additional properties of the partition, as described in the data model of the 'Partition' object in the :ref:`HMC API <HMC API>` book.
+
+    If :literal:`expand\_crypto\_adapters` is True, the :literal:`partition.crypto\-configuration` property contains an additional artificial property :literal:`crypto\-adapters` that is the list of crypto adapters used in the crypto configuration of the partition, with properties as described in the data model of the 'Adapter' object in the :ref:`HMC API <HMC API>` book.
+
+    Write\-only properties in the data model are not included.
+
+    The property names will have hyphens (\-) as described in that book.
 
     | **type**: raw
 
   hbas
-    HBAs of the partition. If the CPC does not have the storage\-management feature enabled (ie. on z13), the list is empty.
+    HBAs of the partition.
+
+    Attaching HBAs directly to a partition was last supported on z13 systems. On later systems, the 'dpm\-storage\-management' feature is always enabled, HBAs are managed indirectly through storage groups, this property is still provided for compatibility but will always be an empty list.
+
+    :strong:`Deprecated`\ : This property will be removed in release 2.0.0 of this collection.
 
     | **type**: list
     | **elements**: dict
@@ -546,7 +556,7 @@ partition
       | **type**: str
 
     {property}
-      Additional properties of the HBA, as described in the data model of the 'HBA' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (\-) as described in that book.
+      Additional properties of the HBA, as described in the data model of the 'HBA' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
       | **type**: raw
 
@@ -565,13 +575,17 @@ partition
       | **type**: str
 
     {property}
-      Additional properties of the NIC, as described in the data model of the 'NIC' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (\-) as described in that book.
+      Additional properties of the NIC, as described in the data model of the 'NIC' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
       | **type**: raw
 
 
   virtual-functions
-    Virtual functions of the partition.
+    Virtual functions on zEDC accelerator adapters attached to the partition.
+
+    zEDC accelerator adapters were last supported on z13 systems. On later systems, this property is still provided for compatibility but will always be an empty list.
+
+    :strong:`Deprecated`\ : This property will be removed in release 2.0.0 of this collection.
 
     | **type**: list
     | **elements**: dict
@@ -582,13 +596,15 @@ partition
       | **type**: str
 
     {property}
-      Additional properties of the virtual function, as described in the data model of the 'Virtual Function' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names have hyphens (\-) as described in that book.
+      Additional properties of the virtual function, as described in the data model of the 'Virtual Function' element object of the 'Partition' object in the :ref:`HMC API <HMC API>` book. The property names will have hyphens (\-) as described in that book.
 
       | **type**: raw
 
 
   storage-groups
-    Storage groups attached to the partition. Only present for :literal:`expand\_storage\_groups=true`.
+    Storage groups attached to the partition.
+
+    Only present if :literal:`expand\_storage\_groups` is True.
 
     | **type**: list
     | **elements**: dict

--- a/docs/source/modules/zhmc_storage_group.rst
+++ b/docs/source/modules/zhmc_storage_group.rst
@@ -134,7 +134,7 @@ properties
 
 
 expand
-  Boolean that controls whether the returned storage group contains additional artificial properties that expand certain URI or name properties to the full set of resource properties (see description of return values of this module).
+  If True, the return value will contain additional artificial properties that expand certain URI or name properties to the full set of resource properties. See the return value for details.
 
   | **required**: False
   | **type**: bool
@@ -485,9 +485,13 @@ storage_group
     | **elements**: str
 
   candidate-adapter-ports
-    Only present if :literal:`expand=true`\ : List of candidate storage adapter ports of the storage group. Will be empty for storage group types other than FCP.
+    List of candidate storage adapter ports of the storage group.
 
-    | **returned**: success+expand
+    Will be empty for storage group types other than FCP.
+
+    Only present if :literal:`expand` is True.
+
+    | **returned**: success
     | **type**: list
     | **elements**: dict
 
@@ -524,9 +528,11 @@ storage_group
 
 
   storage-volumes
-    Only present if :literal:`expand=true`\ : Storage volumes of the storage group.
+    Storage volumes of the storage group.
 
-    | **returned**: success+expand
+    Only present if :literal:`expand` is True.
+
+    | **returned**: success
     | **type**: list
     | **elements**: dict
 
@@ -542,9 +548,13 @@ storage_group
 
 
   virtual-storage-resources
-    Only present if :literal:`expand=true`\ : Virtual storage resources of the storage group. Will be empty for storage group types other than FCP.
+    Virtual storage resources of the storage group.
 
-    | **returned**: success+expand
+    Will be empty for storage group types other than FCP.
+
+    Only present if :literal:`expand` is True.
+
+    | **returned**: success
     | **type**: list
     | **elements**: dict
 
@@ -555,9 +565,11 @@ storage_group
 
 
   attached-partitions
-    Only present if :literal:`expand=true`\ : Partitions to which the storage group is attached.
+    Partitions to which the storage group is attached.
 
-    | **returned**: success+expand
+    Only present if :literal:`expand` is True.
+
+    | **returned**: success
     | **type**: list
     | **elements**: dict
 

--- a/docs/source/modules/zhmc_storage_group.rst
+++ b/docs/source/modules/zhmc_storage_group.rst
@@ -134,7 +134,7 @@ properties
 
 
 expand
-  Boolean that controls whether the returned storage group contains additional artificial properties that expand certain URI or name properties to the full set of resource properties (see description of return values of this module).
+  If True, the return value will contain additional artificial properties that expand certain URI or name properties to the full set of resource properties. See the return value for details.
 
   | **required**: False
   | **type**: bool
@@ -485,8 +485,11 @@ storage_group
     | **elements**: str
 
   attached-partitions
-    List of partitions to which the storage group is attached. Only present if :literal:`expand=true`.
+    Partitions to which the storage group is attached.
 
+    Only present if :literal:`expand` is True.
+
+    | **returned**: success
     | **type**: list
     | **elements**: dict
 
@@ -497,8 +500,11 @@ storage_group
 
 
   storage-volumes
-    Storage volumes of the storage group. Only present if :literal:`expand=true`.
+    Storage volumes of the storage group.
 
+    Only present if :literal:`expand` is True.
+
+    | **returned**: success
     | **type**: list
     | **elements**: dict
 
@@ -514,8 +520,13 @@ storage_group
 
 
   candidate-adapter-ports
-    List of candidate storage adapter ports of the storage group. Only present if :literal:`expand=true` and for storage group type FCP.
+    List of candidate storage adapter ports of the storage group.
 
+    Will be empty for storage group types other than FCP.
+
+    Only present if :literal:`expand` is True.
+
+    | **returned**: success
     | **type**: list
     | **elements**: dict
 
@@ -552,8 +563,13 @@ storage_group
 
 
   virtual-storage-resources
-    Virtual storage resources of the storage group. Only present if :literal:`expand=true` and for storage group type FCP.
+    Virtual storage resources of the storage group.
 
+    Will be empty for storage group types other than FCP.
+
+    Only present if :literal:`expand` is True.
+
+    | **returned**: success
     | **type**: list
     | **elements**: dict
 

--- a/docs/source/modules/zhmc_user.rst
+++ b/docs/source/modules/zhmc_user.rst
@@ -140,16 +140,16 @@ properties
 
 
 expand
-  Deprecated: The :literal:`expand` parameter is deprecated because the returned password rule, user role, user pattern and LDAP server definition objects have an independent lifecycle, so the same objects are returned when invoking this module in a loop through all users. Use the respective other modules of this collection to get the properties of these objects.
+  If True, the return value will contain additional artificial properties that expand certain URI or name properties to the full set of resource properties. See the return value for details.
 
-  Boolean that controls whether the returned user contains additional artificial properties that expand certain URI or name properties to the full set of resource properties (see description of return values of this module).
+  :strong:`Deprecated`\ : The :literal:`expand` parameter is deprecated because the returned password rule, user role, user pattern and LDAP server definition objects have an independent lifecycle, so the same objects are returned when invoking this module in a loop through all users. Use the respective other modules of this collection to get the properties of these objects.
 
   | **required**: False
   | **type**: bool
 
 
 expand_names
-  Boolean that controls whether the returned user contains additional artificial properties for the names of referenced objects, such as user roles, password rule, etc.
+  If True, the return value will contain additional artificial properties for the names of referenced objects, such as user roles, password rule, etc.
 
   For backwards compatibility, this parameter defaults to True.
 
@@ -314,9 +314,11 @@ user
     | **type**: str
 
   user-role-objects
-    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+    User roles referenced by property :literal:`user\-roles`.
 
-    Only present if :literal:`expand=true`\ : User roles referenced by property :literal:`user\-roles`.
+    Only present if :literal:`expand` is True.
+
+    :strong:`Deprecated`\ : This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
     | **type**: dict
 
@@ -332,9 +334,11 @@ user
     | **type**: str
 
   user-pattern
-    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+    User pattern referenced by property :literal:`user\-pattern\-uri`.
 
-    Only present for users with :literal:`type=pattern` and if :literal:`expand=true`\ : User pattern referenced by property :literal:`user\-pattern\-uri`.
+    Only present for users with :literal:`type=pattern` and if :literal:`expand` is True.
+
+    :strong:`Deprecated`\ : This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
     | **type**: dict
 
@@ -350,9 +354,11 @@ user
     | **type**: str
 
   user-template
-    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+    User template referenced by property :literal:`user\-template\-uri`.
 
-    Only present for users with :literal:`type=pattern` and if :literal:`expand=true`\ : User template referenced by property :literal:`user\-template\-uri`.
+    Only present for users with :literal:`type=pattern` and if :literal:`expand` is True.
+
+    :strong:`Deprecated`\ : This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
     | **type**: dict
 
@@ -368,9 +374,11 @@ user
     | **type**: str
 
   password-rule
-    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+    Password rule referenced by property :literal:`password\-rule\-uri`.
 
-    Only present if :literal:`expand=true`\ : Password rule referenced by property :literal:`password\-rule\-uri`.
+    Only present if :literal:`expand` is True.
+
+    :strong:`Deprecated`\ : This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
     | **type**: dict
 
@@ -386,9 +394,11 @@ user
     | **type**: str
 
   ldap-server-definition
-    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+    LDAP server definition referenced by property :literal:`ldap\-server\-definition\-uri`.
 
-    Only present if :literal:`expand=true`\ : LDAP server definition referenced by property :literal:`ldap\-server\-definition\-uri`.
+    Only present if :literal:`expand` is True.
+
+    :strong:`Deprecated`\ : This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
     | **type**: dict
 
@@ -404,9 +414,11 @@ user
     | **type**: str
 
   primary-mfa-server-definition
-    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+    MFA server definition referenced by property :literal:`primary\-mfa\-server\-definition\-uri`.
 
-    Only present if :literal:`expand=true`\ : MFA server definition referenced by property :literal:`primary\-mfa\-server\-definition\-uri`.
+    Only present if :literal:`expand` is True.
+
+    :strong:`Deprecated`\ : This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
     | **type**: dict
 
@@ -422,9 +434,11 @@ user
     | **type**: str
 
   backup-mfa-server-definition
-    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+    MFA server definition referenced by property :literal:`backup\-mfa\-server\-definition\-uri`.
 
-    Only present if :literal:`expand=true`\ : MFA server definition referenced by property :literal:`backup\-mfa\-server\-definition\-uri`.
+    Only present if :literal:`expand` is True.
+
+    :strong:`Deprecated`\ : This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
     | **type**: dict
 
@@ -440,9 +454,11 @@ user
     | **type**: str
 
   default-group
-    Deprecated: This result property is deprecated because the :literal:`expand` parameter is deprecated.
+    Group referenced by property :literal:`default\-group\-uri`.
 
-    Only present if :literal:`expand=true`\ : Group referenced by property :literal:`default\-group\-uri`.
+    Only present if :literal:`expand` is True.
+
+    :strong:`Deprecated`\ : This result property is deprecated because the :literal:`expand` parameter is deprecated.
 
     | **type**: dict
 

--- a/docs/source/modules/zhmc_user_list.rst
+++ b/docs/source/modules/zhmc_user_list.rst
@@ -95,7 +95,7 @@ full_properties
 
 
 expand_names
-  If True and :literal:`full\_properties` is set, additional artificial properties will be returned for the names of referenced objects, such as user roles, password rule, etc. Default: False.
+  If True and :literal:`full\_properties` is True, additional artificial properties will be returned for the names of referenced objects, such as user roles, password rule, etc. See the return value for details.
 
   | **required**: False
   | **type**: bool
@@ -187,42 +187,59 @@ users
     | **type**: raw
 
   user_role_names
-    Only present if :literal:`expand\_names=true`\ : Name of the user roles referenced by property :literal:`user\_roles`.
+    Name of the user roles referenced by property :literal:`user\_roles`.
 
-    | **type**: str
+    Only present if :literal:`expand\_names` is True.
+
+    | **type**: list
+    | **elements**: str
 
   user_pattern_name
-    Only present for users with :literal:`type=pattern` and if :literal:`expand\_names=true`\ : Name of the user pattern referenced by property :literal:`user\_pattern\_uri`.
+    Name of the user pattern referenced by property :literal:`user\_pattern\_uri`.
+
+    Only present for users with :literal:`type=pattern` if :literal:`expand\_names` is True.
 
     | **type**: str
 
   user_template_name
-    Only present for users with :literal:`type=pattern` and if :literal:`expand\_names=true`\ : Name of the template user referenced by property :literal:`user\_template\_uri`.
+    Name of the template user referenced by property :literal:`user\_template\_uri`.
+
+    Only present for users with :literal:`type=pattern` if :literal:`expand\_names` is True.
 
     | **type**: str
 
   password_rule_name
-    Only present if :literal:`expand\_names=true`\ : Name of the password rule referenced by property :literal:`password\_rule\_uri`.
+    Name of the password rule referenced by property :literal:`password\_rule\_uri`.
+
+    Only present if :literal:`expand\_names` is True.
 
     | **type**: str
 
   ldap_server_definition_name
-    Only present if :literal:`expand\_names=true`\ : Name of the LDAP server definition referenced by property :literal:`ldap\_server\_definition\_uri`.
+    Name of the LDAP server definition referenced by property :literal:`ldap\_server\_definition\_uri`.
+
+    Only present if :literal:`expand\_names` is True.
 
     | **type**: str
 
   primary_mfa_server_definition_name
-    Only present if :literal:`expand\_names=true`\ : Name of the MFA server definition referenced by property :literal:`primary\_mfa\_server\_definition\_uri`.
+    Name of the MFA server definition referenced by property :literal:`primary\_mfa\_server\_definition\_uri`.
+
+    Only present if :literal:`expand\_names` is True.
 
     | **type**: str
 
   backup_mfa_server_definition_name
-    Only present if :literal:`expand\_names=true`\ : Name of the MFA server definition referenced by property :literal:`backup\_mfa\_server\_definition\_uri`.
+    Name of the MFA server definition referenced by property :literal:`backup\_mfa\_server\_definition\_uri`.
+
+    Only present if :literal:`expand\_names` is True.
 
     | **type**: str
 
   default_group_name
-    Only present if :literal:`expand\_names=true`\ : Name of the Group referenced by property :literal:`default\_group\_uri`.
+    Name of the Group referenced by property :literal:`default\_group\_uri`.
+
+    Only present if :literal:`expand\_names` is True.
 
     | **type**: str
 

--- a/plugins/modules/zhmc_nic_list.py
+++ b/plugins/modules/zhmc_nic_list.py
@@ -124,9 +124,9 @@ options:
     default: false
   expand_names:
     description:
-      - "If True and O(full_properties) is set, additional artificial properties
-         will be returned for the names and other identification of the backing
-         adapter and port. Default: False."
+      - "If True and O(full_properties) is True, additional artificial
+         properties will be returned for the names and other identification of
+         the backing adapter and port. See the return value for details."
     type: bool
     required: false
     default: false
@@ -190,17 +190,22 @@ nics:
         The property names will have underscores instead of hyphens.
       type: raw
     adapter_id:
-      description: "Only present if O(expand_names=true) and
-        O(full_properties=true): Adapter ID (PCHID) of the backing adapter of
-        the NIC."
+      description:
+        - "Adapter ID (PCHID) of the backing adapter of the NIC."
+        - "Only present if O(expand_names) is True and O(full_properties) is
+           True."
       type: str
     adapter_name:
-      description: "Only present if O(expand_names=true) and
-        O(full_properties=true): Name of the backing adapter of the NIC."
+      description:
+        - "Name of the backing adapter of the NIC."
+        - "Only present if O(expand_names) is True and O(full_properties) is
+           True."
       type: str
     adapter_port:
-      description: "Only present if O(expand_names=true) and
-        O(full_properties=true): Port index of the backing port of the NIC."
+      description:
+        - "Port index of the backing port of the NIC."
+        - "Only present if O(expand_names) is True and O(full_properties) is
+           True."
       type: str
   sample:
     [

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -252,20 +252,23 @@ options:
     default: null
   expand_storage_groups:
     description:
-      - "Boolean that controls whether the returned partition contains
-         an additional artificial property RV(partition.storage-groups) that is the list
-         of storage groups attached to the partition, with properties as
-         described for the zhmc_storage_group module with C(expand=true)."
+      - "If True, the return value will contain an additional artificial
+         property RV(partition.storage-groups) that is the list of storage
+         groups attached to the partition, with properties as described in the
+         data model of the 'Storage Group' object in the R(HMC API,HMC API)
+         book.
+         The property names will have hyphens (-) as described in that book."
     type: bool
     required: false
     default: false
   expand_crypto_adapters:
     description:
-      - "Boolean that controls whether the returned partition contains
-         an additional artificial property C(crypto-adapters) in its
-         C(crypto-configuration) property that is the list
-         of crypto adapters attached to the partition, with properties as
-         described for the zhmc_adapter module."
+      - "If True, the return value will contain an additional artificial
+         property C(partition.crypto-configuration.crypto-adapters) that is
+         the list of crypto adapters used in the crypto configuration of the
+         partition, with properties as described in the data model of the
+         'Adapter' object in the R(HMC API,HMC API) book.
+         The property names will have hyphens (-) as described in that book."
     type: bool
     required: false
     default: false
@@ -412,15 +415,28 @@ partition:
       description: "Partition name"
       type: str
     "{property}":
-      description: "Additional properties of the partition, as described in
-        the data model of the 'Partition' object in the R(HMC API,HMC API) book.
-        Write-only properties in the data model are not included.
-        The property names have hyphens (-) as described in that book."
+      description:
+        - "Additional properties of the partition, as described in the data
+           model of the 'Partition' object in the R(HMC API,HMC API) book."
+        - "If O(expand_crypto_adapters) is True, the
+           C(partition.crypto-configuration) property contains an additional
+           artificial property C(crypto-adapters) that is the list of crypto
+           adapters used in the crypto configuration of the partition, with
+           properties as described in the data model of the 'Adapter' object
+           in the R(HMC API,HMC API) book."
+        - "Write-only properties in the data model are not included."
+        - "The property names will have hyphens (-) as described in that book."
       type: raw
     hbas:
-      description: "HBAs of the partition. If the CPC does not have the
-        storage-management feature enabled (ie. on z13), the list is
-        empty."
+      description:
+        - "HBAs of the partition."
+        - "Attaching HBAs directly to a partition was last supported on z13
+           systems. On later systems, the 'dpm-storage-management' feature is
+           always enabled, HBAs are managed indirectly through storage groups,
+           this property is still provided for compatibility but will always
+           be an empty list."
+        - "B(Deprecated): This property will be removed in release 2.0.0 of
+           this collection."
       type: list
       elements: dict
       contains:
@@ -428,10 +444,11 @@ partition:
           description: "HBA name"
           type: str
         "{property}":
-          description: "Additional properties of the HBA, as described in the
-            data model of the 'HBA' element object of the 'Partition' object
-            in the R(HMC API,HMC API) book.
-            The property names have hyphens (-) as described in that book."
+          description:
+            - "Additional properties of the HBA, as described in the data model
+               of the 'HBA' element object of the 'Partition' object in the
+               R(HMC API,HMC API) book.
+               The property names will have hyphens (-) as described in that book."
           type: raw
     nics:
       description: "NICs of the partition."
@@ -442,13 +459,21 @@ partition:
           description: "NIC name"
           type: str
         "{property}":
-          description: "Additional properties of the NIC, as described in the
-            data model of the 'NIC' element object of the 'Partition' object
-            in the R(HMC API,HMC API) book.
-            The property names have hyphens (-) as described in that book."
+          description:
+            - "Additional properties of the NIC, as described in the data model
+               of the 'NIC' element object of the 'Partition' object in the
+               R(HMC API,HMC API) book.
+               The property names will have hyphens (-) as described in that book."
           type: raw
     virtual-functions:
-      description: "Virtual functions of the partition."
+      description:
+        - "Virtual functions on zEDC accelerator adapters attached to the
+           partition."
+        - "zEDC accelerator adapters were last supported on z13 systems.
+           On later systems, this property is still provided for compatibility
+           but will always be an empty list."
+        - "B(Deprecated): This property will be removed in release 2.0.0 of
+           this collection."
       type: list
       elements: dict
       contains:
@@ -456,14 +481,16 @@ partition:
           description: "Virtual function name"
           type: str
         "{property}":
-          description: "Additional properties of the virtual function, as
-            described in the data model of the 'Virtual Function' element
-            object of the 'Partition' object in the R(HMC API,HMC API) book.
-            The property names have hyphens (-) as described in that book."
+          description:
+            - "Additional properties of the virtual function, as described in
+               the data model of the 'Virtual Function' element object of the
+               'Partition' object in the R(HMC API,HMC API) book.
+               The property names will have hyphens (-) as described in that book."
           type: raw
     storage-groups:
-      description: "Storage groups attached to the partition. Only present for
-        O(expand_storage_groups=true)."
+      description:
+        - "Storage groups attached to the partition."
+        - "Only present if O(expand_storage_groups) is True."
       type: list
       elements: dict
       contains:
@@ -471,8 +498,11 @@ partition:
           description: "Storage group name"
           type: str
         "{property}":
-          description: "Additional properties of the storage group, as
-            described for the zhmc_storage_group module with C(expand=true)."
+          description:
+            - "Additional properties of the storage group, as described in the
+               data model of the 'Storage Group' object in the
+               R(HMC API,HMC API) book.
+               The property names will have hyphens (-) as described in that book."
           type: raw
   sample:
     {

--- a/plugins/modules/zhmc_partition.py
+++ b/plugins/modules/zhmc_partition.py
@@ -252,20 +252,23 @@ options:
     default: null
   expand_storage_groups:
     description:
-      - "Boolean that controls whether the returned partition contains
-         an additional artificial property RV(partition.storage-groups) that is the list
-         of storage groups attached to the partition, with properties as
-         described for the zhmc_storage_group module with C(expand=true)."
+      - "If True, the return value will contain an additional artificial
+         property RV(partition.storage-groups) that is the list of storage
+         groups attached to the partition, with properties as described in the
+         data model of the 'Storage Group' object in the R(HMC API,HMC API)
+         book.
+         The property names will have hyphens (-) as described in that book."
     type: bool
     required: false
     default: false
   expand_crypto_adapters:
     description:
-      - "Boolean that controls whether the returned partition contains
-         an additional artificial property C(crypto-adapters) in its
-         C(crypto-configuration) property that is the list
-         of crypto adapters attached to the partition, with properties as
-         described for the zhmc_adapter module."
+      - "If True, the return value will contain an additional artificial
+         property C(partition.crypto-configuration.crypto-adapters) that is
+         the list of crypto adapters used in the crypto configuration of the
+         partition, with properties as described in the data model of the
+         'Adapter' object in the R(HMC API,HMC API) book.
+         The property names will have hyphens (-) as described in that book."
     type: bool
     required: false
     default: false
@@ -437,15 +440,28 @@ partition:
       description: "Partition name"
       type: str
     "{property}":
-      description: "Additional properties of the partition, as described in
-        the data model of the 'Partition' object in the R(HMC API,HMC API) book.
-        Write-only properties in the data model are not included.
-        The property names have hyphens (-) as described in that book."
+      description:
+        - "Additional properties of the partition, as described in the data
+           model of the 'Partition' object in the R(HMC API,HMC API) book."
+        - "If O(expand_crypto_adapters) is True, the
+           C(partition.crypto-configuration) property contains an additional
+           artificial property C(crypto-adapters) that is the list of crypto
+           adapters used in the crypto configuration of the partition, with
+           properties as described in the data model of the 'Adapter' object
+           in the R(HMC API,HMC API) book."
+        - "Write-only properties in the data model are not included."
+        - "The property names will have hyphens (-) as described in that book."
       type: raw
     hbas:
-      description: "HBAs of the partition. If the CPC does not have the
-        storage-management feature enabled (ie. on z13), the list is
-        empty."
+      description:
+        - "HBAs of the partition."
+        - "Attaching HBAs directly to a partition was last supported on z13
+           systems. On later systems, the 'dpm-storage-management' feature is
+           always enabled, HBAs are managed indirectly through storage groups,
+           this property is still provided for compatibility but will always
+           be an empty list."
+        - "B(Deprecated): This property will be removed in release 2.0.0 of
+           this collection."
       type: list
       elements: dict
       contains:
@@ -453,10 +469,11 @@ partition:
           description: "HBA name"
           type: str
         "{property}":
-          description: "Additional properties of the HBA, as described in the
-            data model of the 'HBA' element object of the 'Partition' object
-            in the R(HMC API,HMC API) book.
-            The property names have hyphens (-) as described in that book."
+          description:
+            - "Additional properties of the HBA, as described in the data model
+               of the 'HBA' element object of the 'Partition' object in the
+               R(HMC API,HMC API) book.
+               The property names will have hyphens (-) as described in that book."
           type: raw
     nics:
       description:
@@ -470,13 +487,21 @@ partition:
           description: "NIC name"
           type: str
         "{property}":
-          description: "Additional properties of the NIC, as described in the
-            data model of the 'NIC' element object of the 'Partition' object
-            in the R(HMC API,HMC API) book.
-            The property names have hyphens (-) as described in that book."
+          description:
+            - "Additional properties of the NIC, as described in the data model
+               of the 'NIC' element object of the 'Partition' object in the
+               R(HMC API,HMC API) book.
+               The property names will have hyphens (-) as described in that book."
           type: raw
     virtual-functions:
-      description: "Virtual functions of the partition."
+      description:
+        - "Virtual functions on zEDC accelerator adapters attached to the
+           partition."
+        - "zEDC accelerator adapters were last supported on z13 systems.
+           On later systems, this property is still provided for compatibility
+           but will always be an empty list."
+        - "B(Deprecated): This property will be removed in release 2.0.0 of
+           this collection."
       type: list
       elements: dict
       contains:
@@ -484,14 +509,16 @@ partition:
           description: "Virtual function name"
           type: str
         "{property}":
-          description: "Additional properties of the virtual function, as
-            described in the data model of the 'Virtual Function' element
-            object of the 'Partition' object in the R(HMC API,HMC API) book.
-            The property names have hyphens (-) as described in that book."
+          description:
+            - "Additional properties of the virtual function, as described in
+               the data model of the 'Virtual Function' element object of the
+               'Partition' object in the R(HMC API,HMC API) book.
+               The property names will have hyphens (-) as described in that book."
           type: raw
     storage-groups:
-      description: "Storage groups attached to the partition. Only present for
-        O(expand_storage_groups=true)."
+      description:
+        - "Storage groups attached to the partition."
+        - "Only present if O(expand_storage_groups) is True."
       type: list
       elements: dict
       contains:

--- a/plugins/modules/zhmc_storage_group.py
+++ b/plugins/modules/zhmc_storage_group.py
@@ -167,10 +167,9 @@ options:
     default: null
   expand:
     description:
-      - "Boolean that controls whether the returned storage group contains
-         additional artificial properties that expand certain URI or name
-         properties to the full set of resource properties (see description of
-         return values of this module)."
+      - "If True, the return value will contain additional artificial
+         properties that expand certain URI or name properties to the full set
+         of resource properties. See the return value for details."
     type: bool
     required: false
     default: false
@@ -286,10 +285,11 @@ storage_group:
       type: list
       elements: str
     candidate-adapter-ports:
-      description: "Only present if O(expand=true): List of candidate storage
-        adapter ports of the storage group. Will be empty for storage group
-        types other than FCP."
-      returned: "success+expand"
+      description:
+        - "List of candidate storage adapter ports of the storage group."
+        - "Will be empty for storage group types other than FCP."
+        - "Only present if O(expand) is True."
+      returned: "success"
       type: list
       elements: dict
       contains:
@@ -319,9 +319,10 @@ storage_group:
                 The property names have hyphens (-) as described in that book."
               type: raw
     storage-volumes:
-      description: "Only present if O(expand=true): Storage volumes of the
-        storage group."
-      returned: "success+expand"
+      description:
+        - "Storage volumes of the storage group."
+        - "Only present if O(expand) is True."
+      returned: "success"
       type: list
       elements: dict
       contains:
@@ -335,10 +336,11 @@ storage_group:
             The property names have hyphens (-) as described in that book."
           type: raw
     virtual-storage-resources:
-      description: "Only present if O(expand=true): Virtual storage resources
-        of the storage group. Will be empty for storage group types other than
-        FCP."
-      returned: "success+expand"
+      description:
+        - "Virtual storage resources of the storage group."
+        - "Will be empty for storage group types other than FCP."
+        - "Only present if O(expand) is True."
+      returned: "success"
       type: list
       elements: dict
       contains:
@@ -350,9 +352,10 @@ storage_group:
             The property names have hyphens (-) as described in that book."
           type: raw
     attached-partitions:
-      description: "Only present if O(expand=true): Partitions to which the
-        storage group is attached."
-      returned: "success+expand"
+      description:
+        - "Partitions to which the storage group is attached."
+        - "Only present if O(expand) is True."
+      returned: "success"
       type: list
       elements: dict
       contains:

--- a/plugins/modules/zhmc_storage_group.py
+++ b/plugins/modules/zhmc_storage_group.py
@@ -167,10 +167,9 @@ options:
     default: null
   expand:
     description:
-      - "Boolean that controls whether the returned storage group contains
-         additional artificial properties that expand certain URI or name
-         properties to the full set of resource properties (see description of
-         return values of this module)."
+      - "If True, the return value will contain additional artificial
+         properties that expand certain URI or name properties to the full set
+         of resource properties. See the return value for details."
     type: bool
     required: false
     default: false
@@ -286,8 +285,10 @@ storage_group:
       type: list
       elements: str
     attached-partitions:
-      description: "List of partitions to which the storage group is attached.
-        Only present if O(expand=true)."
+      description:
+        - "Partitions to which the storage group is attached."
+        - "Only present if O(expand) is True."
+      returned: "success"
       type: list
       elements: dict
       contains:
@@ -297,8 +298,10 @@ storage_group:
             The property names have hyphens (-) as described in that book."
           type: raw
     storage-volumes:
-      description: "Storage volumes of the storage group.
-        Only present if O(expand=true)."
+      description:
+        - "Storage volumes of the storage group."
+        - "Only present if O(expand) is True."
+      returned: "success"
       type: list
       elements: dict
       contains:
@@ -312,8 +315,11 @@ storage_group:
             The property names have hyphens (-) as described in that book."
           type: raw
     candidate-adapter-ports:
-      description: "List of candidate storage adapter ports of the storage
-        group. Only present if O(expand=true) and for storage group type FCP."
+      description:
+        - "List of candidate storage adapter ports of the storage group."
+        - "Will be empty for storage group types other than FCP."
+        - "Only present if O(expand) is True."
+      returned: "success"
       type: list
       elements: dict
       contains:
@@ -343,8 +349,11 @@ storage_group:
                 The property names have hyphens (-) as described in that book."
               type: raw
     virtual-storage-resources:
-      description: "Virtual storage resources of the storage group.
-        Only present if O(expand=true) and for storage group type FCP."
+      description:
+        - "Virtual storage resources of the storage group."
+        - "Will be empty for storage group types other than FCP."
+        - "Only present if O(expand) is True."
+      returned: "success"
       type: list
       elements: dict
       contains:

--- a/plugins/modules/zhmc_user.py
+++ b/plugins/modules/zhmc_user.py
@@ -165,24 +165,23 @@ options:
     default: null
   expand:
     description:
-      - "Deprecated: The O(expand) parameter is deprecated because the
+      - "If True, the return value will contain additional artificial
+         properties that expand certain URI or name properties to the full set
+         of resource properties. See the return value for details."
+      - "B(Deprecated): The O(expand) parameter is deprecated because the
          returned password rule, user role, user pattern and LDAP server
          definition objects have an independent lifecycle, so the same objects
          are returned when invoking this module in a loop through all users.
          Use the respective other modules of this collection to get the
          properties of these objects."
-      - "Boolean that controls whether the returned user contains
-         additional artificial properties that expand certain URI or name
-         properties to the full set of resource properties (see description of
-         return values of this module)."
     type: bool
     required: false
     default: false
   expand_names:
     description:
-      - "Boolean that controls whether the returned user contains additional
-         artificial properties for the names of referenced objects, such as
-         user roles, password rule, etc."
+      - "If True, the return value will contain additional artificial
+         properties for the names of referenced objects, such as user roles,
+         password rule, etc."
       - "For backwards compatibility, this parameter defaults to True."
     type: bool
     required: false
@@ -275,10 +274,10 @@ user:
       type: str
     user-role-objects:
       description:
-        - "Deprecated: This result property is deprecated because the
+        - "User roles referenced by property C(user-roles)."
+        - "Only present if O(expand) is True."
+        - "B(Deprecated): This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only present if O(expand=true): User roles referenced by property
-           C(user-roles)."
       type: dict
       contains:
         "{property}":
@@ -294,10 +293,11 @@ user:
       type: str
     user-pattern:
       description:
-        - "Deprecated: This result property is deprecated because the
+        - "User pattern referenced by property C(user-pattern-uri)."
+        - "Only present for users with C(type=pattern) and if O(expand) is
+           True."
+        - "B(Deprecated): This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only present for users with C(type=pattern) and if O(expand=true):
-           User pattern referenced by property C(user-pattern-uri)."
       type: dict
       contains:
         "{property}":
@@ -313,10 +313,11 @@ user:
       type: str
     user-template:
       description:
-        - "Deprecated: This result property is deprecated because the
+        - "User template referenced by property C(user-template-uri)."
+        - "Only present for users with C(type=pattern) and if O(expand) is
+           True."
+        - "B(Deprecated): This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only present for users with C(type=pattern) and if O(expand=true):
-           User template referenced by property C(user-template-uri)."
       type: dict
       contains:
         "{property}":
@@ -330,10 +331,10 @@ user:
       type: str
     password-rule:
       description:
-        - "Deprecated: This result property is deprecated because the
+        - "Password rule referenced by property C(password-rule-uri)."
+        - "Only present if O(expand) is True."
+        - "B(Deprecated): This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only present if O(expand=true): Password rule referenced by property
-           C(password-rule-uri)."
       type: dict
       contains:
         "{property}":
@@ -349,10 +350,11 @@ user:
       type: str
     ldap-server-definition:
       description:
-        - "Deprecated: This result property is deprecated because the
+        - "LDAP server definition referenced by property
+           C(ldap-server-definition-uri)."
+        - "Only present if O(expand) is True."
+        - "B(Deprecated): This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only present if O(expand=true): LDAP server definition referenced by
-           property C(ldap-server-definition-uri)."
       type: dict
       contains:
         "{property}":
@@ -369,10 +371,11 @@ user:
       type: str
     primary-mfa-server-definition:
       description:
-        - "Deprecated: This result property is deprecated because the
+        - "MFA server definition referenced by property
+           C(primary-mfa-server-definition-uri)."
+        - "Only present if O(expand) is True."
+        - "B(Deprecated): This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only present if O(expand=true): MFA server definition referenced by
-           property C(primary-mfa-server-definition-uri)."
       type: dict
       contains:
         "{property}":
@@ -388,10 +391,11 @@ user:
       type: str
     backup-mfa-server-definition:
       description:
-        - "Deprecated: This result property is deprecated because the
+        - "MFA server definition referenced by property
+           C(backup-mfa-server-definition-uri)."
+        - "Only present if O(expand) is True."
+        - "B(Deprecated): This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only present if O(expand=true): MFA server definition referenced by
-           property C(backup-mfa-server-definition-uri)."
       type: dict
       contains:
         "{property}":
@@ -406,10 +410,10 @@ user:
       type: str
     default-group:
       description:
-        - "Deprecated: This result property is deprecated because the
+        - "Group referenced by property C(default-group-uri)."
+        - "Only present if O(expand) is True."
+        - "B(Deprecated): This result property is deprecated because the
            O(expand) parameter is deprecated."
-        - "Only present if O(expand=true): Group referenced by property
-           C(default-group-uri)."
       type: dict
       contains:
         "{property}":
@@ -1415,8 +1419,13 @@ def main():
                      blanked_params(module.params, WRITEONLY_PROPERTIES_USCORE))
 
     if module.params['expand']:
-        LOGGER.warning(
-            "Deprecated parameter 'expand' is used for zhmc_user module")
+        msg = (
+            "The deprecated input parameter 'expand' of the zhmc_user module "
+            "was specified as True. To prepare for the future removal of "
+            "that parameter, specify it as False and stop using its "
+            "additional properties in the return value.")
+        LOGGER.warning("Deprecation warning: %s", msg)
+        module.deprecate(msg, version="2.0.0", collection_name="ibm.ibm_zhmc")
 
     try:
 

--- a/plugins/modules/zhmc_user_list.py
+++ b/plugins/modules/zhmc_user_list.py
@@ -110,9 +110,9 @@ options:
     default: false
   expand_names:
     description:
-      - "If True and O(full_properties) is set, additional artificial properties
-         will be returned for the names of referenced objects, such as user
-         roles, password rule, etc. Default: False."
+      - "If True and O(full_properties) is True, additional artificial
+         properties will be returned for the names of referenced objects, such
+         as user roles, password rule, etc. See the return value for details."
     type: bool
     required: false
     default: false
@@ -171,41 +171,53 @@ users:
         The property names will have underscores instead of hyphens.
       type: raw
     user_role_names:
-      description: "Only present if O(expand_names=true): Name of the user
-        roles referenced by property C(user_roles)."
-      type: str
+      description:
+        - "Name of the user roles referenced by property C(user_roles)."
+        - "Only present if O(expand_names) is True."
+      type: list
+      elements: str
     user_pattern_name:
-      description: "Only present for users with C(type=pattern) and if
-        O(expand_names=true): Name of the user pattern referenced by property
-        C(user_pattern_uri)."
+      description:
+        - "Name of the user pattern referenced by property
+           C(user_pattern_uri)."
+        - "Only present for users with C(type=pattern) if O(expand_names) is
+           True."
       type: str
     user_template_name:
-      description: "Only present for users with C(type=pattern) and if
-        O(expand_names=true): Name of the template user referenced by property
-        C(user_template_uri)."
+      description:
+        - "Name of the template user referenced by property
+           C(user_template_uri)."
+        - "Only present for users with C(type=pattern) if O(expand_names) is
+           True."
       type: str
     password_rule_name:
-      description: "Only present if O(expand_names=true): Name of the password
-        rule referenced by property C(password_rule_uri)."
+      description:
+        - "Name of the password rule referenced by property
+           C(password_rule_uri)."
+        - "Only present if O(expand_names) is True."
       type: str
     ldap_server_definition_name:
-      description: "Only present if O(expand_names=true): Name of the LDAP
-        server definition referenced by property
-        C(ldap_server_definition_uri)."
+      description:
+        - "Name of the LDAP server definition referenced by property
+           C(ldap_server_definition_uri)."
+        - "Only present if O(expand_names) is True."
       type: str
     primary_mfa_server_definition_name:
-      description: "Only present if O(expand_names=true): Name of the MFA
-        server definition referenced by property
-        C(primary_mfa_server_definition_uri)."
+      description:
+        - "Name of the MFA server definition referenced by property
+           C(primary_mfa_server_definition_uri)."
+        - "Only present if O(expand_names) is True."
       type: str
     backup_mfa_server_definition_name:
-      description: "Only present if O(expand_names=true): Name of the MFA
-        server definition referenced by property
-        C(backup_mfa_server_definition_uri)."
+      description:
+        - "Name of the MFA server definition referenced by property
+           C(backup_mfa_server_definition_uri)."
+        - "Only present if O(expand_names) is True."
       type: str
     default_group_name:
-      description: "Only present if O(expand_names=true): Name of the Group
-        referenced by property C(default_group_uri)."
+      description:
+        - "Name of the Group referenced by property C(default_group_uri)."
+        - "Only present if O(expand_names) is True."
       type: str
   sample:
     [


### PR DESCRIPTION
For details, see the commit message.

Tested the new Ansible deprecation message for the "expand" input parameter of the zhmc_user module:

Specifying `expand: false` or omitting it results in no deprecation warning.

Specifying `expand: true` results in this output when running the playbook:

```
[DEPRECATION WARNING]: The deprecated input parameter 'expand' of the zhmc_user module
was specified as True. To prepare for the future removal of that parameter, specify it as False
and stop using its additional properties in the return value. This feature will be removed from
collection 'ibm.ibm_zhmc' version 2.0.0.
```
Note that the last sentence is generated by Ansible and added to the text supplied by our code.

and in this log file entry:
```
2026-07-15T12:56:39+0200 WARNING zhmc_user 94893 Deprecation warning: The deprecated
input parameter 'expand' of the zhmc_user module was specified as True. To prepare for the
future removal of that parameter, specify it as False and stop using its additional properties in the
return value.
```