### PR TITLE
1.11: Increased ansible-lint version for consistency with ansible-core; yamllint

### DIFF
--- a/ansible-constraints.txt
+++ b/ansible-constraints.txt
@@ -39,6 +39,5 @@ MarkupSafe==2.0.0
 # Direct dependencies for development (must be consistent with requirements-develop.txt)
 
 # ansible-test
-yamllint==1.25.0; python_version <= '3.9'
-yamllint==1.30.0; python_version >= '3.10'
+yamllint==1.34.0
 pathspec==1.0.3

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -33,7 +33,7 @@ pip-check-reqs==2.5.6
 yamllint==1.34.0
 
 # ansible-lint checker
-ansible-lint==24.12.2
+ansible-lint==25.1.0
 
 # Safety checker
 safety==3.8.1

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -41,10 +41,15 @@ pip-check-reqs>=2.5.1
 yamllint>=1.30.0
 
 # ansible-lint checker
-# ansible-lint is run only on officially supported ansible-core versions
-# ansible-lint 24.12.2 requires ansible-core>=2.13.0 and is the latest version
-#   that requires ansible-core<=2.15, so it runs on py>=310
-ansible-lint>=24.12.2
+# ansible-lint and ansible-compat must be consistent with the Ansible version that is used.
+# Our current minimum version of ansible-core is 2.16.
+# ansible-lint 25.1.0..26.6.0 require ansible-core>=2.16.x
+# ansible-compat 25.1.0..26.6.0 require ansible-core>=2.16.x
+# ansible-lint 26.8.0 requires ansible-core>=2.16.19,!=2.17.*
+# ansible-compat 26.8.0 requires ansible-core>=2.16.19,!=2.17.*
+# None of our test environments uses ansible-core 2.17 (Ansible 10).
+ansible-lint>=25.1.0
+
 
 # Safety checker
 safety>=3.8.1

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -38,7 +38,7 @@ pipdeptree>=2.24.0
 pip-check-reqs>=2.5.1
 
 # yamllint checker
-yamllint>=1.30.0
+yamllint>=1.34.0
 
 # ansible-lint checker
 # ansible-lint and ansible-compat must be consistent with the Ansible version that is used.


### PR DESCRIPTION
Backports PR #1442 into 1.11, and adds a commit for fixing a version inconsistency with yamllint.