### PR TITLE
1.10: Fixed pip-missing-reqs TypeError by pinning pip to <26.2 (#1380)

### DIFF
--- a/changelogs/fragments/1379.fix.yaml
+++ b/changelogs/fragments/1379.fix.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Development - Fixed that pip-missing-reqs raised TypeError by pinning pip
+    to <26.2. (issue 1379)

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -123,8 +123,7 @@ entrypoints==0.3.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.2.0
-pip-check-reqs==2.4.3; python_version <= '3.11'
-pip-check-reqs==2.5.3; python_version >= '3.12'
+pip-check-reqs==2.5.6
 
 
 # Indirect dependencies for development that are not in requirements-develop.txt and not in minimum-constraints-install.txt

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -10,7 +10,7 @@
 
 # Need to comment out pip==26.0.1 due to issue https://github.com/pyupio/safety/issues/847
 # pip==26.0.1; python_version == '3.9'
-pip==26.1; python_version >= '3.10'
+pip==26.1.2; python_version >= '3.10'
 setuptools==78.1.1
 wheel==0.46.2
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -4,6 +4,8 @@
 
 # Base dependencies (must be consistent with minimum-constraints-install.txt)
 
-pip>=26.0
+pip>=26.0.1; python_version == '3.9'
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'
 setuptools>=78.1.1
 wheel>=0.46.2

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -138,7 +138,7 @@ entrypoints>=0.3.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree>=2.2.0
-# pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
-# pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
-pip-check-reqs>=2.4.3,!=2.5.0; python_version <= '3.11'
-pip-check-reqs>=2.5.3; python_version >= '3.12'
+pip-check-reqs>=2.5.6
+
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'


### PR DESCRIPTION
Backports #1380 into 1.10.